### PR TITLE
PHP7 compatibilty

### DIFF
--- a/INSTALL/config.inc-dist.php
+++ b/INSTALL/config.inc-dist.php
@@ -24,7 +24,7 @@ $configFileText = <<<CONFIGFILETEXT
  * For more details, see README
  */
 
-/*******MYSQL SETTINGS************************/
+/*******mysql SETTINGS************************/
 // defining the ip address of the mysql server.
 define("MYSQL_SERVER","$MYSQL_SERVER");
 

--- a/INSTALL/install.php
+++ b/INSTALL/install.php
@@ -273,7 +273,7 @@ function checkDatabaseAccess() {
 			<pre>CREATE DATABASE `pragyandatabase`;
 CREATE USER 'pragyanuser'@'localhost' IDENTIFIED BY 'pragyanpassword';
 GRANT ALL PRIVILEGES ON `pragyandatabase` . * TO 'pragyanuser'@'localhost';</pre>
-			<p>After you run these queries successfully in your MySQL client, please run this install script again.</p>
+			<p>After you run these queries successfully in your mysql client, please run this install script again.</p>
 WHATEVER;
 
 	$dbhost=MYSQL_SERVER;
@@ -282,43 +282,43 @@ WHATEVER;
 	$dbuser=MYSQL_USERNAME;
 	$dbpasswd=MYSQL_PASSWORD;
 	
-	$dblink=mysql_connect($dbhost,$dbuser,$dbpasswd);
+	$dblink=($GLOBALS["___mysqli_ston"] = mysqli_connect($dbhost, $dbuser, $dbpasswd));
 	if($dblink==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> Pragyan CMS could not connect to database on '$dbhost' using username '$dbuser'. Please check the username/password you provided.</p>$dbpasswd";
 		return $dbaccessInfo . $dbaccessErrorTip;
 	}
-	$db=mysql_select_db($dbname);
+	$db=((bool)mysqli_query($GLOBALS["___mysqli_ston"], "USE " . $dbname));
 	if($db==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> Pragyan CMS could not select the database '$dbname'.<br/> Please make sure the database exists and the user $dbuser has permissions over it.</p>";
 			return $dbaccessInfo . $dbaccessErrorTip;
 	}
-	$res=mysql_query("CREATE TABLE IF NOT EXISTS `testtable948823` ( `testuserid` int(10) )");
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `testtable948823` ( `testuserid` int(10) )");
 	if($res==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> The User '$dbuser' does not have permissions to CREATE tables in '$dbname'.</p>";
 		return $dbaccessInfo . $dbaccessErrorTip;
 	}
-	$res=mysql_query("INSERT INTO `testtable948823` VALUES (123)");
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `testtable948823` VALUES (123)");
 	if($res==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> The User '$dbuser' does not have permissions to INSERT values in tables of database '$dbname'.</p>";
 		return $dbaccessInfo . $dbaccessErrorTip;
 	}
-	$res=mysql_query("UPDATE `testtable948823` SET testuserid=0");
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `testtable948823` SET testuserid=0");
 	if($res==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> The User '$dbuser' does not have permissions to UPDATE values in tables of database '$dbname'.</p>";
 		return $dbaccessInfo . $dbaccessErrorTip;
 	}
-	$res=mysql_query("SELECT * FROM `testtable948823`");
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `testtable948823`");
 	if($res==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> The User '$dbuser' does not have permissions to SELECT values in tables of database '$dbname'.</p>";
 		return $dbaccessInfo . $dbaccessErrorTip;
 	}
-	$res=mysql_query("DROP TABLE `testtable948823`");
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], "DROP TABLE `testtable948823`");
 	if($res==false)
 	{
 		$dbaccessInfo.="<p><b>Error:</b> The User '$dbuser' does not have permissions to DROP tables of database '$dbname'.</p>";
@@ -330,8 +330,8 @@ WHATEVER;
 function importDatabase() {
 	global $installFolder, $URL_REWRITE;
 
-	mysql_connect(MYSQL_SERVER, MYSQL_USERNAME, MYSQL_PASSWORD);
-	mysql_select_db(MYSQL_DATABASE);
+	($GLOBALS["___mysqli_ston"] = mysqli_connect(MYSQL_SERVER,  MYSQL_USERNAME,  MYSQL_PASSWORD));
+	((bool)mysqli_query($GLOBALS["___mysqli_ston"], "USE " . constant('MYSQL_DATABASE')));
 
 	$handle = @fopen($installFolder."/pragyan_structure.sql", "r");
 	$query = '';
@@ -347,9 +347,9 @@ function importDatabase() {
 	$singlequeries = explode(";\n",$query);
 	foreach ($singlequeries as $singlequery) {
 		if (trim($singlequery)!="") {
-			$result1 = mysql_query($singlequery);
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $singlequery);
 			if (!$result1) {
-				$output = "<h3>Error:</h3><pre>".$singlequery."</pre>\n<br/>Unable to create structure. ".mysql_error();
+				$output = "<h3>Error:</h3><pre>".$singlequery."</pre>\n<br/>Unable to create structure. ".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 				return $output;
 			}
 		}
@@ -370,9 +370,9 @@ function importDatabase() {
 	$singlequeries = explode(";\n",$query);
 	foreach ($singlequeries as $singlequery) {
 		if (trim($singlequery)!="") {
-			$result1 = mysql_query($singlequery);
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $singlequery);
 			if (!$result1) {
-  			$output = "<h3>Error:</h3><pre>".$singlequery."</pre>\n<br/>Unable to import the rows. " . mysql_error();
+  			$output = "<h3>Error:</h3><pre>".$singlequery."</pre>\n<br/>Unable to import the rows. " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
   			return $output;
 			}
 		}
@@ -397,7 +397,7 @@ function importDatabase() {
 
 	$query="INSERT IGNORE INTO `".MYSQL_DATABASE_PREFIX."users` (`user_id`,`user_name`,`user_email`,`user_fullname`,`user_password`,`user_regdate`,`user_lastlogin`,`user_activated`,`user_loginmethod`) VALUES (
 	1,'".ADMIN_USERNAME."','".ADMIN_EMAIL."','".ADMIN_FULLNAME."','".md5(ADMIN_PASSWORD)."',NOW(),'',1,'db')";
-	mysql_query($query);
+	mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	global $cmsFolder;
 	$templates=scandir($cmsFolder.'/templates');
 
@@ -408,7 +408,7 @@ function importDatabase() {
 		{
 
 			$query="INSERT IGNORE INTO `".MYSQL_DATABASE_PREFIX."templates` (`template_name`) VALUES ('$tdir')";
-			mysql_query($query);
+			mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		}
 	}
 	

--- a/INSTALL/pragyan_structure.sql
+++ b/INSTALL/pragyan_structure.sql
@@ -1419,7 +1419,7 @@ CREATE TABLE IF NOT EXISTS `events_confirmed_participants` (
 --
 
 CREATE TABLE IF NOT EXISTS `events_details` (
-`event_id` int(10) NOT NULL,
+`event_id` int(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `event_name` varchar(100) NOT NULL,
   `event_start_time` time NOT NULL,
   `event_end_time` time NOT NULL,
@@ -1445,8 +1445,8 @@ CREATE TABLE IF NOT EXISTS `events_details` (
 --
 -- AUTO_INCREMENT for table `events_details`
 --
-ALTER TABLE `events_details`
-  MODIFY `event_id` int(10) NOT NULL AUTO_INCREMENT;
+-- ALTER TABLE `events_details`
+--   MODIFY `event_id` int(10) NOT NULL AUTO_INCREMENT;
 
 --
 -- Table structure for table `events_edited_form`

--- a/INSTALL/pragyan_structure.sql
+++ b/INSTALL/pragyan_structure.sql
@@ -1439,8 +1439,8 @@ CREATE TABLE IF NOT EXISTS `events_details` (
 --
 -- Indexes for table `events_details`
 --
-ALTER TABLE `events_details`
-  ADD PRIMARY KEY (`event_id`);
+-- ALTER TABLE `events_details`
+--   ADD PRIMARY KEY (`event_id`);
   
 --
 -- AUTO_INCREMENT for table `events_details`

--- a/INSTALL/searchStructure.php
+++ b/INSTALL/searchStructure.php
@@ -8,7 +8,7 @@ if(!defined('__PRAGYAN_CMS'))
 }
 
 $error = 0;
-mysql_query("CREATE TABLE IF NOT EXISTS `sites`(
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `sites`(
 	site_id int auto_increment not null primary key,
 	url varchar(255),
 	title varchar(255),
@@ -18,13 +18,13 @@ mysql_query("CREATE TABLE IF NOT EXISTS `sites`(
 	required text,
 	disallowed text,
 	can_leave_domain bool)");
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
-mysql_query("CREATE TABLE IF NOT EXISTS `links` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `links` (
 	link_id int auto_increment primary key not null,
 	site_id int,
 	url varchar(255) not null,
@@ -39,28 +39,28 @@ mysql_query("CREATE TABLE IF NOT EXISTS `links` (
 	visible int default 0, 
 	level int)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
-mysql_query("CREATE TABLE IF NOT EXISTS `keywords`	(
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `keywords`	(
 	keyword_id int primary key not null auto_increment,
 	keyword varchar(30) not null,
 	unique kw (keyword),
 	key keyword (keyword(10)))");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
 for ($i=0;$i<=15; $i++) {
 	$char = dechex($i);
-	mysql_query("CREATE TABLE IF NOT EXISTS `link_keyword$char` (
+	mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `link_keyword$char` (
 		link_id int not null,
 		keyword_id int not null,
 		weight int(3),
@@ -68,53 +68,53 @@ for ($i=0;$i<=15; $i++) {
 		key linkid(link_id),
 		key keyid(keyword_id))");
 
-	if (mysql_errno() > 0) {
+	if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 		print "Error: ";
-		print mysql_error();
+		print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		print "<br>\n";
-		$error += mysql_errno();
+		$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 	}
 }
 
-mysql_query("CREATE TABLE IF NOT EXISTS `categories` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `categories` (
 	category_id integer not null auto_increment primary key, 
 	category text,
 	parent_num integer
 	)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("CREATE TABLE IF NOT EXISTS `site_category` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `site_category` (
 	site_id integer,
 	category_id integer
 	)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("CREATE TABLE IF NOT EXISTS `temp` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `temp` (
 	link varchar(255),
 	level integer,
 	id varchar (32)
 	)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("CREATE TABLE IF NOT EXISTS `pending` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `pending` (
 	site_id integer,
 	temp_id varchar(32),
 	level integer,
@@ -122,36 +122,36 @@ mysql_query("CREATE TABLE IF NOT EXISTS `pending` (
 	num integer
 )");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("CREATE TABLE IF NOT EXISTS `query_log` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `query_log` (
 	query varchar(255),
 	time timestamp,
 	elapsed float(2),
 	results int, 
 	key query_key(query))");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("CREATE TABLE IF NOT EXISTS `domains` (
+mysqli_query($GLOBALS["___mysqli_ston"], "CREATE TABLE IF NOT EXISTS `domains` (
 	domain_id int auto_increment primary key not null,	
 	domain varchar(255))");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
 if($error>0)

--- a/INSTALL/settingsform.php
+++ b/INSTALL/settingsform.php
@@ -250,7 +250,7 @@ $settingsForm = <<<SETTINGSFORM1
 
 			if(!validate_domain(document.getElementById('txtMySQLServerHost'),1))
 			{
-			message+="MySQL Server Host , ";
+			message+="mysql Server Host , ";
 			error++;
 			}if(!validate_username(document.getElementById('txtMySQLUsername'),1))
 			{
@@ -356,11 +356,11 @@ $settingsForm = <<<SETTINGSFORM1
 	<legend>Database Settings</legend>
 	<table border="0" width="580px">
 		<tr>
-			<td width="210px"><label for="txtMySQLServerHost">MySQL Server Host:</label></td>
+			<td width="210px"><label for="txtMySQLServerHost">mysql Server Host:</label></td>
 			<td><input type="text" name="txtMySQLServerHost" id="txtMySQLServerHost" value="localhost" onblur="validate_domain(this,0)" /></td>
 		</tr>
 		<tr>
-			<td width="210px"><label for="txtMySQLServerPort">MySQL Server Port:<br/>(Leave blank if not sure) </label></td>
+			<td width="210px"><label for="txtMySQLServerPort">mysql Server Port:<br/>(Leave blank if not sure) </label></td>
 			<td><input type="text" name="txtMySQLServerPort" id="txtMySQLServerPort" value="" onblur="validate_port(this,0)" /></td>
 		</tr>
 		<tr>

--- a/README.markdown
+++ b/README.markdown
@@ -33,5 +33,6 @@ Contributors
 - Sriram Sundarraj (ssundarraj)
 - Amal (amal1293)
 - Sarwesh Krishnan (baxiz)
+- Gokul Srinivas (gokulsrinivas)
 - Shravan Murali (shravan97)
 - (this could be you...)

--- a/cms/actionbar.lib.php
+++ b/cms/actionbar.lib.php
@@ -26,12 +26,12 @@ if(!defined('__PRAGYAN_CMS'))
 function getActionbarPage($userId, $pageId) {
 
 	$action_query = "SELECT perm_id, perm_action, perm_text FROM `".MYSQL_DATABASE_PREFIX."permissionlist` WHERE page_module = 'page'";
-	$action_result = mysql_query($action_query);
+	$action_result = mysqli_query($GLOBALS["___mysqli_ston"], $action_query);
 	$allow_login_query = "SELECT `value` FROM `".MYSQL_DATABASE_PREFIX."global` WHERE `attribute` = 'allow_login'";
-	$allow_login_result = mysql_query($allow_login_query);
-	$allow_login_result = mysql_fetch_array($allow_login_result);
+	$allow_login_result = mysqli_query($GLOBALS["___mysqli_ston"], $allow_login_query);
+	$allow_login_result = mysqli_fetch_array($allow_login_result);
 	$actionbarPage=array();
-	while($action_row = mysql_fetch_assoc($action_result)) {
+	while($action_row = mysqli_fetch_assoc($action_result)) {
 		if(getPermissions($userId, $pageId, $action_row['perm_action']))
 			$actionbarPage[$action_row['perm_action']]=$action_row['perm_text'];
 	}
@@ -76,12 +76,12 @@ function getActionbarPage($userId, $pageId) {
  */
 function getActionbarModule($userId, $pageId) {
 	$action_query = "SELECT perm_id, perm_action, perm_text FROM `".MYSQL_DATABASE_PREFIX."permissionlist` WHERE perm_action != 'create' AND page_module = '".getEffectivePageModule($pageId)."'";
-	$action_result = mysql_query($action_query);
+	$action_result = mysqli_query($GLOBALS["___mysqli_ston"], $action_query);
 	$allow_login_query = "SELECT `value` FROM `".MYSQL_DATABASE_PREFIX."global` WHERE `attribute` = 'allow_login'";
-	$allow_login_result = mysql_query($allow_login_query);
-	$allow_login_result = mysql_fetch_array($allow_login_result);
+	$allow_login_result = mysqli_query($GLOBALS["___mysqli_ston"], $allow_login_query);
+	$allow_login_result = mysqli_fetch_array($allow_login_result);
 	$actionbarPage = array();
-	while($action_row = mysql_fetch_assoc($action_result))
+	while($action_row = mysqli_fetch_assoc($action_result))
 		if(getPermissions($userId, $pageId, $action_row['perm_action']))
 			$actionbarPage[$action_row['perm_action']]=$action_row['perm_text'];
 	$actionbar="<div id=\"cms-actionbarModule\">";

--- a/cms/admin.lib.php
+++ b/cms/admin.lib.php
@@ -226,8 +226,8 @@ function getBlacklistTable()
 {
 	$black = "<fieldset><legend>Blacklisted Domains</legend><table><tr><td style='width:35%'>Domains</td><td style='width:65%'>IPs</td><td>Actions</td></tr>";	
 	$query = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."blacklist`";
-	$result = mysql_query($query) or displayerror("Unable to load Blacklisted Information".mysql_error());
-	while($row=mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror("Unable to load Blacklisted Information".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	while($row=mysqli_fetch_array($result))
 		$black .="<tr><td>$row[1]</td><td>$row[2]</td><td><a href='./+admin&subaction=global&del_black=$row[0]'>Delete</a></td></tr>";	
 	$black .="</table><fieldset><legend>Add new blacklist</legend><table><tr><td>New Domain :<input type='text' name='blacklist_domain'></td><td>IP (optional) :<input type='text' name='blacklist_ip'></td></tr>";
 	$black.="</table></fieldset></fieldset>";
@@ -241,11 +241,11 @@ function setblacklist($domain="",$ip="")
 	if($ip=="")
 		$ip=gethostbyname($domain);
 	$chk_query = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."blacklist` WHERE `domain` = '$domain' AND `ip`= '$ip'";
-	$chk_result = mysql_num_rows(mysql_query($chk_query));
+	$chk_result = mysqli_num_rows(mysqli_query($GLOBALS["___mysqli_ston"], $chk_query));
 	if($chk_result<1)
 	{
 		$query="INSERT INTO `".MYSQL_DATABASE_PREFIX."blacklist` (`domain`,`ip`) VALUES ('$domain','$ip')";
-		$result =mysql_query($query) or displayerror("Unable to update blacklist".mysql_error());
+		$result =mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror("Unable to update blacklist".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}	
 	return 1;
 }
@@ -253,8 +253,8 @@ function delete_blacklist()
 {
 	$id = safe_html($_GET['del_black']);
 	$query = "DELETE FROM `".MYSQL_DATABASE_PREFIX."blacklist` WHERE `id` = '$id'";
-	$result =mysql_query($query) or displayerror("Unable to Delete blacklist". mysql_error());
-	if(mysql_affected_rows()>0)	
+	$result =mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror("Unable to Delete blacklist". ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)	
 			displayinfo("Blackilist Deleted Successfully");
 	return 1;
 }
@@ -343,11 +343,11 @@ function getSuggestions($pattern) {
 			"IF(`user_fullname` LIKE \"%$pattern%\", 5, 6" .
 			"))))) AS `relevance`,	`user_email`, `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_activated`=1 AND(`user_email` LIKE \"%$pattern%\" OR `user_fullname` LIKE \"%$pattern%\" ) ORDER BY `relevance`";
 //			echo $suggestionsQuery;
-	$suggestionsResult = mysql_query($suggestionsQuery);
+	$suggestionsResult = mysqli_query($GLOBALS["___mysqli_ston"], $suggestionsQuery);
 
 	$suggestions = array($pattern);
 
-	while($suggestionsRow = mysql_fetch_row($suggestionsResult)) {
+	while($suggestionsRow = mysqli_fetch_row($suggestionsResult)) {
 		$suggestions[] = $suggestionsRow[1] . ' - ' . $suggestionsRow[2];
 	}
 
@@ -378,12 +378,12 @@ function admin($pageid, $userid) {
 		}
 	}
 	
-	$result = mysql_fetch_array(mysql_query("SELECT `value` FROM `" . MYSQL_DATABASE_PREFIX . "global` WHERE `attribute` = 'reindex_frequency'"));
+	$result = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `value` FROM `" . MYSQL_DATABASE_PREFIX . "global` WHERE `attribute` = 'reindex_frequency'"));
 	if($result != NULL)
 		$threshold = $result['value'];
 	else
 		$threshold = 30;
-	$result = mysql_fetch_array(mysql_query("SELECT to_days(CURRENT_TIMESTAMP)-to_days(`indexdate`) AS 'diff' FROM `sites` WHERE `url` LIKE '%home%'"));
+	$result = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT to_days(CURRENT_TIMESTAMP)-to_days(`indexdate`) AS 'diff' FROM `sites` WHERE `url` LIKE '%home%'"));
 	
 	if($result == NULL)
 		displayinfo("It seems the site doesn't have index for the search to work. Click <a href='./+admin&indexsite=1'>here</a> to index the site.");
@@ -449,8 +449,8 @@ ADMINPAGE;
 		if(isset($_GET['module'])){
 			$type = escape($_GET['module']);
 			$query = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."modules` WHERE `module_name` = '$type'";
-			$result = mysql_query($query);
-			if(mysql_num_rows($result)==0){
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if(mysqli_num_rows($result)==0){
 				displayerror("No such module exists.");
 			}
 			else {
@@ -471,9 +471,9 @@ ADMINPAGE;
 		}
 		else{
 			$moduleQuery = "SELECT `module_name` FROM `".MYSQL_DATABASE_PREFIX."modules`";
-			$moduleResult = mysql_query($moduleQuery);
+			$moduleResult = mysqli_query($GLOBALS["___mysqli_ston"], $moduleQuery);
 			$returnHtml .="<fieldset><legend>Module Administration</legend>";
-			while($row=mysql_fetch_array($moduleResult)){
+			while($row=mysqli_fetch_array($moduleResult)){
 				$returnHtml .= "<a href=./+admin&subaction=moduleadmin&module=$row[0]>".ucfirst($row[0]) ." Administration</a><br />";
 			}
 			$returnHtml .="</fieldset>";
@@ -762,8 +762,8 @@ function admin_checkFunctionPerms() {
 
 			foreach ($perm as $permission) {
 				$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module`='$module' AND `perm_action`='$permission'";
-				$result = mysql_query($query);
-				if (mysql_num_rows($result) > 0) {
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				if (mysqli_num_rows($result) > 0) {
 					if ($i == 1)
 						$permExists .= ", "; // Just to append ,(comma) after every perm but last
 					$permExists .= $permission;
@@ -771,17 +771,17 @@ function admin_checkFunctionPerms() {
 				} else {
 					$returnStr.="<br/><b>$permission DOES NOT exist for $module but will be created</b><br>";
 					$query = "SELECT MAX(perm_id) as MAX FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist`";
-					$result = mysql_query($query) or die(mysql_error());
-					$row = mysql_fetch_assoc($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					$row = mysqli_fetch_assoc($result);
 					$permid = $row['MAX'] + 1;
 					$query = "SELECT MAX(perm_rank) as MAX FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module`='$module'";
-					$result = mysql_query($query) or die(mysql_error());
-					$row = mysql_fetch_assoc($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					$row = mysqli_fetch_assoc($result);
 					$permrank = $row['MAX'] + 1;
 					$desc = $permission . " the " . $module;
 					$query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "permissionlist`(`perm_id` ,`page_module` ,`perm_action` ,`perm_text` ,`perm_rank` ,`perm_description`)VALUES ('$permid', '$module', '$permission', '$permission', '$permrank', '$desc') ";
-					$result = mysql_query($query) or die(mysql_error());
-					if (mysql_affected_rows())
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 						displayinfo("$permission has been created for $module");
 				}
 			}
@@ -800,8 +800,8 @@ function admin_checkFunctionPerms() {
 			require_once ($sourceFolder . "/" . $moduleFolder . "/" . $module . ".lib.php");
 			$class = new $module ();
 			$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module`='$module'";
-			$result = mysql_query($query);
-			while ($tempres = mysql_fetch_assoc($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			while ($tempres = mysqli_fetch_assoc($result)) {
 
 				$permName = ucfirst($tempres['perm_action']);
 				$method = "action" . $permName;
@@ -820,20 +820,20 @@ function admin_checkFunctionPerms() {
 
 function admin_checkAdminUser() {
 	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_name`='admin'";
-	$result = mysql_query($query);
-	if (mysql_num_rows($result) > 0) {
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if (mysqli_num_rows($result) > 0) {
 		displayinfo("User \"Admin\" exists in database.");
 	} else {
 		$query = "SELECT MAX(user_id) as MAX FROM `" . MYSQL_DATABASE_PREFIX . "users` ";
-		$result = mysql_query($query) or die(mysql_error() . "check.lib L:141");
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "check.lib L:141");
+		$row = mysqli_fetch_assoc($result);
 		$uid = $row['MAX'] + 1;
 		$passwd = rand();
 		$adminPasswd = md5($passwd);
 		$query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "users`( `user_id` ,`user_name` ,`user_email` ,`user_fullname` ,`user_password`  ,`user_activated`)VALUES ( '$uid' , 'admin', 'admin@cms.org', 'Administrator', '$adminPasswd', '1')";
 		
-		$result = mysql_query($query) or die(mysql_error());
-		if (mysql_affected_rows() > 0) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) > 0) {
 			displayinfo("User Admin has been created with email admin@cms.org and password as $passwd");
 		} else
 			displayerror("Failed to create user Admin");
@@ -850,21 +850,21 @@ function admin_checkAdminPerms()
 	$returnStr="";
 	$str="";
 	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_name`='admin' ";
-	$result = mysql_query($query);
-	if (mysql_num_rows($result) > 0) {
-		$temp = mysql_fetch_array($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if (mysqli_num_rows($result) > 0) {
+		$temp = mysqli_fetch_array($result);
 		$user_Id = $temp['user_id'];
 		$query1 = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist`";
-		$result1 = mysql_query($query1);
-		while ($temp1 = mysql_fetch_assoc($result1)) {
+		$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+		while ($temp1 = mysqli_fetch_assoc($result1)) {
 			foreach ($temp1 as $var => $val) {
 				if ($var == 'perm_id') {
 					$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type`='user' AND `usergroup_id`='$user_Id' AND `page_id`=0 AND `perm_id`='$val' AND `perm_permission`='Y'";
-					$result = mysql_query($query) or die(mysql_error());
-					if (!mysql_num_rows($result)) {
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					if (!mysqli_num_rows($result)) {
 						$query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "userpageperm` (`perm_type`,`page_id`,`usergroup_id`,`perm_id`,`perm_permission`) VALUES ('user','0','$user_Id','$val','Y')";
-						$result2 = mysql_query($query);
-						if (mysql_affected_rows())
+						$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 							$returnStr.="\n<br>User Admin userId=$user_Id has been allotted permission $temp1[perm_action] of module $temp1[page_module] over page 0";
 						else
 							$returnStr.="\n<br>Failed to create permission $temp1[perm_action] of module $temp1[page_module] over page 0 for User Admin userId=$user_Id";
@@ -965,8 +965,8 @@ function groupManagementForm($currentUserId, $modifiableGroups, &$pagePath) {
 			}
 			else {
 				$deleteQuery = 'DELETE FROM `' . MYSQL_DATABASE_PREFIX . 'usergroup` WHERE `user_id` = \'' . $userId . '\' AND `group_id` = ' . $groupId;
-				$deleteResult = mysql_query($deleteQuery);
-				if(!$deleteResult || mysql_affected_rows() != 1) {
+				$deleteResult = mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
+				if(!$deleteResult || mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1) {
 					displayerror('Could not delete user with the given E-mail from the given group.');
 				}
 				else {
@@ -982,7 +982,7 @@ function groupManagementForm($currentUserId, $modifiableGroups, &$pagePath) {
 		}
 		elseif ($subAction == 'savegroupproperties' && isset($_POST['txtGroupDescription'])) {
 			$updateQuery = "UPDATE `" . MYSQL_DATABASE_PREFIX . "groups` SET `group_description` = '".escape($_POST['txtGroupDescription'])."' WHERE `group_id` = '$groupId'";
-			$updateResult = mysql_query($updateQuery);
+			$updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 			if (!$updateResult) {
 				displayerror('Could not update database.');
 			}
@@ -1067,7 +1067,7 @@ function groupManagementForm($currentUserId, $modifiableGroups, &$pagePath) {
 		$usersTable = '`' . MYSQL_DATABASE_PREFIX . 'users`';
 		$usergroupTable = '`' . MYSQL_DATABASE_PREFIX . 'usergroup`';
 		$userQuery = "SELECT `user_email`, `user_fullname` FROM $usergroupTable, $usersTable WHERE `group_id` =  '$groupId' AND $usersTable.`user_id` = $usergroupTable.`user_id` ORDER BY `user_email`";
-		$userResult = mysql_query($userQuery);
+		$userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userQuery);
 		if(!$userResult) {
 			displayerror('Error! Could not fetch group information.');
 			return '';
@@ -1075,7 +1075,7 @@ function groupManagementForm($currentUserId, $modifiableGroups, &$pagePath) {
 	
 		$userEmails = array();
 		$userFullnames = array();
-		while($userRow = mysql_fetch_row($userResult)) {
+		while($userRow = mysqli_fetch_row($userResult)) {
 			$userEmails[] = $userRow[0];
 			$userFullnames[] = $userRow[1];
 		}
@@ -1095,7 +1095,7 @@ function groupManagementForm($currentUserId, $modifiableGroups, &$pagePath) {
 				<legend>{$ICONS['User Groups']['small']}Existing Users in Group:</legend>
 GROUPEDITFORM;
 
-		$userCount = mysql_num_rows($userResult);
+		$userCount = mysqli_num_rows($userResult);
 		global $urlRequestRoot, $cmsFolder, $templateFolder,$sourceFolder;
 		$deleteImage = "<img src=\"$urlRequestRoot/$cmsFolder/$templateFolder/common/icons/16x16/actions/edit-delete.png\" alt=\"Remove user from the group\" title=\"Remove user from the group\" />";
 
@@ -1194,17 +1194,17 @@ GROUPEDITFORM;
 		elseif(isset($_GET['dowhat']) && $_GET['dowhat'] == 'addgroup') {
 			if(isset($_POST['txtGroupName']) && isset($_POST['txtGroupDescription']) && isset($_POST['selGroupPriority'])) {
 				$existsQuery = 'SELECT `group_id` FROM `' . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_name` = '".escape($_POST['txtGroupName'])."'";
-				$existsResult = mysql_query($existsQuery);
+				$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
 				if(trim($_POST['txtGroupName']) == '') {
 					displayerror('Cannot create a group with an empty name. Please type in a name for the new group.');
 				}
-				elseif(mysql_num_rows($existsResult) >= 1) {
+				elseif(mysqli_num_rows($existsResult) >= 1) {
 					displayerror('A group with the name you specified already exists.');
 				}
 				else {
 					$idQuery = 'SELECT MAX(`group_id`) FROM `' . MYSQL_DATABASE_PREFIX . 'groups`';
-					$idResult = mysql_query($idQuery);
-					$idRow = mysql_fetch_row($idResult);
+					$idResult = mysqli_query($GLOBALS["___mysqli_ston"], $idQuery);
+					$idRow = mysqli_fetch_row($idResult);
 					$newGroupId = 2;
 					if(!is_null($idRow[0])) {
 						$newGroupId = $idRow[0] + 1;
@@ -1217,13 +1217,13 @@ GROUPEDITFORM;
 
 					$addGroupQuery = 'INSERT INTO `' . MYSQL_DATABASE_PREFIX . 'groups` (`group_id`, `group_name`, `group_description`, `group_priority`) ' .
 							"VALUES($newGroupId, '".escape($_POST['txtGroupName'])."', '".escape($_POST['txtGroupDescription'])."', '$newGroupPriority')";
-					$addGroupResult = mysql_query($addGroupQuery);
+					$addGroupResult = mysqli_query($GLOBALS["___mysqli_ston"], $addGroupQuery);
 					if($addGroupResult) {
 						displayinfo('New group added successfully.');
 
 						if(isset($_POST['chkAddMe'])) {
 							$insertQuery = 'INSERT INTO `' . MYSQL_DATABASE_PREFIX . "usergroup`(`user_id`, `group_id`) VALUES ('$currentUserId', '$newGroupId')";
-							if(!mysql_query($insertQuery)) {
+							if(!mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery)) {
 								displayerror('Error adding user to newly created group: ' . $insertQuery . '<br />' . mysql_query());
 							}
 						}
@@ -1232,7 +1232,7 @@ GROUPEDITFORM;
 						$modifiableGroups = getModifiableGroups($currentUserId, $maxPriorityGroup, $ordering = 'asc');
 					}
 					else {
-						displayerror('Could not run MySQL query. New group could not be added.');
+						displayerror('Could not run mysql query. New group could not be added.');
 					}
 				}
 			}

--- a/cms/authenticate.lib.php
+++ b/cms/authenticate.lib.php
@@ -26,8 +26,8 @@ if(!defined('__PRAGYAN_CMS'))
 function getSessionData($user_id) {
 	$user_id=escape($user_id);
 	$query = "SELECT `user_name`,`user_email`,`user_lastlogin` FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id`='$user_id'";
-	$data = mysql_query($query) or die(mysql_error());
-	$temp = mysql_fetch_assoc($data);
+	$data = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	$temp = mysqli_fetch_assoc($data);
 	$user_name = $temp['user_name'];
 	$user_email = $temp['user_email'];
 	$lastlogin = $temp['user_lastlogin'];
@@ -137,8 +137,8 @@ function getGroupIds($userId) {
 	else
 		$groups[] = 1;
 	$groupQuery = 'SELECT `group_id` FROM `' . MYSQL_DATABASE_PREFIX . 'usergroup` WHERE `user_id` = \'' . escape($userId)."'";
-	$groupQueryResult = mysql_query($groupQuery) or die(mysql_error());
-	while ($groupQueryResultRow = mysql_fetch_row($groupQueryResult))
+	$groupQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	while ($groupQueryResultRow = mysqli_fetch_row($groupQueryResult))
 		$groups[] = $groupQueryResultRow[0];
 	return $groups;
 }

--- a/cms/breadcrumbs.lib.php
+++ b/cms/breadcrumbs.lib.php
@@ -28,9 +28,9 @@ function breadcrumbs($pageIdArray) {
 	$sqlOutputArray = array();
 	$pageIdList = join($pageIdArray, ",");
 	$query = 'SELECT `page_id`, `page_name`, `page_title` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_id` IN (' . $pageIdList . ')';
-	$resultId = mysql_query($query);
+	$resultId = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 
-	while ($row = mysql_fetch_assoc($resultId))
+	while ($row = mysqli_fetch_assoc($resultId))
 		$sqlOutputArray[$row['page_id']] = array($row['page_name'], $row['page_title']);
 
 	global $urlRequestRoot;

--- a/cms/content.lib.php
+++ b/cms/content.lib.php
@@ -98,8 +98,8 @@ function getContent($pageId, $action, $userId, $permission, $recursed=0) {
 	/// Coz work to be done after these actions do involve the page
 
 	$pagetype_query = "SELECT page_module, page_modulecomponentid FROM ".MYSQL_DATABASE_PREFIX."pages WHERE page_id='".escape($pageId)."'";
-	$pagetype_result = mysql_query($pagetype_query);
-	$pagetype_values = mysql_fetch_assoc($pagetype_result);
+	$pagetype_result = mysqli_query($GLOBALS["___mysqli_ston"], $pagetype_query);
+	$pagetype_values = mysqli_fetch_assoc($pagetype_result);
 	if(!$pagetype_values) {
 		displayerror("The requested page does not exist.");
 		return "";
@@ -116,7 +116,7 @@ function getContent($pageId, $action, $userId, $permission, $recursed=0) {
 	}
 	if($recursed==0) {
 		$pagetypeupdate_query = "UPDATE ".MYSQL_DATABASE_PREFIX."pages SET page_lastaccesstime=NOW() WHERE page_id='".escape($pageId)."'";
-		$pagetypeupdate_result = mysql_query($pagetypeupdate_query);
+		$pagetypeupdate_result = mysqli_query($GLOBALS["___mysqli_ston"], $pagetypeupdate_query);
 		if(!$pagetypeupdate_result)
 			return '<div class="cms-error">Error No. 563 - An error has occured. Contact the site administators.</div>';
 	}
@@ -130,8 +130,8 @@ function getContent($pageId, $action, $userId, $permission, $recursed=0) {
 	if($moduleType=="external") {
 		$query = "SELECT `page_extlink` FROM `".MYSQL_DATABASE_PREFIX."external` WHERE `page_modulecomponentid` =
 					(SELECT `page_modulecomponentid` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id`= '".escape($pageId)."')";
-		$result = mysql_query($query);
-		$values = mysql_fetch_array($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$values = mysqli_fetch_array($result);
 		$link=$values[0];
 		header("Location: $link");
 	}
@@ -145,16 +145,16 @@ function getContent($pageId, $action, $userId, $permission, $recursed=0) {
 	}
 	
 	$createperms_query = " SELECT * FROM ".MYSQL_DATABASE_PREFIX."permissionlist where perm_action = 'create' AND page_module = '".$moduleType."'";
-	$createperms_result = mysql_query($createperms_query);
-	if(mysql_num_rows($createperms_result)<1) {
+	$createperms_result = mysqli_query($GLOBALS["___mysqli_ston"], $createperms_query);
+	if(mysqli_num_rows($createperms_result)<1) {
 		displayerror("The action \"create\" does not exist in the module \"$moduleType\"</div>");
 		return "";
 	}
 
 	$availableperms_query = "SELECT * FROM ".MYSQL_DATABASE_PREFIX."permissionlist where perm_action != 'create' AND page_module = '".$moduleType."'";
-	$availableperms_result = mysql_query($availableperms_query);
+	$availableperms_result = mysqli_query($GLOBALS["___mysqli_ston"], $availableperms_query);
 	$permlist = array();
-	while ($value=mysql_fetch_assoc($availableperms_result))	{
+	while ($value=mysqli_fetch_assoc($availableperms_result))	{
 		array_push($permlist,$value['perm_action']);
 	}
 	array_push($permlist,"view");
@@ -269,10 +269,10 @@ function getTitle($pageId,$action, &$heading) {
 		return false;
 		
 	$pagetitle_query = "SELECT `page_title`, `page_module`, `page_modulecomponentid`, `page_displaypageheading` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id`='".$pageId."'";
-	$pagetitle_result = mysql_query($pagetitle_query);
+	$pagetitle_result = mysqli_query($GLOBALS["___mysqli_ston"], $pagetitle_query);
 	if (!$pagetitle_result)
 		return false;
-	$pagetitle_values = mysql_fetch_assoc($pagetitle_result);
+	$pagetitle_values = mysqli_fetch_assoc($pagetitle_result);
 
 	if ($pagetitle_values['page_displaypageheading'] == 0)
 		return false;
@@ -300,9 +300,9 @@ function child($pageId, $userId,$depth) {
 	}
 	
 	
-	$childrenResult = mysql_query($childrenQuery);
+	$childrenResult = mysqli_query($GLOBALS["___mysqli_ston"], $childrenQuery);
 	$children = array();
-	while ($childrenRow = mysql_fetch_assoc($childrenResult))
+	while ($childrenRow = mysqli_fetch_assoc($childrenResult))
 		if ($childrenRow['page_displayinmenu'] == true && getPermissions($userId, $childrenRow['page_id'], 'view', $childrenRow['page_module']) == true)
 			$children[] = array($childrenRow['page_id'], $childrenRow['page_name'], $childrenRow['page_module'], $childrenRow['page_image'],$childrenRow['page_displayicon'],$childrenRow['page_modulecomponentid']);
 			

--- a/cms/download.lib.php
+++ b/cms/download.lib.php
@@ -75,8 +75,8 @@ function download($pageId, $userId, $fileName,$action="") {
 	//return the file the particular page id.
 	
 	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE  `upload_filename`= '". escape($fileName). "' AND `page_module` = '".escape($moduleType)."' AND `page_modulecomponentid` = '".escape($moduleComponentId)."'";
-	$result = mysql_query($query) or die(mysql_error() . "upload L:85");
-	$row = mysql_fetch_assoc($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "upload L:85");
+	$row = mysqli_fetch_assoc($result);
 
 	$fileType = $row['upload_filetype'];
 	/**

--- a/cms/email.lib.php
+++ b/cms/email.lib.php
@@ -18,8 +18,8 @@ if(!defined('__PRAGYAN_CMS'))
 
 function getAllUsers() {
 	$ret = "";
-	$result = mysql_query("SELECT `user_name`,`user_id`,`user_fullname`,`user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users`");
-	while($row = mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_name`,`user_id`,`user_fullname`,`user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users`");
+	while($row = mysqli_fetch_array($result))
 		$ret .= "'{$row['user_id']}' : '{$row['user_name']} - {$row['user_fullname']} [{$row['user_email']}]', ";
 	$ret = rtrim($ret,", ");
 	return $ret;	
@@ -27,8 +27,8 @@ function getAllUsers() {
 
 function getAllGroups() {
 	$ret = "";
-	$result = mysql_query("SELECT `group_name`,`group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups`");
-	while($row = mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `group_name`,`group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups`");
+	while($row = mysqli_fetch_array($result))
 		$ret .= "'{$row['group_id']}' : '{$row['group_name']}', ";
 	$ret = rtrim($ret,", ");
 	return $ret;
@@ -176,20 +176,20 @@ RET;
 function getTo($desc) {
 	$ret = "";
 	if($desc == "all") {
-		$result = mysql_query("SELECT `user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users`");
-		while($row = mysql_fetch_array($result))
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users`");
+		while($row = mysqli_fetch_array($result))
 			$ret .= $row['user_email'] . ", ";
 		$ret = rtrim($ret, ", ");
 	} else if(substr($desc, 0, 5) == "users") {
 		$in = substr($desc, 6);
-		$result = mysql_query("SELECT `user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` IN ({$in})");
-		while($row = mysql_fetch_array($result))
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` IN ({$in})");
+		while($row = mysqli_fetch_array($result))
 			$ret .= $row['user_email'] . ", ";
 		$ret = rtrim($ret, ", ");
 	} else if(substr($desc, 0, 6) == "groups") {
 		$in = substr($desc, 7);
-		$result = mysql_query("SELECT `user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` IN (SELECT `user_id` FROM `" . MYSQL_DATABASE_PREFIX . "usergroup` WHERE `group_id` IN ({$in}))");
-		while($row = mysql_fetch_array($result))
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_email` FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` IN (SELECT `user_id` FROM `" . MYSQL_DATABASE_PREFIX . "usergroup` WHERE `group_id` IN ({$in}))");
+		while($row = mysqli_fetch_array($result))
 			$ret .= $row['user_email'] . ", ";
 		$ret = rtrim($ret, ", ");
 	}

--- a/cms/group.lib.php
+++ b/cms/group.lib.php
@@ -45,8 +45,8 @@ This is what grant will have :
  */
 function getGroupRow($groupName) {
 	$groupQuery = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."groups` WHERE `group_name` = '".escape($groupName)."'";
-	$groupResult = mysql_query($groupQuery);
-	return mysql_fetch_assoc($groupResult);
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	return mysqli_fetch_assoc($groupResult);
 }
 
 function getGroupIdFromName($groupName) {
@@ -62,9 +62,9 @@ function getGroupIdFromName($groupName) {
  	  return false;
  	}
 	$query = "SELECT `group_id` FROM `".MYSQL_DATABASE_PREFIX."groups` WHERE `form_id`='".escape($formId)."'";
-	$result = mysql_query($query);
-	if(mysql_num_rows($result)>0){
-		$array = mysql_fetch_assoc($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(mysqli_num_rows($result)>0){
+		$array = mysqli_fetch_assoc($result);
 		$groupId = $array['group_id'];
 		return $groupId;
 	}
@@ -77,9 +77,9 @@ function getGroupIdFromName($groupName) {
  */
 function getFormIdFromGroupId($groupId){
 	$query = "SELECT `form_id` FROM `".MYSQL_DATABASE_PREFIX."groups` WHERE `group_id`='".escape($groupId)."'";
-	$result = mysql_query($query);
-	if(mysql_num_rows($result)>0){
-		$array = mysql_fetch_assoc($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(mysqli_num_rows($result)>0){
+		$array = mysqli_fetch_assoc($result);
 		$formId = $array['form_id'];
 		return $formId;
 	}
@@ -117,13 +117,13 @@ function shiftGroupPriority($userId, $groupName, $direction = 'up', $userMaxPrio
 	if($groupRow['group_priority'] == $userMaxPriority) {
 		// SELECT `group_id` FROM .. WHERE `group_priority` = maxPriority AND `user_id` = $userId AND `group_id` = `group_id`
 		$memberQuery = "SELECT `$usergroupTable`.`group_id` FROM `$usergroupTable`, `$groupsTable` WHERE `group_priority` = '{$groupRow['group_priority']}' AND `user_id` = '$userId' AND `$usergroupTable`.`group_id` = `$groupsTable`.`group_id`";
-		$memberResult = mysql_query($memberQuery);
+		$memberResult = mysqli_query($GLOBALS["___mysqli_ston"], $memberQuery);
 		if(!$memberResult) {
-			displayerror($memberQuery . '<br />' . mysql_error());
+			displayerror($memberQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			return false;
 		}
-		if(mysql_num_rows($memberResult) == 1) {
-			$memberRow = mysql_fetch_row($memberResult);
+		if(mysqli_num_rows($memberResult) == 1) {
+			$memberRow = mysqli_fetch_row($memberResult);
 			if($memberRow[0] == $groupId) {
 				displayerror('Error. Cannot shift the group that gives you grant permissions at this level.');
 				return false;
@@ -145,13 +145,13 @@ function shiftGroupPriority($userId, $groupName, $direction = 'up', $userMaxPrio
 
 	if($shiftNeighbours) {
 		$groupQuery = 'SELECT `group_id` FROM `' . MYSQL_DATABASE_PREFIX . 'groups` WHERE `group_priority` =\'' . $groupPriority."'";
-		$groupResult = mysql_query($groupQuery);
-		if(mysql_num_rows($groupResult) > 1) {
+		$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+		if(mysqli_num_rows($groupResult) > 1) {
 			$groupQuery = 'SELECT `group_id` FROM `' . MYSQL_DATABASE_PREFIX . 'groups` WHERE `group_priority` = ' . $groupPriority . " $op 1";
-			$groupResult = mysql_query($groupQuery);
-			if (mysql_num_rows($groupResult) > 0) {
+			$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+			if (mysqli_num_rows($groupResult) > 0) {
 				$shiftQuery = "UPDATE `" . MYSQL_DATABASE_PREFIX . "groups` SET `group_priority` = `group_priority` + 1 WHERE `group_priority` " . ($direction == 'up' ? '>' : '>=') . " $groupPriority";
-				$shiftResult = mysql_query($shiftQuery);
+				$shiftResult = mysqli_query($GLOBALS["___mysqli_ston"], $shiftQuery);
 				$groupPriority++;
 			}
 
@@ -163,9 +163,9 @@ function shiftGroupPriority($userId, $groupName, $direction = 'up', $userMaxPrio
 		else {
 			/// no other groups on same level. find next higher existing priority level
 			$groupQuery = 'SELECT `group_priority` FROM `' . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_priority` $rel $groupPriority ORDER BY `group_priority` $order LIMIT 0, 1";
-			$groupResult = mysql_query($groupQuery);
-			if(mysql_num_rows($groupResult) == 1) {
-				$groupRow = mysql_fetch_row($groupResult);
+			$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+			if(mysqli_num_rows($groupResult) == 1) {
+				$groupRow = mysqli_fetch_row($groupResult);
 				$newPriority = $groupRow[0];
 			}
 			else {
@@ -178,9 +178,9 @@ function shiftGroupPriority($userId, $groupName, $direction = 'up', $userMaxPrio
 	}
 	else {
 		$groupQuery = 'SELECT `group_priority` FROM `' . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_priority` $rel $groupPriority ORDER BY `group_priority` $order LIMIT 0, 1";
-		$groupResult = mysql_query($groupQuery);
-		if(mysql_num_rows($groupResult) == 1) {
-			$groupRow = mysql_fetch_row($groupResult);
+		$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+		if(mysqli_num_rows($groupResult) == 1) {
+			$groupRow = mysqli_fetch_row($groupResult);
 			$newPriority = $groupRow[0];
 		}
 		else {
@@ -202,7 +202,7 @@ function shiftGroupPriority($userId, $groupName, $direction = 'up', $userMaxPrio
 	}
 
 	$groupQuery = "UPDATE `".MYSQL_DATABASE_PREFIX."groups` SET `group_priority` = '$newPriority' WHERE `group_id` = '$groupId'";
-	if(mysql_query($groupQuery)) {
+	if(mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery)) {
 		return true;
 	}
 	else {
@@ -212,9 +212,9 @@ function shiftGroupPriority($userId, $groupName, $direction = 'up', $userMaxPrio
 
 function getUsersRegisteredToGroup($groupId) {
 	$userQuery = 'SELECT `user_id` FROM `' . MYSQL_DATABASE_PREFIX . 'usergroup` WHERE `group_id` = \'' . $groupId."'";
-	$userResult = mysql_query($userQuery);
+	$userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userQuery);
 	$registeredUserIds = array();
-	while($userRow = mysql_fetch_row($userResult)) {
+	while($userRow = mysqli_fetch_row($userResult)) {
 		$registeredUserIds[] = $userRow[0];
 	}
 
@@ -226,9 +226,9 @@ function associateGroupWithForm($groupId, $formId) {
 	require_once("$sourceFolder/$moduleFolder/form.lib.php");
 
 	$existsQuery = 'SELECT `group_id` FROM `' . MYSQL_DATABASE_PREFIX . 'groups` WHERE `form_id` = \'' . $formId."'";
-	$existsResult = mysql_query($existsQuery);
-	if(!$existsResult) displayerror($existsQuery . ' ' . mysql_error());
-	if(mysql_num_rows($existsResult)) {
+	$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
+	if(!$existsResult) displayerror($existsQuery . ' ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($existsResult)) {
 		displayerror('The given form is already associated with another group.');
 		return false;
 	}
@@ -263,7 +263,7 @@ function associateGroupWithForm($groupId, $formId) {
 				$registeredUsers[$i] = "($registeredUsers[$i], $groupId)";
 			}
 			$insertQuery .= implode($registeredUsers, ', ');
-			if(!mysql_query($insertQuery)) {
+			if(!mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery)) {
 				displayerror('Could not move registered users to group.');
 				return false;
 			}
@@ -272,7 +272,7 @@ function associateGroupWithForm($groupId, $formId) {
 
 	/// Update group table, copy all users to group
 	$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . "groups` SET `form_id` = '$formId' WHERE `group_id` = '$groupId'";
-	if(!mysql_query($updateQuery)) {
+	if(!mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery)) {
 		displayerror('Could not associate the given group with the selected form.');
 		return false;
 	};
@@ -282,15 +282,15 @@ function associateGroupWithForm($groupId, $formId) {
 
 function unassociateFormFromGroup($groupId) {
 	$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'groups` SET `form_id` = 0 WHERE `group_id` = \'' . $groupId."'";
-	$updateResult = mysql_query($updateQuery);
+	$updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 	if(!$updateResult) {
-		displayerror('MySQL error! Could not unassociate the form from the given group.');
+		displayerror('mysql error! Could not unassociate the form from the given group.');
 	}
 
 	$deleteQuery = 'DELETE FROM `' . MYSQL_DATABASE_PREFIX . 'usergroup` WHERE `group_id` = \'' . $groupId."'";
-	$deleteResult = mysql_query($deleteQuery);
+	$deleteResult = mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
 	if(!$deleteResult) {
-		displayerror('MySQL error! Could not remove users from the given group.');
+		displayerror('mysql error! Could not remove users from the given group.');
 	}
 }
 
@@ -299,14 +299,14 @@ function getAssociableFormsList($userId, $emptyFormsOnly = false) {
 	$formIdQuery = 'SELECT `page_id`, `form_desc`.`page_modulecomponentid`, `page_title` FROM `' . MYSQL_DATABASE_PREFIX . "pages`, `form_desc` " .
 			'WHERE `page_module` = \'form\' AND `form_loginrequired` = 1 AND `' .
 			'form_desc`.`page_modulecomponentid` = `' . MYSQL_DATABASE_PREFIX . 'pages`.`page_modulecomponentid`';
-	$formIdResult = mysql_query($formIdQuery);
-	if(!$formIdResult) displayerror($formIdQuery . ' ' . mysql_error());
+	$formIdResult = mysqli_query($GLOBALS["___mysqli_ston"], $formIdQuery);
+	if(!$formIdResult) displayerror($formIdQuery . ' ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	$associableForms = array();
 
 	global $sourceFolder, $moduleFolder;
 	require_once("$sourceFolder/$moduleFolder/form.lib.php");
 
-	while($formIdRow = mysql_fetch_row($formIdResult)) {
+	while($formIdRow = mysqli_fetch_row($formIdResult)) {
 //		displayerror($userId . ' ' . $formIdRow[0] . ' ' . getPermissions($userId, $formIdRow[0], 'editform'));
 		if(getPermissions($userId, $formIdRow[0], 'editregistrants')) {
 			if($emptyFormsOnly) {
@@ -334,8 +334,8 @@ function emptyGroup($groupName, $silent = false) {
 
 	if($formId == 0) {
 		$groupQuery = 'DELETE FROM `'.MYSQL_DATABASE_PREFIX.'usergroup` WHERE `group_id` = \''.$groupId."'";
-		if(!mysql_query($groupQuery)) {
-			displayerror('Error running MySQL query. The given group could not be emptied.');
+		if(!mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery)) {
+			displayerror('Error running mysql query. The given group could not be emptied.');
 			return false;
 		}
 		if(!$silent) displayinfo("Group '$groupName' Emptied Successfully");
@@ -353,7 +353,7 @@ function emptyGroup($groupName, $silent = false) {
 function deleteGroup($groupName) {
 	if(emptyGroup($groupName, true)) {
 		$deleteQuery = 'DELETE FROM `' . MYSQL_DATABASE_PREFIX . 'groups` WHERE `group_name` = \'' . $groupName . '\'';
-		if(mysql_query($deleteQuery)) {
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery)) {
 			displayinfo("Group '$groupName' Deleted Successfully");
 			return true;
 		}
@@ -364,8 +364,8 @@ function deleteGroup($groupName) {
 
 function isGroupEmpty($groupId) {
 	$groupQuery = 'SELECT COUNT(`user_id`) FROM `' . MYSQL_DATABASE_PREFIX . 'usergroup` WHERE `group_id` = \'' . $groupId."'";
-	$groupResult = mysql_query($groupQuery);
-	$groupRow = mysql_fetch_row($groupResult);
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	$groupRow = mysqli_fetch_row($groupResult);
 	return ($groupRow[0] == 0);
 }
 
@@ -377,40 +377,40 @@ function addUserToGroupName($groupName, $userId) {
 	$groupId = $groupRow['group_id'];
 
 	$groupQuery = "SELECT `user_id` FROM `".MYSQL_DATABASE_PREFIX."usergroup` WHERE `group_id` = '$groupId' AND `user_id` = '$userId'";
-	$groupResult = mysql_query($groupQuery);
-	if($groupRow = mysql_fetch_assoc($groupResult)) {
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if($groupRow = mysqli_fetch_assoc($groupResult)) {
 		return true;
 	}
 
 	$groupQuery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."usergroup`(`group_id`, `user_id`) VALUES('$groupId', '$userId')";
-	mysql_query($groupQuery);
+	mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
 	return true;
 }
 
 function addUserToGroupId($groupId, $userId) {
 	$groupQuery = "SELECT `user_id` FROM `".MYSQL_DATABASE_PREFIX."usergroup` WHERE `group_id` = '$groupId' AND `user_id` = '$userId'";
-	$groupResult = mysql_query($groupQuery);
-	if($groupRow = mysql_fetch_assoc($groupResult)) {
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if($groupRow = mysqli_fetch_assoc($groupResult)) {
 		displayerror("User already registered to the group.");
 		return false;
 	}
 
 	$groupQuery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."usergroup`(`group_id`, `user_id`) VALUES('$groupId', '$userId')";
-	$groupResult = mysql_query($groupQuery);
-	if(mysql_affected_rows() == 0) {
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) == 0) {
 		return false;
 	}
 	return true;
 }
 function removeUserFromGroupId($groupId, $userId) {
 	$groupQuery = "SELECT `user_id` FROM `".MYSQL_DATABASE_PREFIX."usergroup` WHERE `group_id` = '$groupId' AND `user_id` = '$userId'";
-	$groupResult = mysql_query($groupQuery);
-	if(mysql_num_fields($groupResult)==0) {
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if((($___mysqli_tmp = mysqli_num_fields($groupResult)) ? $___mysqli_tmp : false)==0) {
 		return false;
 	}
 	$groupQuery = "DELETE FROM `".MYSQL_DATABASE_PREFIX."usergroup` WHERE `user_id`='$userId' and `group_id` = '$groupId'";
-	$groupResult = mysql_query($groupQuery);
-	if(mysql_affected_rows() > 0) {
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) > 0) {
 		return true;
 	}
 	else
@@ -427,8 +427,8 @@ function reevaluateGroupPriorities($modifiableGroups) {
 	$modifiableGroups = array();
 	if($modifiableCount) {
 		$groupQuery = 'SELECT `group_id`, `group_name`, `group_description`, `group_priority` FROM `' . MYSQL_DATABASE_PREFIX . 'groups` WHERE `group_id` IN (' . join($groupIdList, ', ') . ') ORDER BY `group_priority` DESC';
-		$groupResult = mysql_query($groupQuery) or die($groupQuery);
-		while($groupRow = mysql_fetch_assoc($groupResult)) {
+		$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery) or die($groupQuery);
+		while($groupRow = mysqli_fetch_assoc($groupResult)) {
 			$modifiableGroups[] = $groupRow;
 		}
 	}
@@ -438,9 +438,9 @@ function reevaluateGroupPriorities($modifiableGroups) {
 
 function getGroupAssociatedWithForm($formId) {
 	$groupQuery = "SELECT `group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups` WHERE `form_id` = '$formId'";
-	$groupResult = mysql_query($groupQuery);
-	if(mysql_num_rows($groupResult) != 0) {
-		$groupRow = mysql_fetch_row($groupResult);
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if(mysqli_num_rows($groupResult) != 0) {
+		$groupRow = mysqli_fetch_row($groupResult);
 		return $groupRow[0];
 	}
 
@@ -452,11 +452,11 @@ function getGroupsFromUserId($userId) {
 	$groupQuery = 'SELECT `' . MYSQL_DATABASE_PREFIX . 'groups`.`group_id`, `group_name`, `group_description`, `form_id` FROM `' . MYSQL_DATABASE_PREFIX .
 			'groups`, `'. MYSQL_DATABASE_PREFIX . 'usergroup` WHERE `user_id` = \'' . $userId . '\' AND `' .
 			MYSQL_DATABASE_PREFIX . 'groups`.`group_id` = `' . MYSQL_DATABASE_PREFIX . 'usergroup`.`group_id`';
-	$groupResult = mysql_query($groupQuery);
-	if(!$groupResult) displayerror($groupQuery . '<br />' . mysql_error());
+	$groupResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupQuery);
+	if(!$groupResult) displayerror($groupQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
 	$groupRows = array();
-	while($groupRow = mysql_fetch_assoc($groupResult)) {
+	while($groupRow = mysqli_fetch_assoc($groupResult)) {
 		$groupRows[] = $groupRow;
 	}
 	return $groupRows;

--- a/cms/iconmanagement.lib.php
+++ b/cms/iconmanagement.lib.php
@@ -63,7 +63,7 @@ function handleIconManagement() {
 			 * Save the Icon in Database - The following entries are saved
 			 * icon URL - path relative to the website installation folder on the server
 			 */
-			mysql_query("UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_image`='$iconURL' WHERE `page_id`='$target'");
+			mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_image`='$iconURL' WHERE `page_id`='$target'");
 			$pageDetails = getPageInfo($target);
 			if($pageDetails['page_image'] != NULL)
 				echo "<img src=\"$rootUri/$cmsFolder/$templateFolder/common/icons/16x16/status/weather-clear.png\" /> ";

--- a/cms/inheritedinfo.lib.php
+++ b/cms/inheritedinfo.lib.php
@@ -28,15 +28,15 @@ if(!defined('__PRAGYAN_CMS'))
 function inheritedinfo($array) {
 
 	$query = "SELECT `page_inheritedinfoid` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` IN(" . join($array, ",") . ")";
-	$data = mysql_query($query);
+	$data = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$inheritedinfoid = -1;
-	while ($temp = mysql_fetch_assoc($data))
+	while ($temp = mysqli_fetch_assoc($data))
 		if ($temp['page_inheritedinfoid'] != -1)
 			$inheritedinfoid = $temp['page_inheritedinfoid'];
 	if ($inheritedinfoid != -1) {
 		$query = "SELECT `page_inheritedinfocontent` FROM `" . MYSQL_DATABASE_PREFIX . "inheritedinfo` WHERE `page_inheritedinfoid` = '$inheritedinfoid'";
-		$data = mysql_query($query);
-		$temp = mysql_fetch_assoc($data);
+		$data = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$temp = mysqli_fetch_assoc($data);
 	}
 	$inheritedinfocontent = $temp['page_inheritedinfocontent'];
 	return $inheritedinfocontent;

--- a/cms/login.lib.php
+++ b/cms/login.lib.php
@@ -46,9 +46,9 @@ RESET;
 							displayerror("Invalid Email Id. <br /><input type=\"button\" onclick=\"history.go(-1)\" value=\"Go back\" />");
 						else {
 							$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_email`='".escape($_POST[user_email])."' ";
-							$result = mysql_query($query);
-							$temp = mysql_fetch_assoc($result);
-							if (mysql_num_rows($result) == 0)
+							$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+							$temp = mysqli_fetch_assoc($result);
+							if (mysqli_num_rows($result) == 0)
 								displayerror("E-mail not in registered accounts list. <br /><input type=\"button\" onclick=\"history.go(-1)\" value=\"Go back\" />");
 							elseif ($temp['user_loginmethod']==='openid')
 		displayerror("This email is registered as an OpenID user. You do not have a permanent account on our server. Hence, we do not keep or maintain your password. Please ask the parent OpenID provider to reset the password for you");
@@ -83,12 +83,12 @@ RESET;
 					$password = rand();
 					$dbpassword = md5($password);
 					$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_email`='" . $user_email . "'";
-					$result = mysql_query($query);
-					$temp = mysql_fetch_assoc($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					$temp = mysqli_fetch_assoc($result);
 					if ($key == md5($temp['user_password'].'xXc'.substr($temp['user_email'],1,2))) {
 						$query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "users`  SET `user_password`='$dbpassword' WHERE `user_email`='$user_email'";
-						$result = mysql_query($query);
-						if (mysql_affected_rows() > 0) { 
+						$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) > 0) { 
 							// send mail code starts here
 //							$from = "no-reply@pragyan.org";
 							$to = "$temp[user_email]";
@@ -270,8 +270,8 @@ function openid_login($userdata){
   /// Build a query to check if the OpenID already exits in openid_users table
   $query="SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "openid_users` WHERE `openid_url` = '". $userdata['openid_url'] . "';";
 
-  $result=mysql_query($query) or die(mysql_error(). " in openid_login() inside login.lib.php while executing query for openid_row");
-  $openid_row=mysql_fetch_array($result);
+  $result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)). " in openid_login() inside login.lib.php while executing query for openid_row");
+  $openid_row=mysqli_fetch_array($result);
   if($openid_row)
     { ///the record exists, this user has already used his OpenID before
       //print_r($row);
@@ -296,13 +296,13 @@ function openid_login($userdata){
     
       ///Assign the value to $_SESSION['last_to_last_login_datetime']
       $query = "SELECT `user_lastlogin` FROM `". MYSQL_DATABASE_PREFIX .  "users` WHERE `user_id`='".$openid_row['user_id']. "';";
-      $result=mysql_query($query) or die(mysql_error(). " in openid_login() inside login.lib.php while trying to fetch last login");
-      $last_login_row=mysql_fetch_array($result);
+      $result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)). " in openid_login() inside login.lib.php while trying to fetch last login");
+      $last_login_row=mysqli_fetch_array($result);
       $_SESSION['last_to_last_login_datetime']=$last_login_row['user_lastlogin'];
       
       ///update the last login
       $query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "users` SET `user_lastlogin`=NOW() WHERE `" . MYSQL_DATABASE_PREFIX . "users`.`user_id` ='". $openid_row['user_id']. "';" ;
-      mysql_query($query) or die(mysql_error() . " in openid_login() inside login.lib.php while trying to update the last login");
+      mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . " in openid_login() inside login.lib.php while trying to update the last login");
       ///logging in the user
       setAuth($openid_row['user_id']);
 					
@@ -532,8 +532,8 @@ LOGIN;
  */
 function login() {
   $allow_login_query = "SELECT `value` FROM `".MYSQL_DATABASE_PREFIX."global` WHERE `attribute` = 'allow_login'";
-  $allow_login_result = mysql_query($allow_login_query);
-  $allow_login_result = mysql_fetch_array($allow_login_result);
+  $allow_login_result = mysqli_query($GLOBALS["___mysqli_ston"], $allow_login_query);
+  $allow_login_result = mysqli_fetch_array($allow_login_result);
   if(isset($_GET['subaction'])) {
     if($_GET['subaction']=="resetPasswd") {
       return resetPasswd($allow_login_result[0]);
@@ -609,7 +609,7 @@ function login() {
 		    {
 		      //Password was correct. Link the account
 		      $query="INSERT INTO `" . MYSQL_DATABASE_PREFIX ."openid_users` (`openid_url`,`user_id`) VALUES ('$openid_url',".$info['user_id'].")";
-		      $result=mysql_query($query) or die(mysql_error()." in login() subaction=openid_pass while trying to Link OpenID account");
+		      $result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." in login() subaction=openid_pass while trying to Link OpenID account");
 		      if($result)
 			{
 			  displayinfo("Account successfully Linked. Log In one more time to continue.");
@@ -645,12 +645,12 @@ function login() {
 	      //Now let's start making the dummy user
 	      $query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "users` " ."(`user_name`, `user_email`, `user_fullname`, `user_password`, `user_activated`,`user_loginmethod`) ".
 		"VALUES ('".$openid_email."', '".$openid_email."','".$openid_fname."','0',1,'openid');";	    
-	      $result=mysql_query($query) or die(mysql_error()." in login() subaction=quick_openid_reg while trying to insert information of new account");
+	      $result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." in login() subaction=quick_openid_reg while trying to insert information of new account");
 	      if($result)
 		{
-		  $id=mysql_insert_id();
+		  $id=((is_null($___mysqli_res = mysqli_insert_id($GLOBALS["___mysqli_ston"]))) ? false : $___mysqli_res);
 		  $query="INSERT INTO `" . MYSQL_DATABASE_PREFIX ."openid_users` (`openid_url`,`user_id`) VALUES ('$openid_url',".$id.")";
-		  $result=mysql_query($query) or die(mysql_error()." in login() subaction=quick_openid_reg while trying to Link OpenID account");
+		  $result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." in login() subaction=quick_openid_reg while trying to Link OpenID account");
 		  if($result)
 		    {
 		      displayinfo("Account successfully registered. You can now login via OpenID. Please complete your profile information after logging in.");
@@ -731,7 +731,7 @@ function login() {
 	    $query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "users` " .
 	      "(`user_id`, `user_name`, `user_email`, `user_fullname`, `user_password`, `user_loginmethod`, `user_activated`) " .
 	      "VALUES (DEFAULT, '{$user_name}', '{$user_email}', '{$user_fullname}', '{$user_md5passwd}', '{$login_method}', '1')";
-	    mysql_query($query) or die(mysql_error() . " creating new user !");
+	    mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . " creating new user !");
 	  }
 	  else displaywarning("Incorrect username and/or password for <b>".(isset($user_domain)?$user_domain."</b> domain!":$user_name."</b> user"));
 	}
@@ -745,7 +745,7 @@ function login() {
 	  }
 	  else {
 	    $query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "users` SET `user_lastlogin`=NOW() WHERE `" . MYSQL_DATABASE_PREFIX . "users`.`user_id` ='$temp[user_id]'";
-	    mysql_query($query) or die(mysql_error() . " in login.lib.L:111");
+	    mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . " in login.lib.L:111");
 	    $_SESSION['last_to_last_login_datetime']=$temp['user_lastlogin'];
 	    setAuth($temp['user_id']);
 							

--- a/cms/menu.lib.php
+++ b/cms/menu.lib.php
@@ -179,8 +179,8 @@ function getChildList($pageId,$depth,$rootUri,$userId,$curdepth) {
   $var = "<div class='div_{$classname}'><ul class='{$classname} depth{$curdepth}'>";
   for($i=0;$i<count($pageRow);$i+=1) {
   	$query = "SELECT `page_openinnewtab` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id` = '{$pageRow[$i][0]}'";
-		$result = mysql_query($query);
-		$result = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$result = mysqli_fetch_assoc($result);
 		$opennewtab="";
 		if($result['page_openinnewtab']=='1') 
 			$opennewtab = ' target="_blank" ';
@@ -214,8 +214,8 @@ function htmlMenuRenderer($menuArray, $currentIndex = -1, $linkPrefix = '') {
 	
 	for ($i = 0; $i < count($menuArray); ++$i) {
 			$query = "SELECT `page_openinnewtab` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id` = '{$menuArray[$i][0]}'";
-			$result = mysql_query($query);
-			$result = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$result = mysqli_fetch_assoc($result);
 			
 			if($result['page_openinnewtab']=='1') {
 				$menuHtml .= "<a href=\"".$hostURL."{$linkPrefix}{$menuArray[$i][1]}/\" target=\"_blank\"";
@@ -270,9 +270,9 @@ function getChildren($pageId, $userId) {
 	$pageId=escape($pageId);
 	$childrenQuery = 'SELECT `page_id`, `page_name`, `page_title`, `page_module`, `page_modulecomponentid`, `page_displayinmenu`, `page_image` , `page_displayicon` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_parentid` = \'' . $pageId . '\' AND `page_id` != \'' . $pageId . '\' AND `page_displayinmenu` = 1 ORDER BY `page_menurank`';
 	
-	$childrenResult = mysql_query($childrenQuery);
+	$childrenResult = mysqli_query($GLOBALS["___mysqli_ston"], $childrenQuery);
 	$children = array();
-	while ($childrenRow = mysql_fetch_assoc($childrenResult))
+	while ($childrenRow = mysqli_fetch_assoc($childrenResult))
 		if ($childrenRow['page_displayinmenu'] == true && getPermissions($userId, $childrenRow['page_id'], 'view', $childrenRow['page_module']) == true)
 			$children[] = array($childrenRow['page_id'], $childrenRow['page_name'], $childrenRow['page_title'], $childrenRow['page_image'],$childrenRow['page_displayicon']);
 			

--- a/cms/module.lib.php
+++ b/cms/module.lib.php
@@ -60,14 +60,14 @@ function processUploaded($type) {
 			$colName = "template_name";
 			$tableName = "templates";
 		}
-		if(mysql_fetch_array(mysql_query("SELECT `{$colName}` FROM `".MYSQL_DATABASE_PREFIX."{$tableName}` WHERE `{$colName}` = '{$moduleName}'"))) {
+		if(mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `{$colName}` FROM `".MYSQL_DATABASE_PREFIX."{$tableName}` WHERE `{$colName}` = '{$moduleName}'"))) {
 			displayerror("A {$type} with name '{$moduleName}' already exist, Installation aborted");
 			delDir($extractedPath);
 			unlink($zipFile);
 			return -1;
 		}
-		mysql_query("INSERT INTO `" . MYSQL_DATABASE_PREFIX . "tempuploads`(`filePath`,`info`) VALUES('{$zipFile}','{$extractedPath};{$moduleActualPath};{$moduleName}')");
-		$result = mysql_fetch_assoc(mysql_query("SELECT `id` FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `filePath` = '{$zipFile}'"));
+		mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "tempuploads`(`filePath`,`info`) VALUES('{$zipFile}','{$extractedPath};{$moduleActualPath};{$moduleName}')");
+		$result = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `id` FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `filePath` = '{$zipFile}'"));
 		return $result['id'];
 	}
 	
@@ -80,7 +80,7 @@ function processUploaded($type) {
 
 function finalizeInstallation($uploadId,$type) {
 	global $sourceFolder, $widgetFolder, $templateFolder;
-	$result = mysql_fetch_assoc(mysql_query("SELECT * FROM `" . MYSQL_DATABASE_PREFIX. "tempuploads` WHERE `id` = '{$uploadId}'"));
+	$result = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `" . MYSQL_DATABASE_PREFIX. "tempuploads` WHERE `id` = '{$uploadId}'"));
 	if($result != NULL) {
 		$zipFile = $result['filePath'];
 		$temp = explode(";",$result['info']);
@@ -98,7 +98,7 @@ function finalizeInstallation($uploadId,$type) {
 		displayerror("Your {$type} is still not compatible with Pragyan CMS. Please fix the reported issues during installation.");
 		delDir($extractedPath);
 		unlink($zipFile);
-		mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(mysql_error());
+		mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		return "";
 	}
 	
@@ -113,12 +113,12 @@ function finalizeInstallation($uploadId,$type) {
  		$tableName = "templates";
  	}
  	
- 	if(mysql_fetch_array(mysql_query("SELECT `{$colName}` FROM `" . MYSQL_DATABASE_PREFIX . "{$tableName}` WHERE `{$colName}` = '{$moduleName}'"))) 
+ 	if(mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `{$colName}` FROM `" . MYSQL_DATABASE_PREFIX . "{$tableName}` WHERE `{$colName}` = '{$moduleName}'"))) 
 	{
 		displayerror("{$type} Installation failed : {$type} already exist");
 		delDir($extractedPath);
 		unlink($zipFile);
-		mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(mysql_error());
+		mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		return "";
 	}
 
@@ -152,13 +152,13 @@ function finalizeInstallation($uploadId,$type) {
 		$singlequeries = explode(";\n",$query);
 		foreach ($singlequeries as $singlequery) {
 			if (trim($singlequery)!="") {
-				$result1 = mysql_query($singlequery);
+				$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $singlequery);
 				if (!$result1) {
-		  			displayerror("<h3>Error:</h3><pre>".$singlequery."</pre>\n<br/>Unable to execute query. " . mysql_error());
+		  			displayerror("<h3>Error:</h3><pre>".$singlequery."</pre>\n<br/>Unable to execute query. " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				}
 			}
 		}
-		mysql_query("INSERT INTO `" . MYSQL_DATABASE_PREFIX . "modules`(`module_name`,`module_tables`) VALUES('{$moduleName}','" . escape(file_get_contents($moduleActualPath . "moduleTables.txt")) . "')") or displayerror(mysql_error());
+		mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "modules`(`module_name`,`module_tables`) VALUES('{$moduleName}','" . escape(file_get_contents($moduleActualPath . "moduleTables.txt")) . "')") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$notice = "";
 		if(file_exists($moduleActualPath . "moduleNotice.txt"))
 			$notice = ", New module samoduleTablesys:<br>" . file_get_contents($moduleActualPath . "moduleNotice.txt");
@@ -179,19 +179,19 @@ function finalizeInstallation($uploadId,$type) {
  			$widgetAuthor = escape($content[4]);
  		} else
  			displaywarning("Widget information could not be read properly");
- 		mysql_query("INSERT INTO `" . MYSQL_DATABASE_PREFIX . "widgetsinfo`(`widget_name`,`widget_classname`,`widget_description`,`widget_version`,`widget_author`,`widget_foldername`) VALUES ('{$widgetName}','{$widgetClassName}','{$widgetDescription}','{$widgetVersion}','{$widgetAuthor}','{$widgetFolder}')");
- 		if(!mysql_affected_rows()) {
+ 		mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "widgetsinfo`(`widget_name`,`widget_classname`,`widget_description`,`widget_version`,`widget_author`,`widget_foldername`) VALUES ('{$widgetName}','{$widgetClassName}','{$widgetDescription}','{$widgetVersion}','{$widgetAuthor}','{$widgetFolder}')");
+ 		if(!mysqli_affected_rows($GLOBALS["___mysqli_ston"])) {
  			displayerror("Installation error, try again later");
  			delDir($sourceFolder . "/widgets/" . $moduleName);
  		}
 	} else if($type=="Template") {
-		mysql_query("INSERT INTO `" . MYSQL_DATABASE_PREFIX . "templates`(`template_name`) VALUES('{$moduleName}')");
-		if(!mysql_affected_rows())
+		mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "templates`(`template_name`) VALUES('{$moduleName}')");
+		if(!mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 			displayerrro("Problem including uploaded template to database, try <a href='./+admin&subaction=reloadtemplates'>reload templates</a>");
 	}
 	delDir($extractedPath);
 	unlink($zipFile);
-	mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(mysql_error());
+	mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	displayinfo("{$type} installation complete" . $notice);
 	return "";
 }
@@ -211,8 +211,8 @@ function handleModuleManagement() {
 		}
 		$toDelete = escape($_POST['Module']);
 		$query = "SELECT `page_id` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_module` = '{$toDelete}' LIMIT 10";
-		$result = mysql_query($query) or displayerror(mysql_error());
-		if(mysql_num_rows($result)==0||isset($_POST['confirm']))
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		if(mysqli_num_rows($result)==0||isset($_POST['confirm']))
 			if(deleteModule($toDelete)) {
 				displayinfo("Module ".safe_html($_POST['Module'])." uninstalled!");
 				return "";
@@ -222,11 +222,11 @@ function handleModuleManagement() {
 			}
 		if(isset($_POST['confirm'])) {
 			$query = "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_module` = '" . $toDelete . "'";
-			mysql_query($query) or displayerror(mysql_error());
+			mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		}
 		
 		$pageList = "";
-		while($row = mysql_fetch_assoc($result))
+		while($row = mysqli_fetch_assoc($result))
 			$pageList .= "/home" . getPagePath($row['page_id']) . "<br>";
 		
 		$modulename = safe_html($_POST['Module']);
@@ -250,7 +250,7 @@ RET;
 	else if(isset($_GET['subsubaction']) && $_GET['subsubaction'] == 'cancel') 
 	{
 		$uploadId = escape($_POST['id']);
-		$result = mysql_fetch_assoc(mysql_query("SELECT * FROM `" . MYSQL_DATABASE_PREFIX. "tempuploads` WHERE `id` = '{$uploadId}'"));
+		$result = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `" . MYSQL_DATABASE_PREFIX. "tempuploads` WHERE `id` = '{$uploadId}'"));
 		if($result != NULL) {
 			$zipFile = $result['filePath'];
 			$temp = explode(";",$result['info']);
@@ -260,28 +260,28 @@ RET;
 		}
 		delDir($extractedPath);
 		unlink($zipFile);
-		mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(mysql_error());
+		mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		return "";
 	}
 }
 
 function deleteModule($module) {
-	$result = mysql_query("SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "modules` WHERE `module_name` = '" . $module . "'") or displayerror(mysql_error());
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "modules` WHERE `module_name` = '" . $module . "'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	global $sourceFolder;
-	if($row = mysql_fetch_array($result)) {
+	if($row = mysqli_fetch_array($result)) {
 		$tables = preg_split("/[\s,;]+/",$row['module_tables']);
 		$i = 1;
 		foreach($tables as $table)
 			if($table != "")
-				mysql_query("DROP TABLE `{$table}`") or displayerror(mysql_error());
-		mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "modules` WHERE `module_name` = '" . $module . "'") or displayerror(mysql_error());
-		$result = mysql_query("SELECT `perm_id` FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module` = '{$module}'") or displayerror(mysql_error());
+				mysqli_query($GLOBALS["___mysqli_ston"], "DROP TABLE `{$table}`") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "modules` WHERE `module_name` = '" . $module . "'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `perm_id` FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module` = '{$module}'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$perms = "";
-		while($row = mysql_fetch_assoc($result))
+		while($row = mysqli_fetch_assoc($result))
 			$perms .= $row['perm_id'] . ",";
 		$perms = rtrim($perms, ",");
-		mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_id` IN ({$perms})") or displayerror(mysql_error());
-		mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module` = '" . $module . "'") or displayerror(mysql_error());
+		mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_id` IN ({$perms})") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `page_module` = '" . $module . "'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$moduleDir = $sourceFolder . "/modules/" . $module . "/";
 		if(file_exists($moduleDir))
 			delDir($moduleDir);
@@ -303,7 +303,7 @@ function installModuleFiles($from, $to, $module) {
 
 function installModule($uploadId,$type) {
 	global $sourceFolder;
-	$result = mysql_fetch_assoc(mysql_query("SELECT * FROM `" . MYSQL_DATABASE_PREFIX. "tempuploads` WHERE `id` = '{$uploadId}'"));
+	$result = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `" . MYSQL_DATABASE_PREFIX. "tempuploads` WHERE `id` = '{$uploadId}'"));
 	if($result != NULL) {
 		$zipFile = $result['filePath'];
 		$temp = explode(";",$result['info']);
@@ -324,7 +324,7 @@ function installModule($uploadId,$type) {
 	<b>Installation cannot proceed for the above mentioned issues, fix them and <a href='./+admin&subaction=widgets&subsubaction=installwidget'>try again</a>.</b>";
 	delDir($extractedPath);
 	unlink($zipFile);
-	mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(mysql_error());
+	mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "tempuploads` WHERE `id` = '{$uploadId}'") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	return $issues;
 }
 

--- a/cms/modules/article.lib.php
+++ b/cms/modules/article.lib.php
@@ -42,12 +42,12 @@ class article implements module, fileuploadable {
 	}
 	
 	function isCommentsEnabled() {
-		$result = mysql_fetch_array(mysql_query("SELECT `allowComments` FROM `article_content` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
+		$result = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `allowComments` FROM `article_content` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
 		return $result['allowComments'];
 	}
 	
 	function setCommentEnable($val) {
-		mysql_query("UPDATE `article_content` SET `allowComments` ='$val' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'");
+		mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `article_content` SET `allowComments` ='$val' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'");
 	}
 	
 	function renderComment($id,$user,$timestamp,$comment,$delete=0) {
@@ -97,36 +97,36 @@ RET;
 				
 				//$query = "UPDATE `article_draft` SET `draft_content` = '" . $_POST["CKEditor1"] . "' WHERE `page_modulecomponentid` =".$this->moduleComponentId;
 				$query="SELECT MAX(draft_number) AS MAX FROM `article_draft` WHERE page_modulecomponentid ='$this->moduleComponentId'";
-			$result = mysql_query($query);
-			if(!$result) { displayerror(mysql_error() . "article.lib L:44"); return; }
-			if(mysql_num_rows($result))
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if(!$result) { displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "article.lib L:44"); return; }
+			if(mysqli_num_rows($result))
 			{
-				$drow = mysql_fetch_assoc($result);
+				$drow = mysqli_fetch_assoc($result);
 				$draftId = $drow['MAX'] + 1;
 			}
 			else $draftId=1;
 			
 				$query = "INSERT INTO `article_draft` (`page_modulecomponentid`,`draft_number`,`draft_content`,`draft_lastsaved`,`user_id`) VALUES ('".$this->moduleComponentId."','".$draftId."','".$_POST['CKEditor1']."',now(),'".$this->userId."')";
-				$result = mysql_query($query) or die(mysql_error());
-					if(mysql_affected_rows() < 1)
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) < 1)
 					displayerror("Unable to draft the article");
 				
 	}
 		if($this->isCommentsEnabled() && isset($_POST['btnSubmit'])) {
-			$id = mysql_fetch_array(mysql_query("SELECT MAX(`comment_id`) AS MAX FROM `article_comments`"));
+			$id = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT MAX(`comment_id`) AS MAX FROM `article_comments`"));
 			$id = $id['MAX'] + 1;
 			$user = getUserName($this->userId);
 			$comment = escape(safe_html($_POST['comment']));
-			mysql_query("INSERT INTO `article_comments`(`comment_id`,`page_modulecomponentid`,`user`,`comment`) VALUES('$id','{$this->moduleComponentId}','$user','$comment')");
-			if(mysql_affected_rows())
+			mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `article_comments`(`comment_id`,`page_modulecomponentid`,`user`,`comment`) VALUES('$id','{$this->moduleComponentId}','$user','$comment')");
+			if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 				displayinfo("Post successful");
 			else
 				displayerror("Error in posting comment");
 		}
 		if($text==""){
 			$query = "SELECT article_content,article_lastupdated FROM article_content WHERE page_modulecomponentid='" . $this->moduleComponentId."'";
-			$result = mysql_query($query);
-			if($row = mysql_fetch_assoc($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if($row = mysqli_fetch_assoc($result)) {
 				$text = $row['article_content'];
 				$text = censor_words($text);
 				global $PAGELASTUPDATED;
@@ -148,12 +148,12 @@ RET;
 		
 		
 		if($this->isCommentsEnabled()) {
-			$comments = mysql_query("SELECT `comment_id`,`user`,`timestamp`,`comment` FROM `article_comments` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' ORDER BY `timestamp`");
-			if(mysql_num_rows($comments)>0)
+			$comments = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `comment_id`,`user`,`timestamp`,`comment` FROM `article_comments` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' ORDER BY `timestamp`");
+			if(mysqli_num_rows($comments)>0)
 				$ret .= "<fieldset><legend>Comments</legend>";
-			while($row = mysql_fetch_array($comments))
+			while($row = mysqli_fetch_array($comments))
 				$ret .= $this->renderComment($row['comment_id'],$row['user'],$row['timestamp'],censor_words($row['comment']));
-			if(mysql_num_rows($comments)>0)
+			if(mysqli_num_rows($comments)>0)
 				$ret .= "</fieldset>";
 			$ret .= $this->commentBox();
 		}
@@ -170,7 +170,7 @@ RET;
 		{
 		$dno = escape($_GET['dno']);
 		$query = "DELETE FROM `article_draft` WHERE `page_modulecomponentid`='". $this->moduleComponentId."' AND `draft_number`=".$dno;
-		$result = mysql_query($query) or die(mysql_error());
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		}
 		
 		global $ICONS;
@@ -192,8 +192,8 @@ HEADER;
 		
 		submitFileUploadForm($this->moduleComponentId,"article",$this->userId,UPLOAD_SIZE_LIMIT);
 		if(isset($_GET['delComment']) && $this->userId == 1) {
-			mysql_query("DELETE FROM `article_comments` WHERE `comment_id` = '".escape($_GET['delComment'])."'");
-			if(mysql_affected_rows())
+			mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `article_comments` WHERE `comment_id` = '".escape($_GET['delComment'])."'");
+			if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 				displayinfo("Comment deleted!");
 			else
 				displayerror("Error in deleting comment");
@@ -217,15 +217,15 @@ HEADER;
 
 			/*Save the diff :-*/
 			$query = "SELECT article_content FROM article_content WHERE page_modulecomponentid='" . $this->moduleComponentId."'";
-			$result = mysql_query($query);
-			$row = mysql_fetch_assoc($result);
-			$diff = mysql_escape_string($this->diff($_POST['CKEditor1'],$row['article_content']));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$row = mysqli_fetch_assoc($result);
+			$diff = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $this->diff($_POST['CKEditor1'],$row['article_content'])) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
 			$query="SELECT MAX(article_revision) AS MAX FROM `article_contentbak` WHERE page_modulecomponentid ='" . $this->moduleComponentId."'";
-			$result = mysql_query($query);
-			if(!$result) { displayerror(mysql_error() . "article.lib L:44"); return; }
-			if(mysql_num_rows($result))
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if(!$result) { displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "article.lib L:44"); return; }
+			if(mysqli_num_rows($result))
 			{
-				$row = mysql_fetch_assoc($result);
+				$row = mysqli_fetch_assoc($result);
 				$revId = $row['MAX'] + 1;
 			}
 			else $revId=1;
@@ -233,14 +233,14 @@ HEADER;
 
 			$query = "INSERT INTO `article_contentbak` (`page_modulecomponentid` ,`article_revision` ,`article_diff`,`user_id`)
 VALUES ('$this->moduleComponentId', '$revId','$diff','$this->userId')";
-			$result = mysql_query($query);
-			if(!$result) { displayerror(mysql_error() . "article.lib L:44"); return; }
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if(!$result) { displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "article.lib L:44"); return; }
 
 		/*Save the diff end.*/
 
 			$query = "UPDATE `article_content` SET `article_content` = '" . escape($_POST["CKEditor1"]) . "' WHERE `page_modulecomponentid` ='$this->moduleComponentId' ";
-			$result = mysql_query($query);
-			if(mysql_affected_rows() < 0)
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) < 0)
 				displayerror("Unable to update the article content");
 			else {
 				
@@ -254,8 +254,8 @@ VALUES ('$this->moduleComponentId', '$revId','$diff','$this->userId')";
 			if(isset($_POST['editor'])){
 			  $editor=escape($_POST['editor']);
 			  $query = "UPDATE `article_content` SET `default_editor` = '" . $editor . "' WHERE `page_modulecomponentid` ='$this->moduleComponentId' ";
-			  $result = mysql_query($query);
-			  if(mysql_affected_rows() < 0)
+			  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			  if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) < 0)
 			    displayerror("Unable to update the article Editor");
 			}
 			return $this->actionView();
@@ -265,12 +265,12 @@ VALUES ('$this->moduleComponentId', '$revId','$diff','$this->userId')";
 		$commentsedit = "<fieldset><legend><a name='comments'>{$ICONS['Page Comments']['small']}Comments</a></legend>";
 		
 		if($this->isCommentsEnabled()) {
-			$comments = mysql_query("SELECT `comment_id`,`user`,`timestamp`,`comment` FROM `article_comments` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' ORDER BY `timestamp`");
-			if(mysql_num_rows($comments)==0)
+			$comments = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `comment_id`,`user`,`timestamp`,`comment` FROM `article_comments` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' ORDER BY `timestamp`");
+			if(mysqli_num_rows($comments)==0)
 				$commentsedit.= "No comments have been posted !";
 			
 			
-			while($row = mysql_fetch_array($comments))
+			while($row = mysqli_fetch_array($comments))
 			{
 				$commentsedit .= $this->renderComment($row['comment_id'],$row['user'],$row['timestamp'],$row['comment'],1);
 				
@@ -367,12 +367,12 @@ VALUES ('$this->moduleComponentId', '$revId','$diff','$this->userId')";
 	}
 	public function getRevision($revisionNo) {
 		$currentquery = "SELECT article_content FROM article_content WHERE page_modulecomponentid='" . $this->moduleComponentId."'";
-		$currentresult = mysql_query($currentquery);
-		$currentrow = mysql_fetch_assoc($currentresult);
+		$currentresult = mysqli_query($GLOBALS["___mysqli_ston"], $currentquery);
+		$currentrow = mysqli_fetch_assoc($currentresult);
 		$revision = $currentrow['article_content'];
 		$diffquery = "SELECT * FROM `article_contentbak` WHERE `page_modulecomponentid`='$this->moduleComponentId' AND article_revision >= '$revisionNo' ORDER BY article_revision DESC";
-		$diffresult = mysql_query($diffquery);
-		while($diffrow = mysql_fetch_assoc($diffresult)) {
+		$diffresult = mysqli_query($GLOBALS["___mysqli_ston"], $diffquery);
+		while($diffrow = mysqli_fetch_assoc($diffresult)) {
 			$revision = $this->patch($revision,$diffrow['article_diff']);
 		}
 		return $revision;
@@ -380,12 +380,12 @@ VALUES ('$this->moduleComponentId', '$revId','$diff','$this->userId')";
 	
 	public function getDraft($draftNo) {
 		$currentquery = "SELECT draft_content FROM article_draft WHERE page_modulecomponentid='" . $this->moduleComponentId."'";
-		$currentresult = mysql_query($currentquery);
-		$currentrow = mysql_fetch_assoc($currentresult);
+		$currentresult = mysqli_query($GLOBALS["___mysqli_ston"], $currentquery);
+		$currentrow = mysqli_fetch_assoc($currentresult);
 		$draft = $currentrow['draft_content'];
 		$diffquery = "SELECT * FROM `article_draft` WHERE `page_modulecomponentid`= '$this->moduleComponentId' AND draft_number >= '$draftNo' ORDER BY draft_number DESC";
-		$diffresult = mysql_query($diffquery);
-		while($diffrow = mysql_fetch_assoc($diffresult)) {
+		$diffresult = mysqli_query($GLOBALS["___mysqli_ston"], $diffquery);
+		while($diffrow = mysqli_fetch_assoc($diffresult)) {
 			$draft = $this->patch($draft,$diffrow['draft_content']);
 		}
 		return $draft;
@@ -399,8 +399,8 @@ VALUES ('$this->moduleComponentId', '$revId','$diff','$this->userId')";
 			global $ICONS;
 			require_once ("$sourceFolder/$moduleFolder/article/ckeditor4.4/ckeditor.php");
 			$query = "SELECT * FROM `article_content` WHERE `page_modulecomponentid`= '$this->moduleComponentId'";
-			$result = mysql_query($query);
-			$temp = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$temp = mysqli_fetch_assoc($result);
 			if($content=="") 				
 				$content = $temp['article_content'];
 			$editor=$temp['default_editor'];
@@ -465,8 +465,8 @@ Ck1;
 
 		/* Revisions available */
 		$revisionquery = "SELECT MAX(article_revision) AS MAX FROM `article_contentbak` where page_modulecomponentid = '$this->moduleComponentId'";
-		$revisionresult = mysql_query($revisionquery);
-		$revisionrow = mysql_fetch_assoc($revisionresult);
+		$revisionresult = mysqli_query($GLOBALS["___mysqli_ston"], $revisionquery);
+		$revisionrow = mysqli_fetch_assoc($revisionresult);
 		$start = $revisionrow['MAX'] - 10;
 		if(isset($_GET['revisionno']))
 			$start = escape($_GET['revisionno']);
@@ -477,11 +477,11 @@ Ck1;
 			$count = escape($_GET['count']);
 		if($count>($revisionrow['MAX']-$start+1)) $count = $revisionrow['MAX']-$start+1;
 		$query = "SELECT article_revision,article_updatetime,user_id FROM `article_contentbak` where page_modulecomponentid = '$this->moduleComponentId' ORDER BY article_revision LIMIT $start,$count";
-		$result = mysql_query($query);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$revisionTable = "<fieldset>
 					        <legend><a name='revisions'>{$ICONS['Page Revisions']['small']}Page Revisions : </a></legend>" .
 					        		"<table border='1'><tr><td>Revision Number</td><td>Date Updated</td><td>User Fullname</td><td>User Email</td></tr>";
-		while ($row = mysql_fetch_assoc($result)) {
+		while ($row = mysqli_fetch_assoc($result)) {
 			$revisionTable .= "<tr><td><a href=\"./+edit&version=".$row['article_revision']."#preview\">".$row['article_revision']."</a></td><td>".$row['article_updatetime']."</td><td>".getUserFullName($row['user_id'])."</td><td>".getUserEmail($row['user_id'])."</td></tr>";
 		}
 		$revisionTable .="</table>" .
@@ -493,8 +493,8 @@ Ck1;
 				
 			/* Drafts available */
 		$draftquery = "SELECT MAX(draft_number) AS MAX FROM `article_draft` where page_modulecomponentid = '$this->moduleComponentId'";
-		$draftresult = mysql_query($draftquery);
-		$draftrow = mysql_fetch_assoc($draftresult);
+		$draftresult = mysqli_query($GLOBALS["___mysqli_ston"], $draftquery);
+		$draftrow = mysqli_fetch_assoc($draftresult);
 		$dstart = $draftrow['MAX'] - 10;
 		if(isset($_GET['draftno']))
 			$dstart = escape($_GET['draftno']);
@@ -506,12 +506,12 @@ Ck1;
 		if($dcount>($draftrow['MAX']-$dstart+1)) $dcount = $draftrow['MAX']-$dstart+1;
 		
 		$query = "SELECT `draft_lastsaved`,`draft_number`,`user_id` FROM `article_draft` where `page_modulecomponentid` = '$this->moduleComponentId' ORDER BY `draft_lastsaved` LIMIT $dstart,$dcount";
-		$result = mysql_query($query);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$draftTable = "<fieldset>
 					        <legend><a name='drafts'>{$ICONS['Page Revisions']['small']}Drafts Saved : </a></legend>" .
 					        		"<table border='1'><tr><td>Draft Number</td><td>Date Drafted</td><td>User Fullname</td><td>User Email</td><td>Delete</td></tr>";
 					    
-		while ($row = mysql_fetch_assoc($result)) {
+		while ($row = mysqli_fetch_assoc($result)) {
 			$draftTable .= "<tr><td><a href=\"./+edit&dversion=".$row['draft_number']."#preview\">".$row['draft_number']."</a></td><td>".$row['draft_lastsaved']."</td><td>".getUserFullName($row['user_id'])."</td><td>".getUserEmail($row['user_id'])."</td><td><form action='./+edit&deldraft=yes&dno=".$row['draft_number']."' method='post'><input type='button' value='Delete' onclick='submitarticleformDeldraft(this);'></form>
 		<script language='javascript'>
 					    	function submitarticleformDeldraft(butt) {
@@ -537,7 +537,7 @@ Ck1;
 
 	public function createModule($compId) {
 		$query = "INSERT INTO `article_content` (`page_modulecomponentid` ,`article_content`, `allowComments`)VALUES ('$compId', 'Coming up Soon!!!','0')";
-		$result = mysql_query($query) or die(mysql_error()."article.lib L:76");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."article.lib L:76");
 	}
 	public function deleteModule($moduleComponentId) {
 		/* Remove the indexing from sphider // Abhishek */
@@ -547,23 +547,23 @@ Ck1;
 		$delurl = "http://".$_SERVER['HTTP_HOST'].$urlRequestRoot."/home".$path;
 		$query="SELECT link_id FROM `links` WHERE url='$delurl'";
 		
-		$result=mysql_query($query);
-		if(mysql_num_rows($result)==0) return true; //Nothing to delete 
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_num_rows($result)==0) return true; //Nothing to delete 
 		$delids="";
-		while($row=mysql_fetch_row($result))
+		while($row=mysqli_fetch_row($result))
 			$delids.=$row[0].",";
 		
 		$delids=rtrim($delids,",");
 		
 		$query="DELETE FROM `links` WHERE url='$delurl'";
 		
-		mysql_query($query);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		for ($i=0;$i<=15; $i++) 
 		{
 			$char = dechex($i);
 			$query="DELETE FROM `link_keyword$char` WHERE link_id IN ($delids)";
 			
-			mysql_query($query) or die(mysql_error()." article.lib.php L:441");
+			mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." article.lib.php L:441");
 			
 		}
 		return true;

--- a/cms/modules/book.lib.php
+++ b/cms/modules/book.lib.php
@@ -45,8 +45,8 @@ class book implements module {
 		$this->moduleComponentId = $gotmoduleComponentId;
 		$this->action = $gotaction;
 		$this->pageId = getPageIdFromModuleComponentId("book",$gotmoduleComponentId);
-		$this->bookProps = mysql_fetch_assoc(mysql_query("SELECT * FROM `book_desc` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
-		$page_title = mysql_fetch_row(mysql_query("SELECT `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '{$this->pageId}'"));
+		$this->bookProps = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `book_desc` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
+		$page_title = mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '{$this->pageId}'"));
 		$this->bookProps['page_title'] = $page_title[0];
 		$this->hideInMenu();
 		if ($this->action == "edit")
@@ -62,7 +62,7 @@ class book implements module {
 		global $INFOSTRING, $WARNINGSTRING, $ERRORSTRING;
 
 		$childrenQuery = 'SELECT `page_title`, `page_id`, `page_module`, `page_modulecomponentid`, `page_name` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_parentid` = ' . $this->pageId . ' AND `page_id` IN (' . $this->bookProps['list'] . ') ORDER BY `page_menurank`';
-		$result = mysql_query($childrenQuery);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $childrenQuery);
 		$ret = $this->tabScript();
 		$ret .=<<<RET
 <h2>{$this->bookProps['page_title']}</h2>
@@ -76,7 +76,7 @@ RET;
 		$backup_info = $INFOSTRING;
 		$backup_warning = $WARNINGSTRING;
 		$backup_error = $ERRORSTRING;
-		while($row = mysql_fetch_assoc($result)) {
+		while($row = mysqli_fetch_assoc($result)) {
 			if(getPermissions($this->userId, $row['page_id'], "view")) {
 				$INFOSTRING = "";
 				$WARNINGSTRING = "";
@@ -128,21 +128,21 @@ RET;
 				$this->bookProps['menu_hide'] = $hList;
 				$this->hideInMenu();
 				$query = "UPDATE `book_desc` SET `initial` = '" . escape($_POST['optInitial']) . "', `list` = '{$tList}', `menu_hide` = '{$hList}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'";
-				mysql_query($query) or die(mysql_error() . ": book.lib.php L:131");
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . ": book.lib.php L:131");
 				$query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_title` = '" . $this->bookProps['page_title'] . "' WHERE `page_id` = '{$this->pageId}'";
-				mysql_query($query) or die(mysql_error() . ": book.lib.php L:133");
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . ": book.lib.php L:133");
 				displayinfo("Book Properties saved properly");
 			} else
 				displayerror("You've choosen a hidden sub-page as default which is not possible, so the settings are not saved.");
 		}
 		$childrenQuery = 'SELECT `page_id`, `page_title`, `page_module`, `page_name`, `page_modulecomponentid` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_parentid` = '."'" . $this->pageId ."'". ' AND `page_id` != \'' . $this->pageId . '\' ORDER BY `page_menurank`';
-		$result = mysql_query($childrenQuery);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $childrenQuery);
 		$table = "";
 		$hide_list = explode(",",$this->bookProps['menu_hide']);
 		$show_list = explode(",",$this->bookProps['list']);
-		if(mysql_num_rows($result)) {
+		if(mysqli_num_rows($result)) {
 			$table = "<table><thead><td>Initial</td><td>Show in Tab</td><td>Hide in Menu</td><td>Page</td></thead>";
-			while($row = mysql_fetch_assoc($result)) {
+			while($row = mysqli_fetch_assoc($result)) {
 				$radio = "";
 				if($row['page_id'] == $this->bookProps['initial'])
 					$radio = "checked";
@@ -179,7 +179,7 @@ RET;
 	 */	
 	public function createModule($compId) {
 		$query = "INSERT INTO `book_desc` (`page_modulecomponentid` , `initial`, `list`,`menu_hide`)VALUES ('$compId','','','')";
-		$result = mysql_query($query) or die(mysql_error()."book.lib L:187");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."book.lib L:187");
 	}
 	
 	/**
@@ -270,7 +270,7 @@ RET;
 	 */
 	public function isPresent($parentId,$pageId) {
 		$moduleComponentId = getModuleComponentIdFromPageId($parentId,'book');
-		$list = mysql_fetch_assoc(mysql_query("SELECT `list` FROM `book_desc` WHERE `page_modulecomponentid` = '{$moduleComponentId}'"));
+		$list = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `list` FROM `book_desc` WHERE `page_modulecomponentid` = '{$moduleComponentId}'"));
 		$list = explode(",",$list['list']);
 		foreach($list as $element) {
 			if($pageId == $element)
@@ -288,10 +288,10 @@ RET;
 	private function hideInMenu() {
 		$cond = "";
 		if($this->bookProps['menu_hide'] != "") {
-			mysql_query("UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_displayinmenu` = 0 WHERE `page_parentid` = '{$this->pageId}' AND `page_id` IN ({$this->bookProps['menu_hide']})");
+			mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_displayinmenu` = 0 WHERE `page_parentid` = '{$this->pageId}' AND `page_id` IN ({$this->bookProps['menu_hide']})");
 			$cond = " AND `page_id` NOT IN ({$this->bookProps['menu_hide']})";
 		}
-		mysql_query("UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_displayinmenu` = 1 WHERE `page_parentid` = '{$this->pageId}'{$cond}");
+		mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_displayinmenu` = 1 WHERE `page_parentid` = '{$this->pageId}'{$cond}");
 	}
 }
 ?>

--- a/cms/modules/contest.lib.php
+++ b/cms/modules/contest.lib.php
@@ -60,14 +60,14 @@ class contest implements module, fileuploadable {
 
 	private function getContestPage($contestId) {
 		$problemQuery = "SELECT * FROM `contest_problem` WHERE `cid` = '$contestId' AND `testable` = 1 ORDER BY `pid`";
-		$problemResult = mysql_query($problemQuery);
+		$problemResult = mysqli_query($GLOBALS["___mysqli_ston"], $problemQuery);
 
 		$html = '<table border="0">';
 
 		$className = array('even', 'odd');
 		$parity = 0;
 
-		while ($problemRow = mysql_fetch_assoc($problemResult)) {
+		while ($problemRow = mysqli_fetch_assoc($problemResult)) {
 			$pcode = $problemRow['pcode'];
 			$ptitle = $problemRow['pname'];
 			$html .= "<tr class=\"{$className[$parity]}\"><td><a href=\"./+view&subaction=showproblem&pcode=$pcode\">{$problemRow['pcode']}</a></td><td><a href=\"./+view&subaction=showproblem&pcode=$pcode\">{$problemRow['ptitle']}</a></td></tr>\n";
@@ -80,12 +80,12 @@ class contest implements module, fileuploadable {
 
 	private function getProblemId($contestId, $pcode) {
 		$idQuery = "SELECT `pid` FROM `contest_problem` WHERE `cid` = '$contestId' AND `pcode` = '$pcode'";
-		$idResult = mysql_query($idQuery);
+		$idResult = mysqli_query($GLOBALS["___mysqli_ston"], $idQuery);
 		if (!$idResult) {
-			displayerror('MySQL error while attempting to fetch problem id, on line ' . __LINE__ . ', ' . __FILE__);
+			displayerror('mysql error while attempting to fetch problem id, on line ' . __LINE__ . ', ' . __FILE__);
 			return -1;
 		}
-		$idRow = mysql_fetch_row($idResult);
+		$idRow = mysqli_fetch_row($idResult);
 		if ($idRow) return $idRow[0];
 		else return -1;
 	}
@@ -123,9 +123,9 @@ class contest implements module, fileuploadable {
 	        $startItem = 0;
 	        if ($itemsPerPage <= 0) $itemsPerPage = 20;
 
-	        $itemCountResult = mysql_query($countQuery);
+	        $itemCountResult = mysqli_query($GLOBALS["___mysqli_ston"], $countQuery);
 	        if (!$itemCountResult) return false;
-	        $itemCount = mysql_fetch_row($itemCountResult);
+	        $itemCount = mysqli_fetch_row($itemCountResult);
 	        $itemCount = $itemCount[0];
 
 	        $pageCount = ceil($itemCount / $itemsPerPage);
@@ -138,17 +138,17 @@ class contest implements module, fileuploadable {
 	        if ($sortField != '' && ($sortDirection == 'ASC' || $sortDirection == 'DESC')) $selectQuery .= " ORDER BY `$sortField` $sortDirection";
 
 	        $selectQuery .= " LIMIT $startItem, $itemsPerPage";
-        	$selectResult = mysql_query($selectQuery);
+        	$selectResult = mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery);
 	        if (!$selectResult) {
-        	        log_error(__FILE__, __LINE__, 'MySQL Error in query ' . $selectQuery . ': ' . mysql_error());
+        	        log_error(__FILE__, __LINE__, 'mysql Error in query ' . $selectQuery . ': ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	                return false;
         	}
 
 	        $results = array();
-	        while ($selectRow = mysql_fetch_array($selectResult)) {
+	        while ($selectRow = mysqli_fetch_array($selectResult)) {
         	        $results[] = $selectRow;
 	        }
-	        mysql_free_result($selectResult);
+	        ((mysqli_free_result($selectResult) || (is_object($selectResult) && (get_class($selectResult) == "mysqli_result"))) ? true : false);
 
         	return $results;
 	}

--- a/cms/modules/contest/submit.php
+++ b/cms/modules/contest/submit.php
@@ -121,7 +121,7 @@ function submitPostSolution($contestCode, $problemCode) {
 	$time = time();
 	$insertQuery = 'INSERT INTO `problem`(`pid`, `uid`, `lang`, `stid`, `status`, `code`, `runout`, `time`, `score`) VALUES ' .
 		"({$problemRow['pid']}, {$userId}, '{$_POST['language']}', 1, 'Waiting', '$uploadedSource', '', $time, 0)";
-	if (mysql_query($insertQuery))
+	if (mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery))
 		return "<p>Your solution has been submitted. Please check the <a href=\"../../status/\">status page</a> for more.</p>";
 	else {
 		display_error("Error. Could not insert submission into database.");

--- a/cms/modules/events.lib.php
+++ b/cms/modules/events.lib.php
@@ -88,7 +88,7 @@ class events implements module,fileuploadable {
 				else if($_POST['type']=="notif"){
 				  $query="INSERT INTO `events_notifications` VALUES (NULL, '{$_POST['content']}', CURRENT_TIMESTAMP);";
 				  //echo NOW();
-				  mysql_query($query);
+				  mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				  //				  header('Location: ./+eventsHead');
 				  //
 				}
@@ -220,15 +220,15 @@ public function actionQa(){
     $eventAdd.="<th>AMOUNT REFUNDED AT HOSPI</th>";
     $eventAdd.="<th>No. of days of stay</th></tr>";
  $prStatus="SELECT * FROM `prhospi_pr_status` WHERE `user_id`='{$userId}' and `page_moduleComponentId`={$moduleComponentId}";
-$prQuery=mysql_query($prStatus) or displayerror(mysql_error());
-$prRows=mysql_fetch_array($prQuery);
+$prQuery=mysqli_query($GLOBALS["___mysqli_ston"], $prStatus) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$prRows=mysqli_fetch_array($prQuery);
 $checkintime_pr=$prRows['hospi_checkin_time'];
 $checkoutime_pr=$prRows['hospi_checkpout_time'];
 $amount_recieved_pr=$prRows['amount_recieved'];
 $amount_refunded_pr=$prRows['amount_refunded'];
  $HospiStatus="SELECT * FROM `prhospi_accomodation_status` WHERE `user_id`='{$userId}' and `page_modulecomponentid`={$moduleComponentId}";
-$HospiQuery=mysql_query($HospiStatus) or displayerror(mysql_error());
-$HospiRows=mysql_fetch_array($HospiQuery);
+$HospiQuery=mysqli_query($GLOBALS["___mysqli_ston"], $HospiStatus) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$HospiRows=mysqli_fetch_array($HospiQuery);
 $checkintime_hospi=$HospiRows['hospi_actual_checkin'];
 $checkoutime_hospi=$HospiRows['hospi_actual_checkout'];
 $amount_recieved_hospi=$HospiRows['hospi_cash_recieved'];
@@ -246,8 +246,8 @@ $eventAdd.="<td>".$amount_refunded_hospi."</td>";
 $eventAdd.="<td>{$no_of_days}</td>";
     $eventAdd.="</tr></table>";
     $hostelQuery = "SELECT * FROM `prhospi_hostel` WHERE `hospi_room_id`={$hospi_room_id} and `page_modulecomponentid`={$moduleComponentId}";
-    $hostelQueryResult = mysql_query($hostelQuery) or displayerror(mysql_error());
-    $hostelDetails=mysql_fetch_array($hostelQueryResult);
+    $hostelQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $hostelQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    $hostelDetails=mysqli_fetch_array($hostelQueryResult);
     $eventAdd.="<h2>Hostel Details</h2>";
     $eventAdd.="<table>";
     $eventAdd.="<th>HOSTEL</th>";
@@ -267,18 +267,18 @@ $eventAdd.="<td>{$no_of_days}</td>";
     $eventAdd.="<th>PRIZE MONEY</th>";
 
 $userDetails = "SELECT * FROM `events_result`  WHERE `user_id`='{$userId}' and `page_moduleComponentId`={$moduleComponentId}";
-    $userDetailsRows= mysql_query($userDetails) or displayerror(mysql_error());
-while($row=mysql_fetch_array($userDetailsRows))
+    $userDetailsRows= mysqli_query($GLOBALS["___mysqli_ston"], $userDetails) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+while($row=mysqli_fetch_array($userDetailsRows))
     {
     $eventAdd.="<tr>";
     $eventDetails="SELECT * FROM `events_details` WHERE `event_id`='{$row['event_id']}'";
-    $eventResults=mysql_query($eventDetails)  or displayerror(mysql_error());
-    $eventsResults=mysql_fetch_array($eventResults);
+    $eventResults=mysqli_query($GLOBALS["___mysqli_ston"], $eventDetails)  or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    $eventsResults=mysqli_fetch_array($eventResults);
   $eventAdd.="<td>".$eventsResults['event_name']."</td>";
     $eventAdd.="<td>".$row['user_rank']."</td>";
     $userPrizeDetails = "SELECT * FROM `events_participants` WHERE `user_pid`='{$userId}' ";
-    $userPrizeQuery= mysql_query($userPrizeDetails) or displayerror(mysql_error());
-   $userPrizeRows=mysql_fetch_array($userPrizeQuery);
+    $userPrizeQuery= mysqli_query($GLOBALS["___mysqli_ston"], $userPrizeDetails) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+   $userPrizeRows=mysqli_fetch_array($userPrizeQuery);
     $eventAdd.="<td>".$userPrizeRows['prize_money']."</td>";
  //   $eventAdd.="<td>".$eventsResults['
     
@@ -395,15 +395,15 @@ FORM;
     $eventAdd.="<th>AMOUNT REFUNDED AT HOSPI</th>";
     $eventAdd.="<th>No. of days of stay</th></tr>";
  $prStatus="SELECT * FROM `prhospi_pr_status` WHERE `user_id`='{$userId}' and `page_moduleComponentId`={$moduleComponentId}";
-$prQuery=mysql_query($prStatus) or displayerror(mysql_error());
-$prRows=mysql_fetch_array($prQuery);
+$prQuery=mysqli_query($GLOBALS["___mysqli_ston"], $prStatus) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$prRows=mysqli_fetch_array($prQuery);
 $checkintime_pr=$prRows['hospi_checkin_time'];
 $checkoutime_pr=$prRows['hospi_checkpout_time'];
 $amount_recieved_pr=$prRows['amount_recieved'];
 $amount_refunded_pr=$prRows['amount_refunded'];
  $HospiStatus="SELECT * FROM `prhospi_accomodation_status` WHERE `user_id`='{$userId}' and `page_modulecomponentid`={$moduleComponentId}";
-$HospiQuery=mysql_query($HospiStatus) or displayerror(mysql_error());
-$HospiRows=mysql_fetch_array($HospiQuery);
+$HospiQuery=mysqli_query($GLOBALS["___mysqli_ston"], $HospiStatus) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$HospiRows=mysqli_fetch_array($HospiQuery);
 $checkintime_hospi=$HospiRows['hospi_actual_checkin'];
 $checkoutime_hospi=$HospiRows['hospi_actual_checkout'];
 $amount_recieved_hospi=$HospiRows['hospi_cash_recieved'];
@@ -421,8 +421,8 @@ $eventAdd.="<td>".$amount_refunded_hospi."</td>";
 $eventAdd.="<td>{$no_of_days}</td>";
     $eventAdd.="</tr></table>";
     $hostelQuery = "SELECT * FROM `prhospi_hostel` WHERE `hospi_room_id`={$hospi_room_id} and `page_modulecomponentid`={$moduleComponentId}";
-    $hostelQueryResult = mysql_query($hostelQuery) or displayerror(mysql_error());
-    $hostelDetails=mysql_fetch_array($hostelQueryResult);
+    $hostelQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $hostelQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    $hostelDetails=mysqli_fetch_array($hostelQueryResult);
     $eventAdd.="<h2>Hostel Details</h2>";
     $eventAdd.="<table>";
     $eventAdd.="<th>HOSTEL</th>";
@@ -444,30 +444,30 @@ $eventAdd.="<td>{$no_of_days}</td>";
    $eventAdd.="<th>TEAMMATES </th>";
 
 $userDetails = "SELECT * FROM `events_result`  WHERE `user_id`='{$userId}' and `page_moduleComponentId`={$moduleComponentId}";
-    $userDetailsRows= mysql_query($userDetails) or displayerror(mysql_error());
- while($row=mysql_fetch_array($userDetailsRows))
+    $userDetailsRows= mysqli_query($GLOBALS["___mysqli_ston"], $userDetails) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+ while($row=mysqli_fetch_array($userDetailsRows))
 
     {
     $eventAdd.="<tr>";
     $eventDetails="SELECT * FROM `events_details` WHERE `event_id`='{$row['event_id']}'";
-    $eventResults=mysql_query($eventDetails)  or displayerror(mysql_error());
-    $eventsResults=mysql_fetch_array($eventResults);
+    $eventResults=mysqli_query($GLOBALS["___mysqli_ston"], $eventDetails)  or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    $eventsResults=mysqli_fetch_array($eventResults);
   $eventAdd.="<td>".$eventsResults['event_name']."</td>";
     $eventAdd.="<td>".$row['user_rank']."</td>";
     $userPrizeDetails = "SELECT * FROM `events_participants` WHERE `user_pid`='{$userId}' ";
-    $userPrizeQuery= mysql_query($userPrizeDetails) or displayerror(mysql_error());
-   $userPrizeRows=mysql_fetch_array($userPrizeQuery);
+    $userPrizeQuery= mysqli_query($GLOBALS["___mysqli_ston"], $userPrizeDetails) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+   $userPrizeRows=mysqli_fetch_array($userPrizeQuery);
     $eventAdd.="<td>".$userPrizeRows['prize_money']."</td>";
 
     $teamMateDetails="SELECT * FROM `events_participants` WHERE `user_pid`='{$userId}' and `event_id` ='{$row['event_id']}'";
    displayerror($teamMateDetails);
-   $teamMateQuery=mysql_query($teamMateDetails) or displayerror(mysql_error);
-   $teamMateDetails=mysql_fetch_assoc($teamMateQuery);
+   $teamMateQuery=mysqli_query($GLOBALS["___mysqli_ston"], $teamMateDetails) or displayerror(mysql_error);
+   $teamMateDetails=mysqli_fetch_assoc($teamMateQuery);
   $teamMates=$teamMateDetails['user_team_id'];
  $teamMateDetails="SELECT * FROM `events_participants` WHERE `user_team_id`=$teamMates  and `event_id` ='{$row['event_id']}'";
- $teamMateQuery=mysql_query($teamMateDetails) or displayerror(mysql_error);
+ $teamMateQuery=mysqli_query($GLOBALS["___mysqli_ston"], $teamMateDetails) or displayerror(mysql_error);
  $eventAdd.="<td>";
-while($newRow=mysql_fetch_array($teamMateQuery))
+while($newRow=mysqli_fetch_array($teamMateQuery))
  {
  $eventAdd.=$newRow['user_pid']."  ";
  }  

--- a/cms/modules/events/autoupdate.php
+++ b/cms/modules/events/autoupdate.php
@@ -3,7 +3,7 @@ require_once('config.inc.php');
 
 for($i=30022;$i<=31000;$i+=1){
 	$insertQuery="INSERT INTO `festemberV3_users`(`user_id`) VALUES($i)";
-	$insertRes=mysql_query($insertQuery) or displayerror(mysql_error());
+	$insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 }
 
 ?>

--- a/cms/modules/events/events_certi_image.php
+++ b/cms/modules/events/events_certi_image.php
@@ -10,8 +10,8 @@
 	$font = './font.ttf';
 	//$getCertiImgQuery= $urlRequestRoot." ".$sourceFolder." ".$templateFolder;
 	$getCertiImgQuery = "SELECT `certificate_id`,`certificate_image` FROM `events_certificate` WHERE `user_rank` = '{$userRank}' AND `page_moduleComponentId`='{$pmcId}' AND `event_id` = '{$eventId}'";
-	$getCertiImgRes = mysql_query($getCertiImgQuery);// or displayerror(mysql_error());
-	while($certiDetails = mysql_fetch_assoc($getCertiImgRes)){
+	$getCertiImgRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCertiImgQuery);// or displayerror(mysql_error());
+	while($certiDetails = mysqli_fetch_assoc($getCertiImgRes)){
 		$certiImage = imagecreatefromjpeg($certiDetails['certificate_image']);
 		$color = imagecolorallocate($certiImage, 0, 0, 0);	//black
 		$rotatedImage = imagerotate($certiImage, 90, $color);	//rotate certificate
@@ -21,12 +21,12 @@
 		//Get Certificate Details From evets_certficate_details
 
 		$getCertiDetailsQuery = "SELECT `certificate_posx`,`certificate_posy`,`form_value_id` FROM `events_certificate_details` WHERE `page_moduleComponentId`='{$pmcId}' AND `certificate_id`='{$certiId}'";
-		$getCertiDetailsRes = mysql_query($getCertiDetailsQuery) or displayerror(mysql_error());
+		$getCertiDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCertiDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
 		//Get Form Values From form_elementdesc
 		//Form_value_id=-1 -> Rank
 		//Form_value_id=-2 -> Event Name
-		while($getValues = mysql_fetch_assoc($getCertiDetailsRes)){
+		while($getValues = mysqli_fetch_assoc($getCertiDetailsRes)){
 			//User Rank
 			if($getValues['form_value_id'] == -1){
 				imagettftext($rotatedImage, 20, 90, $getValues['certificate_posx'], $getValues['certificate_posy'], $color, $font, $userRank);
@@ -35,8 +35,8 @@
 			else if($getValues['form_value_id'] == -2){
 				//Get Event Name
 				$getEventNameQuery = "SELECT `event_name` FROM `events_details` WHERE `event_id` = '{$eventId}' AND `page_moduleComponentId` '{$pmcId}'";
-				$getEventNameRes = mysql_query($getEventNameQuery) or displayerror(mysql_error());
-				$eventName = mysql_result($getEventNameRes,0);
+				$getEventNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getEventNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				$eventName = mysqli_result($getEventNameRes, 0);
 				imagettftext($rotatedImage, 20, 90, $getValues['certificate_posx'], $getValues['certificate_posy'], $color, $font, $eventName);
 			}
 			else{
@@ -44,12 +44,12 @@
 				$getFormValuesQuery = "SELECT `events_edited_form`.`form_elementdata` FROM `events_edited_form` INNER JOIN `events_form` ON `events_edited_form`.`form_id`=`events_form`.`form_id`
 				AND `events_form`.`event_id`='{$event_id}' AND `events_form`.`page_moduleComponentId`='{$pmcId}' AND `events_edited_form`.`user_id`='{$userId}' AND `events_edited_form`.`page_moduleComponentId`='{$pmcId}' AND 
 				`events_edited_form`.`form_elementid`='{$getValues['form_value_id']}'";
-				$getFormValuesRes = mysql_query($getFormValuesQuery) or displayerror(mysql_error());
-				if(mysql_num_rows($getFormValuesRes) == 0){
+				$getFormValuesRes = mysqli_query($GLOBALS["___mysqli_ston"], $getFormValuesQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_num_rows($getFormValuesRes) == 0){
 					//Else get value from form_elementdata
 					$getFormValuesQuery = "SELECT `form_elementdata`.`form_elementdata` FROM `form_elementdata` INNER JOIN `events_form` ON `form_elementdata`.`page_moduleComponentId`=`events_form`.`form_id` 
 					AND `events_form`.`event_id`='{$eventId}' AND `events_form`.`page_moduleComponentId`='{$pmcId}' AND `form_elementdata`.`user_id`='{$userId}' AND `form_elementdata`.`form_elementid`='{$getValues['form_value_id']}'";
-					$getFormValuesRes = mysql_query($getFormValuesQuery) or displayerror(mysql_error());
+					$getFormValuesRes = mysqli_query($GLOBALS["___mysqli_ston"], $getFormValuesQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				}
 				while($formData = mysql_fetch_assos($getFormValuesRes)){
 					imagettftext($rotatedImage, 20, 90, $getValues['certificate_posx'], $getValues['certificate_posy'], $color, $font, $formData['form_elementdata']);

--- a/cms/modules/events/events_common.php
+++ b/cms/modules/events/events_common.php
@@ -13,7 +13,7 @@ function returnUserProfileDetails($userId){
                             data.user_id = $userId
                          WHERE descr.page_modulecomponentid = 0
                          ";
-  $profileDetailRes = mysql_query($profileDetailQuery) or displayerror(mysql_error());
+  $profileDetailRes = mysqli_query($GLOBALS["___mysqli_ston"], $profileDetailQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if(!$profileDetailRes) {
     displayerror("check the error in getProfileDetailsForPr function in prhospi_common.php");
     return '';
@@ -32,8 +32,8 @@ TABLE;
     if($userId>20000 && $userId<30000)
         $userId +=180000;
 $userNameCons="SELECT * FROM `festemberV3_users` WHERE `user_id`='{$userId}'";
-$userNameQuery=mysql_query($userNameCons) or displayerror(mysql_error());
-$userNameDetails=mysql_fetch_assoc($userNameQuery);
+$userNameQuery=mysqli_query($GLOBALS["___mysqli_ston"], $userNameCons) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$userNameDetails=mysqli_fetch_assoc($userNameQuery);
 $userDetails.=<<<TR
      <tr>
         <td>$userId</td>
@@ -49,7 +49,7 @@ $userDetails.=<<<TR
     </tr>
 TR;
 
-  while($result=mysql_fetch_assoc($profileDetailRes)) {
+  while($result=mysqli_fetch_assoc($profileDetailRes)) {
     if($count == 11) { $count ++ ; continue; }
     $dispText = $result['dispText'];
     $dispData = $result['dispData'];
@@ -68,8 +68,8 @@ TR;
 function getBookletIdFromUserId($userId,$mcId) {
   $bookletId = escape($bookletId);
   $checkUserRegisteredToPr = "SELECT * FROM `prhospi_pr_status` WHERE `page_modulecomponentid` = {$mcId} AND `user_id` = '{$userId}'";
-  $checkUserRegisteredToPrQuery = mysql_query($checkUserRegisteredToPr) or displayerror(mysql_error());
-  $row = mysql_fetch_assoc($checkUserRegisteredToPrQuery);
+  $checkUserRegisteredToPrQuery = mysqli_query($GLOBALS["___mysqli_ston"], $checkUserRegisteredToPr) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $row = mysqli_fetch_assoc($checkUserRegisteredToPrQuery);
   return $row['booklet_id'];
 
 }
@@ -126,7 +126,7 @@ function validateAddEventData($pageModuleComponentId){
                                     ."'{$_POST['eventStartTime']}', '{$_POST['eventEndTime']}', "
                                     ."'{$_POST['eventVenue']}', '{$_POST['eventDesc']}', CURRENT_TIME(), '', '{$pageModuleComponentId}', "
                                     ."'{$_POST['lng']}', '{$_POST['lat']}');";
-            $insertRes=mysql_query($insertQuery) or displayerror(mysql_error());
+            $insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
             echo "Valid";
     }
     else echo "Invalid";
@@ -153,7 +153,7 @@ function validateEditEventData($pageModuleComponentId){
                                                     `event_loc_y`='{$_POST['lat']}' "
                         ." WHERE `page_moduleComponentId`='{$pageModuleComponentId}'"
                         ."AND `event_id`={$_POST['eventId']}";
-            $editRes=mysql_query($editQuery) or displayerror(mysql_error());
+            $editRes=mysqli_query($GLOBALS["___mysqli_ston"], $editQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
             echo "Valid";
     }
     else echo "Invalid";
@@ -166,7 +166,7 @@ function getAllEvents($pmcid){
     $scriptFolder = "$urlRequestRoot/$cmsFolder/$moduleFolder/events";
     //displaywarning($scriptFolder);
     $selectQuery="SELECT * FROM `events_details` WHERE `page_moduleComponentId`={$pmcid};";
-    $insertRes=mysql_query($selectQuery) or displayerror(mysql_error());
+    $insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     global $STARTSCRIPTS;
     $smarttablestuff = smarttable::render(array('table_event_details'),null);
     $STARTSCRIPTS .="initSmartTable();";
@@ -188,7 +188,7 @@ function getAllEvents($pmcid){
     </thead>
 TABLE;
 
-while($res = mysql_fetch_assoc($insertRes)) {
+while($res = mysqli_fetch_assoc($insertRes)) {
     $eventDetails .=<<<TR
     <tr>        
     <td>{$res['event_id']}</td>
@@ -265,8 +265,8 @@ MAP1;
             
     $fpmcid=1;
     $q="SELECT * from `events_notifications` WHERE NOW()-`timeadded` <= 3600 * 20 AND  NOW()-`timeadded`>=0  ORDER BY `timeadded` DESC";
-    $res=mysql_query($q); 
-    while($row=mysql_fetch_array($res)){
+    $res=mysqli_query($GLOBALS["___mysqli_ston"], $q); 
+    while($row=mysqli_fetch_array($res)){
      $maps.="<tr  style='margin-bottom:5px;'><td style='margin-bottom:5px;border:1px solid #C3AC7A; border-radius: 5px;font-size:2em;'> {$row['notif_content']}  </td></tr>";
     }
       
@@ -312,8 +312,8 @@ function getEventsJSON($pmcid){
     $eventsQuery="SELECT * FROM `events_details` "
                             ."WHERE '{$lastdate}'<=`event_last_update_time` AND event_date>='{$date1}' AND `page_moduleComponentId`='{$pmcid}'" 
                             ."ORDER BY event_date ASC LIMIT {$prod}, {$ipp};";
-    $eventsRes=mysql_query($eventsQuery) or displayerror(mysql_error());
-    while($row=mysql_fetch_array($eventsRes)){
+    $eventsRes=mysqli_query($GLOBALS["___mysqli_ston"], $eventsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    while($row=mysqli_fetch_array($eventsRes)){
             $event=array(
                     "event_id"=> $row['event_id'], 
                     "event_name"=> $row['event_name'],
@@ -343,7 +343,7 @@ function getSchedule($pmcid){
     $eventsQuery="SELECT * FROM `events_details` "
                 ."WHERE `page_moduleComponentId`='{$pmcid}'"
                 ."ORDER BY event_date ASC;";
-    $eventsRes=mysql_query($eventsQuery) or displayerror(mysql_error());
+    $eventsRes=mysqli_query($GLOBALS["___mysqli_ston"], $eventsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
     $schedule=<<<SCHEDULE
     <script src="$scriptFolder/jquery.js"></script>
@@ -355,7 +355,7 @@ function getSchedule($pmcid){
     <th width='10%;'>Time</th>
 SCHEDULE;
 
-    while($row=mysql_fetch_array($eventsRes)){
+    while($row=mysqli_fetch_array($eventsRes)){
         $edate=$row['event_name'];
         $schedule.="<tr> <td>{$row['event_name']}</td> <td>{$row['event_venue']}</td><td>";
         $schedule.="{$row['event_date']}</td><td>";
@@ -371,7 +371,7 @@ SCHEDULE;
 function deleteEvent($eventid, $pmcid){
     //query to delete event
     $deleteQuery="DELETE FROM `events_details` WHERE `event_id`='{$eventid}' AND `page_moduleComponentId`='{$pmcid}';";
-    $deletetRes=mysql_query($deleteQuery) or displayerror(mysql_error());
+    $deletetRes=mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if ($deletetRes==1) {
             echo("Success");
     }
@@ -393,8 +393,8 @@ function validateProcurementData($pageModuleComponentId){
             $_POST['eventName']=escape($_POST['eventName']);
             $_POST['procurementName']=escape($_POST['procurementName']);
             $selectQuery = "SELECT * FROM `events_event_procurement` WHERE `event_name`='{$_POST[eventName]}' AND `procurement_name`='{$_POST[procurementName]}' ";
-            $selectRes=mysql_query($selectQuery);
-            if(mysql_num_rows($selectRes)==1){
+            $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery);
+            if(mysqli_num_rows($selectRes)==1){
                 $isValid=false;
                 echo "Procurement ".$_POST['procurementName']." already exists for event ".$_POST['eventName'].". Kindly edit in VIEW ALL if you want to change.";
                 exit();
@@ -409,10 +409,10 @@ function validateProcurementData($pageModuleComponentId){
             //Query to insert into the db
             $insertQuery="INSERT INTO `events_event_procurement` (`event_name`, `procurement_name`, `quantity`, `page_moduleComponentId`) "
                          ."VALUES ('{$_POST['eventName']}', '{$_POST['procurementName']}','{$_POST['quantity']}', '{$pageModuleComponentId}')";
-            $insertRes=mysql_query($insertQuery) or displayerror(mysql_error());
+            $insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
             $updateQuery="UPDATE `events_procurements` SET `quantity`=`quantity`+ {$_POST['quantity']} WHERE `procurement_name`='{$_POST['procurementName']}'";
-            $updateRes=mysql_query($updateQuery) or displayerror(mysql_error());
+            $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
             echo "Valid";
     }
     exit();
@@ -427,9 +427,9 @@ function validateEditProcurementData($pageModuleComponentId){
     }
     else {
             $selectQuery="SELECT * FROM `events_event_procurement`";
-            $selectRes=mysql_query($selectQuery);
+            $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery);
             $cnt=1;
-            while($res = mysql_fetch_assoc($selectRes)) {
+            while($res = mysqli_fetch_assoc($selectRes)) {
             if($cnt!=$_POST['eventnum'] &&	($_POST['procurementName']==$res['procurement_name'] && $_POST['eventName']==$res['event_name']) )
                 $isValid=false;
             $cnt++;
@@ -443,22 +443,22 @@ function validateEditProcurementData($pageModuleComponentId){
             }
             //Query to insert into the db
             $selectQuery="SELECT * FROM `events_event_procurement`";
-            $selectRes=mysql_query($selectQuery);
+            $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery);
             $cnt=1;
-            while($res = mysql_fetch_assoc($selectRes)) {		
+            while($res = mysqli_fetch_assoc($selectRes)) {		
             if($cnt==$_POST['eventnum']){
                 $updateQuery="UPDATE `events_procurements` SET `quantity`=`quantity`-{$res['quantity']} WHERE `procurement_name`='{$res['procurement_name']}'";	
-                $updateRes=mysql_query($updateQuery) or displayerror(mysql_error());
+                $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
                 $updateQuery="UPDATE `events_procurements` SET `quantity`=`quantity`+ {$_POST['editquantity']} WHERE `procurement_name`='{$_POST['procurementName']}'";
-                $updateRes=mysql_query($updateQuery) or displayerror(mysql_error());
+                $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
                 
                 $deleteQuery="DELETE FROM `events_event_procurement` WHERE `event_name`='{$res['event_name']}' AND `procurement_name`='{$res['procurement_name']}' ";
-                $deleteRes=mysql_query($deleteQuery) or displayerror(mysql_error());
+                $deleteRes=mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
                 $insertQuery="INSERT INTO `events_event_procurement` (`event_name`, `procurement_name`, `quantity`, `page_moduleComponentId`) "
                          ."VALUES ('{$_POST['eventName']}', '{$_POST['procurementName']}','{$_POST['editquantity']}', '{$pageModuleComponentId}')";
-                $insertRes=mysql_query($insertQuery) or displayerror(mysql_error());
+                $insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
                 
                 echo '<script>window.location = ("./+ochead&subaction=viewAll");</script>';
                 echo '<script>cmsShow("info", "Procurement edited");</script>';
@@ -481,8 +481,8 @@ function validateNewProcurement($pageModuleComponentId){
     else {
             $_POST['newProc']=escape(strtolower($_POST['newProc']));
             $selectQuery = "SELECT `procurement_name` FROM `events_procurements` WHERE `procurement_name`='{$_POST['newProc']}' ";
-            $selectRes=mysql_query($selectQuery);
-            if(mysql_num_rows($selectRes)==1){
+            $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery);
+            if(mysqli_num_rows($selectRes)==1){
                 $isValid=false;
                 echo "Exists";
                 exit();
@@ -497,7 +497,7 @@ function validateNewProcurement($pageModuleComponentId){
             //Query to insert into the db
             $insertQuery="INSERT INTO `events_procurements` (`procurement_id`, `procurement_name`, `quantity`, `page_moduleComponentId`) "
                          ."VALUES (NULL, '{$_POST['newProc']}', 0, '{$pageModuleComponentId}')";
-            $insertRes=mysql_query($insertQuery) or displayerror(mysql_error());
+            $insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
             echo "Valid";
     }
     else echo "Invalid";
@@ -527,7 +527,7 @@ function getAllProcurements($pmcid){
     global $cmsFolder,$moduleFolder,$urlRequestRoot, $sourceFolder;
     $scriptFolder = "$urlRequestRoot/$cmsFolder/$moduleFolder/events";
     $selectQuery="SELECT * FROM `events_event_procurement` WHERE `page_moduleComponentId`={$pmcid};";
-    $selectRes=mysql_query($selectQuery) or displayerror(mysql_error());
+    $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     global $STARTSCRIPTS;
     $smarttablestuff = smarttable::render(array('table_procurement_details'),null);
     $STARTSCRIPTS .="initSmartTable();";
@@ -552,10 +552,10 @@ $procurementDetails =<<<TABLE
     </thead>
 TABLE;
 $cnt=1;
-while($res = mysql_fetch_assoc($selectRes)) {
+while($res = mysqli_fetch_assoc($selectRes)) {
 $selQuery="SELECT * FROM `events_details` WHERE `event_name`='{$res['event_name']}'";
-$selRes=mysql_query($selQuery) or displayerror(mysql_error());
-$selRes = mysql_fetch_assoc($selRes);
+$selRes=mysqli_query($GLOBALS["___mysqli_ston"], $selQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$selRes = mysqli_fetch_assoc($selRes);
 $procurementDetails .=<<<TR
 
       <tr>        
@@ -587,14 +587,14 @@ return $procurementDetails;
 
 function deleteProcurement($eventname, $pmcid){
 $selectQuery="SELECT * FROM `events_event_procurement` ";
-$selectRes=mysql_query($selectQuery) or displayerror(mysql_error());
+$selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 $cnt=1;
-while($res = mysql_fetch_assoc($selectRes)) {		
+while($res = mysqli_fetch_assoc($selectRes)) {		
 if($cnt==$eventname){
 $updateQuery="UPDATE `events_procurements` SET `quantity`=`quantity`-{$res['quantity']} WHERE `procurement_name`='{$res['procurement_name']}'";	
-$updateRes=mysql_query($updateQuery) or displayerror(mysql_error());
+$updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 $deleteQuery="DELETE FROM `events_event_procurement` WHERE `event_name`='{$res['event_name']}' AND `procurement_name`='{$res['procurement_name']}'";
-$deletetRes=mysql_query($deleteQuery) or displayerror(mysql_error());
+$deletetRes=mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 }
 $cnt++;
 }
@@ -625,7 +625,7 @@ function viewEventWise(){
     global $cmsFolder,$moduleFolder,$urlRequestRoot, $sourceFolder;
     $scriptFolder = "$urlRequestRoot/$cmsFolder/$moduleFolder/events";
     $selectQuery="SELECT * FROM `events_details` ORDER BY STR_TO_DATE(`event_date`, '%d.%m.%y'),`event_start_time` ";
-    $selectRes=mysql_query($selectQuery) or displayerror(mysql_error());
+    $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     global $STARTSCRIPTS;
     $smarttablestuff = smarttable::render(array('show_event_wise'),null);
     $STARTSCRIPTS .="initSmartTable();";
@@ -648,9 +648,9 @@ $procurementDetails =<<<TABLE
     </thead>
 TABLE;
 $cnt=1;
-while($event=mysql_fetch_assoc($selectRes)) {	
-$result=mysql_query("SELECT * FROM `events_event_procurement` WHERE `event_name`='{$event['event_name']}'");
-while($res=mysql_fetch_assoc($result))
+while($event=mysqli_fetch_assoc($selectRes)) {	
+$result=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `events_event_procurement` WHERE `event_name`='{$event['event_name']}'");
+while($res=mysqli_fetch_assoc($result))
 {
         $procurementDetails .=<<<TR
         <tr>        
@@ -677,7 +677,7 @@ function viewProcurementWise(){
     global $cmsFolder,$moduleFolder,$urlRequestRoot, $sourceFolder;
     $scriptFolder = "$urlRequestRoot/$cmsFolder/$moduleFolder/events";
     $selectQuery="SELECT * FROM `events_procurements`;";
-    $selectRes=mysql_query($selectQuery) or displayerror(mysql_error());
+    $selectRes=mysqli_query($GLOBALS["___mysqli_ston"], $selectQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     global $STARTSCRIPTS;
     $smarttablestuff = smarttable::render(array('show_procurement_wise'),null);
     $STARTSCRIPTS .="initSmartTable();";
@@ -697,7 +697,7 @@ $procurementDetails =<<<TABLE
     </thead>
 TABLE;
 $cnt=1;
-while($res = mysql_fetch_assoc($selectRes)) {
+while($res = mysqli_fetch_assoc($selectRes)) {
 $procurementDetails .=<<<TR
       <tr>        
        <td>{$cnt}</td>
@@ -718,8 +718,8 @@ return $procurementDetails;
 
 function getEventName($pmcId,$eventId){
 $getEventNameQuery = "SELECT `event_name` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id` = '{$eventId}'";
-$getEventNameRes = mysql_query($getEventNameQuery) or displayerror(mysql_error());
-return mysql_result($getEventNameRes,0);
+$getEventNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getEventNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+return mysqli_result($getEventNameRes, 0);
 }
 
 
@@ -745,8 +745,8 @@ if($gotoaction == 'qa'){
 else if($gotoaction == 'qahead'){
     $eventDetails .= qaHeadOptions($pmcId).'<br/><br/>asdasdasd<h2>'.getEventName($pmcId,$eventId).'</h2>';
     $checkLockedQuery  = "SELECT `event_id` FROM `events_locked` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}'";
-    $checkLockedRes = mysql_query($checkLockedQuery) or displayerror(mysql_error());
-    if(mysql_num_rows($checkLockedRes) > 0){
+    $checkLockedRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkLockedQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(mysqli_num_rows($checkLockedRes) > 0){
         $eventDetails.=<<<FORM
             <br/><p>Event Locked</p>
             <table><tr><td>
@@ -765,8 +765,8 @@ FORM;
 }*/
 
 $checkParticipantsQuery = "SELECT `user_pid` FROM `events_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' LIMIT 1";
-$checkParticipantsRes = mysql_query($checkParticipantsQuery) or displayerror(mysql_error());
-if(mysql_num_rows($checkParticipantsRes) == 0){
+$checkParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+if(mysqli_num_rows($checkParticipantsRes) == 0){
     //Show FileUpload Details
     $fileUploadableField=getFileUploadField('fileUploadField',"events");
 
@@ -796,13 +796,13 @@ else{
 PRINTTABLE;
     //$downloadTable = getUserDetailsTable($pmcId,$eventId);
     //$eventDetails.=displayExcelForTable($downloadTable);
-    if(($gotoaction=='qahead') && mysql_num_rows($checkLockedRes) == 0)
+    if(($gotoaction=='qahead') && mysqli_num_rows($checkLockedRes) == 0)
      {
       $eventDetails.=deleteEventForm($pmcID,$eventId);
     $eventDetails.=addParticipant($gotoaction,$pmcId,$eventId);
    $eventDetails.=searchParticipant($gotoaction,$pmcId,$eventId);
     }
-    if(($gotoaction=='qa') && mysql_num_rows($checkLockedRes) == 0)
+    if(($gotoaction=='qa') && mysqli_num_rows($checkLockedRes) == 0)
      {
     $eventDetails.=addParticipant($gotoaction,$pmcId,$eventId);
     }
@@ -829,7 +829,7 @@ $selectParticipantsQuery = "SELECT `events_participants`.`user_pid`,`events_part
             AND `events_participants`.`event_id`='{$eventId}' AND `events_participants`.`user_pid` NOT IN (SELECT `events_confirmed_participants`.`user_id` 
             FROM `events_confirmed_participants` WHERE `events_confirmed_participants`.`page_moduleComponentId` =  '{$pmcId}') ORDER BY `events_participants`.`user_team_id`";
 //	return $selectParticipantsQuery;
-$selectParticipantsRes = mysql_query($selectParticipantsQuery) or displayerror(mysql_error());
+$selectParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 $participantsTable.=<<<TABLE
 
   $smarttable<table id='participants_table' class='display' width='100%' border='1'><thead><tr><th>Team Id</th><th>FID</th><th>Booklet Id</th><th>Name</th><th>College</th><th>Phone No.</th><th>Rank</th><th>Prize Money</th><th>Options</th>
@@ -838,21 +838,21 @@ TABLE;
 if($gotoaction=='qahead')
   $participantsTable.="<th>Delete</th>";
 $participantsTable.="</thead>";
-while($participant = mysql_fetch_assoc($selectParticipantsRes)){
+while($participant = mysqli_fetch_assoc($selectParticipantsRes)){
     $editRowId = "";
     $participantNameQuery = "SELECT `".MYSQL_DATABASE_PREFIX."users`.`user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$participant['user_pid']}'";
-    $participantNameRes = mysql_query($participantNameQuery) or displayerror(mysql_error());
+    $participantNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     $getBookletIdQuery = "SELECT `booklet_id` FROM `prhospi_pr_status` WHERE `user_id`='{$participant['user_pid']}' AND `page_moduleComponentId`='{$pmcId}'";
-    $getBookletIdRes = mysql_query($getBookletIdQuery) or displayerror(mysql_error());
-    if(mysql_num_rows($getBookletIdRes == 0))
+    $getBookletIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $getBookletIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(mysqli_num_rows($getBookletIdRes == 0))
        $bookletId = " ";
     else
-      $bookletId = mysql_result($getBookletIdRes,0);
+      $bookletId = mysqli_result($getBookletIdRes, 0);
     if($participant['user_pid']<30000&&$participant['user_pid']>20000) 
    $rep = $participant['user_pid']+180000;
     else
     $rep = $participant['user_pid'];
-    $participantsTable.="<tr id='partRow{$participant['user_pid']}'><td>".$participant['user_team_id']."</td><td>".$rep."</td><td>".$bookletId."<td><span class='userDataDisp{$participant['user_pid']}'>".mysql_result($participantNameRes, 0)."</span><input type='text' class='userDataEditVal{$participant['user_pid']}' value='".mysql_result($participantNameRes, 0)."' style='display:none'></td>";
+    $participantsTable.="<tr id='partRow{$participant['user_pid']}'><td>".$participant['user_team_id']."</td><td>".$rep."</td><td>".$bookletId."<td><span class='userDataDisp{$participant['user_pid']}'>".mysqli_result($participantNameRes,  0)."</span><input type='text' class='userDataEditVal{$participant['user_pid']}' value='".mysqli_result($participantNameRes,  0)."' style='display:none'></td>";
     $editRowId.='-1,';
     $phNoFormId = retPnoneNoFormId();
     $collFormId = retCollFormId();
@@ -861,18 +861,18 @@ while($participant = mysql_fetch_assoc($selectParticipantsRes)){
     $participantsDetailsQuery = "SELECT `form_elementid`,`form_elementdata` FROM `form_elementdata` WHERE `page_moduleComponentId`='{$globalPmcId}' AND `user_id`='{$participant['user_pid']}' AND `form_elementid` IN ($phNoFormId,$collFormId) ORDER BY `form_elementid`";
     //displayinfo($participantsDetailsQuery);
     //1
-    $participantsDetailsRes = mysql_query($participantsDetailsQuery) or displayerror(mysql_error());
+    $participantsDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     //displayinfo(mysql_num_rows($participantsDetailsRes));
-    if(mysql_num_rows($participantsDetailsRes) == 0 || mysql_num_rows($participantsDetailsRes) == 1){
+    if(mysqli_num_rows($participantsDetailsRes) == 0 || mysqli_num_rows($participantsDetailsRes) == 1){
       $participantsDetailsQuery = "SELECT `form_elementid`,`form_elementdata` FROM `form_elementdata` WHERE `page_moduleComponentId`='{$globalPmcId}' AND `user_id`='{$participant['user_pid']}' AND `form_elementid`='{$otherCollFormId}'";
-      $participantsDetailsRes = mysql_query($participantsDetailsQuery) or displayerror(mysql_error());
+      $participantsDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       //echo $participantsDetailsQuery;
       //die();
       $collNameId = $otherCollFormId;
-      if(mysql_num_rows($participantsDetailsRes) == 0)
+      if(mysqli_num_rows($participantsDetailsRes) == 0)
         $collName = " ";
       else{
-        while($userDetails = mysql_fetch_assoc($participantsDetailsRes)){
+        while($userDetails = mysqli_fetch_assoc($participantsDetailsRes)){
           //echo $userDetails['form_elementdata'];
           //die();
           $collName = $userDetails['form_elementdata'];
@@ -884,7 +884,7 @@ while($participant = mysql_fetch_assoc($selectParticipantsRes)){
       //displayinfo($collName);
     }
     else{
-    while($userDetails = mysql_fetch_assoc($participantsDetailsRes)){
+    while($userDetails = mysqli_fetch_assoc($participantsDetailsRes)){
         if($userDetails['form_elementid'] == $phNoFormId){
             $phNoId = $userDetails['form_elementid'];
             $phNo = $userDetails['form_elementdata'];
@@ -895,8 +895,8 @@ while($participant = mysql_fetch_assoc($selectParticipantsRes)){
             $collName = $userDetails['form_elementdata'];
             if($collName == "" || $collName == "Others"){
                 $getCollNameQuery = "SELECT `form_elementdata`,`form_elementid` FROM `form_elementdata` WHERE `form_elementid`='{$otherCollFormId}' AND `page_modulecomponentid`='{retglobalPmcId()}' AND `user_id`='{$participant['user_pid']}'";
-                $getCollNameRes = mysql_query($getCollNameQuery) or displayerror(mysql_error());
-                while($otherCollDetails = mysql_fetch_assoc($getCollNameRes)){
+                $getCollNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCollNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+                while($otherCollDetails = mysqli_fetch_assoc($getCollNameRes)){
                     $collNameId = $otherCollDetails['form_elementid'];
                     $collName = $otherCollDetails['form_elementdata'];
                 }
@@ -918,8 +918,8 @@ while($participant = mysql_fetch_assoc($selectParticipantsRes)){
     /////////////////////////////////////////////////GETTING A DROPDOWN FOR THE LIST OF COLLEGES FROM REGISTRATION FORM 
         $selectTag="<select name='college' class='userDataEditVal{$participant['user_pid']}' style='display:none '>";
             $getCollegeListQuery="SELECT `form_elementtypeoptions` FROM `form_elementdesc` WHERE `page_modulecomponentid`=0 AND `form_elementid`=10";
-            $getCollegeListRes=mysql_query($getCollegeListQuery) or displayerror(mysql_error());
-            if($fullCollegeList=mysql_fetch_array($getCollegeListRes))
+            $getCollegeListRes=mysqli_query($GLOBALS["___mysqli_ston"], $getCollegeListQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+            if($fullCollegeList=mysqli_fetch_array($getCollegeListRes))
             {
             
             $fullCollegeArray=explode('|',$fullCollegeList['form_elementtypeoptions']);
@@ -946,13 +946,13 @@ while($participant = mysql_fetch_assoc($selectParticipantsRes)){
 	*/	
     $participantsTable.="<td><span class='userDataDisp{$participant['user_pid']}'>".$phNo."</span><input type='text' class='userDataEditVal{$participant['user_pid']}' value='{$phNo}' style='display:none'></td>";
 		$participantsRankQuery = "SELECT `user_rank` FROM `events_result` WHERE `page_moduleComponentId`='{$pmcId}' AND `user_id`='{$participant['user_pid']}' AND `event_id`='{$eventId}'";
-		$participantsRankRes = mysql_query($participantsRankQuery) or displayerror(mysql_error());
-		$userRank = mysql_result($participantsRankRes,0);
+		$participantsRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$userRank = mysqli_result($participantsRankRes, 0);
 		$participantsTable.="<td><span class='userDataDisp{$participant['user_pid']}'>".$userRank."</span><input type='text' class='userDataEditVal{$participant['user_pid']}' value='{$userRank}' style='display:none'></td>";
 		$editRowId.='-2,';
 		$getPrizeMoneyQuery = "SELECT `prize_money` FROM `events_participants` WHERE `user_pid`='{$participant['user_pid']}' AND `event_id`='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-		$getPrizeMoneyRes = mysql_query($getPrizeMoneyQuery) or displayerror(mysql_error());
-		$prizeMoney = mysql_result($getPrizeMoneyRes,0);
+		$getPrizeMoneyRes = mysqli_query($GLOBALS["___mysqli_ston"], $getPrizeMoneyQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$prizeMoney = mysqli_result($getPrizeMoneyRes, 0);
 		$participantsTable.="<td><span class='userDataDisp{$participant['user_pid']}'>".$prizeMoney."</span><input type='text' class='userDataEditVal{$participant['user_pid']}' value='{$prizeMoney}' style='display:none'></td>";
 		$editRowId.='-3,';
 		$editRowId=trim($editRowId,',');
@@ -1002,20 +1002,20 @@ function getUserDetailsTable($gotoaction,$pmcId,$eventId){
 				<table id='participants_table' class='display' width='100%' border='1'><thead><tr><th>Team Id</th><th>FID</th><th>Booklet ID</th><th>Name</th><th>College</th><th>Phone No.</th><th>Rank</th><th>Prize Money</th></tr></thead>
 TABLE;
 	$selectTeamQuery = "SELECT `user_team_id`,COUNT(*) AS `count` FROM `events_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' GROUP BY `user_team_id`";
-	$selectTeamRes = mysql_query($selectTeamQuery) or displayerror(mysql_error());
-	while($team = mysql_fetch_assoc($selectTeamRes)){
+	$selectTeamRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectTeamQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	while($team = mysqli_fetch_assoc($selectTeamRes)){
 		$participantsTable.="<tr><td rowspan='{$team['count']}'>".$team['user_team_id']."</td>";
 		$selectParticipantsQuery = "SELECT `user_pid` FROM `events_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' AND `user_team_id`='{$team['user_team_id']}'";
-		$selectParticipantsRes = mysql_query($selectParticipantsQuery) or displayerror(mysql_error());
-		while($participant = mysql_fetch_assoc($selectParticipantsRes)){
+		$selectParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		while($participant = mysqli_fetch_assoc($selectParticipantsRes)){
 			$participantNameQuery = "SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$participant['user_pid']}'";
-			$participantNameRes = mysql_query($participantNameQuery) or displayerror(mysql_error());
+			$participantNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$getBookletIdQuery = "SELECT `booklet_id` FROM `prhospi_pr_status` WHERE `user_id`='{$participant['user_pid']}' AND `page_moduleComponentId`='1'";
-		$getBookletIdRes = mysql_query($getBookletIdQuery) or displayerror(mysql_error());
-		if(mysql_num_rows($getBookletIdRes == 0))
+		$getBookletIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $getBookletIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		if(mysqli_num_rows($getBookletIdRes == 0))
 		   $bookletId = " ";
 		else
-		  $bookletId = mysql_result($getBookletIdRes,0);
+		  $bookletId = mysqli_result($getBookletIdRes, 0);
             //$getBookeltIdQuery = "SELECT `booklet_id` FROM `prhospi_pr_status` WHERE `page_moduleComponentId`='{$pmcId}' and `user_id`='{$participant['user_pid']}'";
 			//$getBookletIdRes = mysql_query($getBookletIdQuery) or displayerror(mysql_error());
 			//$bookletId = mysql_result($getBookletIdRes,0);
@@ -1023,14 +1023,14 @@ TABLE;
             $rep = $participant['user_pid']+180000;
         else
             $rep=$participant['user_pid'];
-			$participantsTable.="<td>".$rep."</td><td>".$bookletId."</td><td>".mysql_result($participantNameRes, 0)."</td>";
+			$participantsTable.="<td>".$rep."</td><td>".$bookletId."</td><td>".mysqli_result($participantNameRes,  0)."</td>";
 			$phNoFormId = retPnoneNoFormId();
 			$collFormId = retCollFormId();
 			$otherCollFormId = retOtherCollFormId();
 			$participantsDetailsQuery = "SELECT `form_elementdata`,`form_elementid` FROM `form_elementdata` WHERE `page_moduleComponentId`='{retglobalPmcId()}' AND `user_id`='{$participant['user_pid']}' AND `form_elementid` IN ($phNoFormId,$collFormId)";
 			//2
-			$participantsDetailsRes = mysql_query($participantsDetailsQuery) or displayerror(mysql_error());
-			while($userDetails = mysql_fetch_assoc($participantsDetailsRes)){
+			$participantsDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			while($userDetails = mysqli_fetch_assoc($participantsDetailsRes)){
 				if($userDetails['form_elementid'] == $phNoFormId){
 					$phNoId = $userDetails['form_elementid'];
 					$phNo = $userDetails['form_elementdata'];
@@ -1040,8 +1040,8 @@ TABLE;
 					$collName = $userDetails['form_elementdata'];
 					if($collName == "Others"){
 						$getCollNameQuery = "SELECT `form_elementdata`,`form_elementid` FROM `form_elementdata` WHERE `form_elementid`='{$otherCollFormId}' AND `page_modulecomponentid`='{retglobalPmcId()}' AND `user_id`='{$participant['user_pid']}'";
-						$getCollNameRes = mysql_query($getCollNameQuery) or displayerror(mysql_error());
-						while($otherCollDetails = mysql_fetch_assoc($getCollNameRes)){
+						$getCollNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCollNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+						while($otherCollDetails = mysqli_fetch_assoc($getCollNameRes)){
 							$collNameId = $otherCollDetails['form_elementid'];
 							$collName = $otherCollDetails['form_elementdata'];
 						}
@@ -1050,19 +1050,19 @@ TABLE;
 			}
 			$participantsTable.="<td>".$collName."</td><td>".$phNo."</td>";
 			$getUserRankQuery = "SELECT `user_rank` FROM `events_result` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' AND `user_id`='{$participant['user_pid']}'";
-			$getUserRankRes = mysql_query($getUserRankQuery) or displayerror(mysql_error());
-			$userRank = mysql_result($getUserRankRes,0);
+			$getUserRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$userRank = mysqli_result($getUserRankRes, 0);
 			$participantsTable.="<td>".$userRank."</td>";
 			$getPrizeMoneyQuery = "SELECT `prize_money` FROM `events_participants` WHERE `user_pid`='{$participant['user_pid']}' AND `event_id`='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-			$getPrizeMoneyRes = mysql_query($getPrizeMoneyQuery) or displayerror(mysql_error());
-			$prizeMoney = mysql_result($getPrizeMoneyRes,0);
+			$getPrizeMoneyRes = mysqli_query($GLOBALS["___mysqli_ston"], $getPrizeMoneyQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$prizeMoney = mysqli_result($getPrizeMoneyRes, 0);
 			$participantsTable.="<td>".$prizeMoney."</td>";
 			$participantsTable.="</tr>";
 		}
 	}
 	$eventNameQuery = "SELECT `event_name` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}'";
-	$eventNameRes = mysql_query($eventNameQuery) or displayerror(mysql_error());
-	$eventName = mysql_result($eventNameRes, 0);
+	$eventNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $eventNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	$eventName = mysqli_result($eventNameRes,  0);
 	$participantsTable.="</table>";
 	displayExcelForTable($participantsTable,$eventName);
 	//return $participantsTable;
@@ -1070,9 +1070,9 @@ TABLE;
 
 function confirmParticipation($gotoaction,$pmcid,$eventId,$userId){
 	$confirmQuery = "INSERT INTO `events_confirmed_participants`(`page_moduleComponentId`,`event_id`,`user_id`) VALUES('{$pmcid}','{$eventId}','{$userId}')";
-	$confirmRes = mysql_query($confirmQuery) or displayerror(mysql_error());
+	$confirmRes = mysqli_query($GLOBALS["___mysqli_ston"], $confirmQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	$userRankQuery = "INSERT INTO `events_result`(`page_moduleComponentId`,`event_id`,`user_id`) VALUES('{$pmcid}','{$eventId}','{$userId}')";
-	$userRankRes = mysql_query($userRankQuery) or displayerror(mysql_error());
+	$userRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $userRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	//return "Successfully deleted.";
 	$redirectData = <<<POSTDATA
 		<form method='POST' action='./+{$gotoaction}&subaction=viewEvent' name='postDataForm'>
@@ -1091,11 +1091,11 @@ function editParticipant($gotoaction,$pmcId,$eventId,$formId,$userId,$teamId,$ro
 	$rowIdArray = explode(",",$rowId);
 	$updatedRow = "";
 	$getBookletIdQuery = "SELECT `booklet_id` FROM `prhospi_pr_status` WHERE `user_id`='{$userId}' AND `page_moduleComponentId`='1'";
-	$getBookletIdRes = mysql_query($getBookletIdQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($getBookletIdRes) == 0)
+	$getBookletIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $getBookletIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($getBookletIdRes) == 0)
 	  $bookletId = " ";
 	else
-	  $bookletId = mysql_result($getBookletIdRes,0);
+	  $bookletId = mysqli_result($getBookletIdRes, 0);
 	$updatedRow.="<td>".$teamId."</td><td>".$userId."</td><td>".$bookletId."</td>";
        	for($i=0;$i<sizeof($rowValueArray);$i++){
 /*
@@ -1104,22 +1104,22 @@ function editParticipant($gotoaction,$pmcId,$eventId,$formId,$userId,$teamId,$ro
 		$insertEditedRowRes = mysql_query($insertEditedRowQuery) or displayerror(mysql_error());
 */
     $formDataQuery = "SELECT * FROM `form_elementdata` WHERE `user_id`={$userId}";
-    $formDataRes = mysql_query($formDataQuery) or displayerror(mysql_error());
-    if(mysql_num_rows($formDataRes)==0){
+    $formDataRes = mysqli_query($GLOBALS["___mysqli_ston"], $formDataQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(mysqli_num_rows($formDataRes)==0){
         for($k=0;$k<13;$k++){
             $insQuery="INSERT INTO `form_elementdata` VALUES({$userId},0,{$k},'')";
-            $inses=mysql_query($insQuery) or displayerror(mysql_error());
+            $inses=mysqli_query($GLOBALS["___mysqli_ston"], $insQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
         }
     }
 			if($rowIdArray[$i] == -1){
 			$editNameQuery = "UPDATE `".MYSQL_DATABASE_PREFIX."users` SET `user_fullname`='{$rowValueArray[$i]}' WHERE `user_id`='{$userId}'";
-			$editNameRes = mysql_query($editNameQuery) or displayerror(mysql_error());
+			$editNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $editNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
             $updatedRow.="<td><span class='userDataDisp{$userId}'>".$rowValueArray[$i]."</span><input type='text' class='userDataEditVal{$userId}' value='".$rowValueArray[$i]."' style='display:none' /></td>";
 		}
 		else if($rowIdArray[$i] == -2){
 			$editRankQuery = "UPDATE `events_result` SET `user_rank`='{$rowValueArray[$i]}' WHERE `user_id`='{$userId}' AND `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}'";
-			$editRankRes = mysql_query($editRankQuery) or displayerror(mysql_error());
+			$editRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $editRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
 
             $updatedRow.="<td><span class='userDataDisp{$userId}'>".$rowValueArray[$i]."</span><input type='text' class='userDataEditVal{$userId}' value='".$rowValueArray[$i]."' style='display:none' /></td>";
@@ -1128,7 +1128,7 @@ function editParticipant($gotoaction,$pmcId,$eventId,$formId,$userId,$teamId,$ro
                   $editPrizeMoneyQuery = "UPDATE `events_participants` SET `prize_money`='{$rowValueArray[$i]}' WHERE `user_pid`='{$userId}' AND `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}'";
 
 		  //		  return $editPrizeMoneyQuery;
-                  $editPrizeMoneyRes = mysql_query($editPrizeMoneyQuery) or displayerror(mysql_error());
+                  $editPrizeMoneyRes = mysqli_query($GLOBALS["___mysqli_ston"], $editPrizeMoneyQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
 
                   $updatedRow.="<td><span class='userDataDisp{$userId}'>".$rowValueArray[$i]."</span><input type='text' class='userDataEditVal{$userId}' value='".$rowValueArray[$i]."' style='display:none' /></td>";
@@ -1148,14 +1148,14 @@ function editParticipant($gotoaction,$pmcId,$eventId,$formId,$userId,$teamId,$ro
      //           $rowIdArray[$i]=12;
        //          }
             $editValuesQuery = "UPDATE `form_elementdata` SET `form_elementdata`='{$rowValueArray[$i]}' WHERE `user_id`='{$userId}' AND `form_elementid`=10 AND `page_moduleComponentId`='{retglobalPmcId()}'";
-            $editValuesRes = mysql_query($editValuesQuery) or displayerror(mysql_error());
+            $editValuesRes = mysqli_query($GLOBALS["___mysqli_ston"], $editValuesQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
        
      
             $selectTag="<td><span class='userDataDisp{$userId}'>".$rowValueArray[$i]."</span>";
 //<select class='userdataeditval{$userid}' style='display:none' >";
             $getCollegeListQuery="SELECT `form_elementtypeoptions` FROM `form_elementdesc` WHERE `page_modulecomponentid`=0 AND `form_elementid`=10";
-            $getCollegeListRes=mysql_query($getCollegeListQuery) or displayerror(mysql_error());
-            if($fullCollegeList=mysql_fetch_array($getCollegeListRes))
+            $getCollegeListRes=mysqli_query($GLOBALS["___mysqli_ston"], $getCollegeListQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+            if($fullCollegeList=mysqli_fetch_array($getCollegeListRes))
             {
                $selectTag.="<select class='userDataEditVal{$userId}' style='display:none' >";
       
@@ -1181,7 +1181,7 @@ function editParticipant($gotoaction,$pmcId,$eventId,$formId,$userId,$teamId,$ro
             {
             $editValuesQuery = "UPDATE `form_elementdata` SET `form_elementdata`='{$rowValueArray[$i]}' WHERE `user_id`='{$userId}' AND `form_elementid`='{$rowIdArray[$i]}' AND `page_moduleComponentId`='{retglobalPmcId()}'";
                     //3
-            $editValuesRes = mysql_query($editValuesQuery) or displayerror(mysql_error());
+            $editValuesRes = mysqli_query($GLOBALS["___mysqli_ston"], $editValuesQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
         //if($rowIdArray[$i]==12){
     
        //$updatedRow.="<input type='text' class='userDataEditVal{$userId}' value='{$rowValueArray[$i]}' style='display:none' /></td>";   
@@ -1229,7 +1229,7 @@ return $updatedRow;
 function lockEvent($pmcId,$eventId){
 
 	$lockEventQuery = "INSERT INTO `events_locked`(`page_moduleComponentId`,`event_id`) VALUES('{$pmcId}','{$eventId}')";
-	$lockEventRes = mysql_query($lockEventQuery) or displayerror(mysql_error());
+	$lockEventRes = mysqli_query($GLOBALS["___mysqli_ston"], $lockEventQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	return displayinfo("Event Locked");
 }
 
@@ -1237,7 +1237,7 @@ function lockEvent($pmcId,$eventId){
 function unlockEvent($pmcId,$eventId){
 
 	$unlockEventQuery = "DELETE FROM `events_locked` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}'";
-	$unlockEventRes = mysql_query($unlockEventQuery) or displayerror(mysql_error());
+	$unlockEventRes = mysqli_query($GLOBALS["___mysqli_ston"], $unlockEventQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	return displayinfo("Event Unlocked");
 }
 
@@ -1254,21 +1254,21 @@ function syncExcelFile($pmcId,$eventId,$fileLoc){
 			}
 			if(!empty($excelData[$i][$j])){
 				$checkDuplicateQuery = "SELECT `user_pid` FROM `events_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' AND `user_pid`='{$userPid}'";
-				$checkDuplicateRes = mysql_query($checkDuplicateQuery) or displayerror(mysql_error());
-				if(mysql_num_rows($checkDuplicateRes) == 0){
+				$checkDuplicateRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkDuplicateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_num_rows($checkDuplicateRes) == 0){
                                         
                      $getBookletIdQuery = "SELECT `booklet_id` FROM `prhospi_pr_status` WHERE `user_id`='{$userPid}' AND `page_moduleComponentId`='{$pmcId}'";
-        $getBookletIdRes = mysql_query($getBookletIdQuery) or displayerror(mysql_error());
-        if(mysql_num_rows($getBookletIdRes)>0 || 1)
+        $getBookletIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $getBookletIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+        if(mysqli_num_rows($getBookletIdRes)>0 || 1)
           {
     displaywarning("Am here");
-          $bookletId = mysql_result($getBookletIdRes,0);
+          $bookletId = mysqli_result($getBookletIdRes, 0);
           $saveUserIdQuery = "INSERT INTO `events_participants`(`page_moduleComponentId`,`event_id`,`user_pid`,`user_team_id`) VALUES('{$pmcId}','{$eventId}','{$userPid}','{$i}')";
-                    $saveUserIdRes = mysql_query($saveUserIdQuery) or displayerror(mysql_error());
+                    $saveUserIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $saveUserIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
                     $userInitRankQuery = "INSERT INTO `events_result`(`page_moduleComponentId`,`user_id`,`user_rank`,`event_id`) VALUES('{$pmcId}','{$userPid}','-1','{$eventId}')";
                     displaywarning($userInitQuery);
-                    $userInitRankRes = mysql_query($userInitRankQuery) or displayerror(mysql_error());
+                    $userInitRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $userInitRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
           }
                 }
 			}
@@ -1307,7 +1307,7 @@ UNLOCK;
 	}
 
 	$checkParticipantsQuery = "SELECT `user_pid` FROM `events_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' LIMIT 1";
-	$checkParticipantsRes = mysql_query($checkParticipantsQuery) or displayerror(mysql_error());
+	$checkParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	
 	$eventParticipants=displayParticipantRank($gotoaction,$pmcId,$eventId);
 		//displayExcelForTable($eventParticipants);
@@ -1324,27 +1324,27 @@ function displayParticipantRank($gotoaction,$pmcId,$eventId){
 				AND `events_participants`.`event_id`='{$eventId}' AND `events_participants`.`user_pid` NOT IN (SELECT `events_confirmed_participants`.`user_id` 
 				FROM `events_confirmed_participants` WHERE `events_confirmed_participants`.`page_moduleComponentId` =  '{$pmcId}') ORDER BY `events_participants`.`user_team_id`";
 //	return $selectParticipantsQuery;
-	$selectParticipantsRes = mysql_query($selectParticipantsQuery) or displayerror(mysql_error());
+	$selectParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	$participantsTable.=<<<TABLE
 				$smarttable<table id='participants_table' class='display' width='100%' border='1'><thead><tr><th>Team Id</th><th>FID</th><th>Name</th><th>College</th><th>Phone No.</th><th>Rank</th><th>Prize Money</th><th>Options</th></tr></thead>
 TABLE;
-	while($participant = mysql_fetch_assoc($selectParticipantsRes)){
+	while($participant = mysqli_fetch_assoc($selectParticipantsRes)){
 	  $participantsTable.="<tr id='partRow{$participant['user_pid']}'><td>".$participant['user_team_id']."</td>";
 		$participantNameQuery = "SELECT `".MYSQL_DATABASE_PREFIX."users`.`user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$participant['user_pid']}'";
-		$participantNameRes = mysql_query($participantNameQuery) or displayerror(mysql_error());
+		$participantNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
         if($participant['user_pid']>20000&&$participant['user_pid']<30000)
             $rep = $participant['user_pid']+180000;
         else
             $rep=$participant['user_pid'];
-		$participantsTable.="<td>".$rep."</td><td>".mysql_result($participantNameRes, 0)."</td>";
+		$participantsTable.="<td>".$rep."</td><td>".mysqli_result($participantNameRes,  0)."</td>";
 		$phNoFormId = retPnoneNoFormId();
 		$collFormId = retCollFormId();
 		$otherCollFormId = retOtherCollFormId();
 		$participantsDetailsQuery = "SELECT `form_elementid`,`form_elementdata` FROM `form_elementdata` WHERE `page_moduleComponentId`='{retglobalPmcId()}' AND `user_id`='{$participant['user_pid']}' AND `form_elementid` IN ($phNoFormId,$collFormId) ORDER BY `form_elementid`";
 		//4
-		$participantsDetailsRes = mysql_query($participantsDetailsQuery) or displayerror(mysql_error());
-		if(mysql_num_rows($participantsDetailsRes)>0){
-		while($userDetails = mysql_fetch_assoc($participantsDetailsRes)){
+		$participantsDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		if(mysqli_num_rows($participantsDetailsRes)>0){
+		while($userDetails = mysqli_fetch_assoc($participantsDetailsRes)){
 			if($userDetails['form_elementid'] == $phNoFormId){
 				$phNoId = $userDetails['form_elementid'];
 				$phNo = $userDetails['form_elementdata'];
@@ -1354,8 +1354,8 @@ TABLE;
 				$collName = $userDetails['form_elementdata'];
 				if($collName == "Others"){
 					$getCollNameQuery = "SELECT `form_elementdata`,`form_elementid` FROM `form_elementdata` WHERE `form_elementid`='{$otherCollFormId}' AND `page_modulecomponentid`='{retglobalPmcId()}' AND `user_id`='{$participant['user_pid']}'";
-					$getCollNameRes = mysql_query($getCollNameQuery) or displayerror(mysql_error());
-					while($otherCollDetails = mysql_fetch_assoc($getCollNameRes)){
+					$getCollNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCollNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					while($otherCollDetails = mysqli_fetch_assoc($getCollNameRes)){
 						$collNameId = $otherCollDetails['form_elementid'];
 						$collName = $otherCollDetails['form_elementdata'];
 					}
@@ -1371,12 +1371,12 @@ TABLE;
 		}
 		$participantsTable.="<td>".$collName."</td><td>".$phNo."</td>";
 		$participantsRankQuery = "SELECT `user_rank` FROM `events_result` WHERE `page_moduleComponentId`='{$pmcId}' AND `user_id`='{$participant['user_pid']}' AND `event_id`='{$eventId}'";
-		$participantsRankRes = mysql_query($participantsRankQuery) or displayerror(mysql_error());
-		$userRank = mysql_result($participantsRankRes,0);
+		$participantsRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$userRank = mysqli_result($participantsRankRes, 0);
 		$participantsTable.="<td>".$userRank."</td>";
 		$getPrizeMoneyQuery = "SELECT `prize_money` FROM `events_participants` WHERE `event_id`='{$eventId}' AND `user_pid`='{$participant['user_pid']}'";
-		$getPrizeMoneyRes = mysql_query($getPrizeMoneyQuery) or displayerror(mysql_error());
-		$prizeMoney = mysql_result($getPrizeMoneyRes,0);
+		$getPrizeMoneyRes = mysqli_query($GLOBALS["___mysqli_ston"], $getPrizeMoneyQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$prizeMoney = mysqli_result($getPrizeMoneyRes, 0);
 		$participantsTable.="<td>".$prizeMoney."</td>";
 		$participantsTable.=<<<FORM
 			<td>
@@ -1401,8 +1401,8 @@ function printIndividualCerti($gotoaction,$eventAction,$pmcId,$userId,$eventId){
 	if($eventAction == 'event'){
 		$eventName = getEventName($pmcId,$eventId);
 		$getUserRankQuery = "SELECT `user_rank` FROM `events_result` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_id`='{$eventId}' AND `user_id`='{$userId}'";
-		$getUserRankRes = mysql_query($getUserRankQuery) or displayerror(mysql_error());
-		$userRank = mysql_result($getUserRankRes,0);
+		$getUserRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$userRank = mysqli_result($getUserRankRes, 0);
 
 	}
 
@@ -1411,8 +1411,8 @@ function printIndividualCerti($gotoaction,$eventAction,$pmcId,$userId,$eventId){
 	      return "";
 		$getWorkshopNameQuery = "SELECT `workshop_name` FROM `events_workshop_details` WHERE `workshop_id`='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
 		//		return $getWorkshopNameQuery;
-		$getWorkshopNameRes = mysql_query($getWorkshopNameQuery) or displayerror(mysql_error());
-		$eventName = mysql_result($getWorkshopNameRes,0);
+		$getWorkshopNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getWorkshopNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$eventName = mysqli_result($getWorkshopNameRes, 0);
 		$userRank="-1";
 	}
 	//displayerror($eventAction." ".$eventId." ".$pmcId." ".$userId." ".$userRank);
@@ -1432,29 +1432,29 @@ function printCertificates($eventAction,$pmcId,$eventId){
 	require_once("$sourceFolder/$moduleFolder/events/events_certi_image2.php");
 	
 	$eventCountQuery = "SELECT COUNT(*) FROM `events_participants` WHERE `event_id` ='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-	$eventCountRes = mysql_query($eventCountQuery) or displayerror(mysql_error());
-	$eventCount = mysql_result($eventCountRes,0);
+	$eventCountRes = mysqli_query($GLOBALS["___mysqli_ston"], $eventCountQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	$eventCount = mysqli_result($eventCountRes, 0);
 	//	for($i=0;$i<=ceil(
 	//	for($i=0;$i < ceil($eventCount/30);$i++){
 	if($eventAction == 'event'){
 	  
 		$getEventNameQuery = "SELECT `event_name` FROM `events_details` WHERE `event_id` = '{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-		$getEventNameRes = mysql_query($getEventNameQuery) or displayerror(mysql_error());
-		$eventName = mysql_result($getEventNameRes,0);
+		$getEventNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getEventNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$eventName = mysqli_result($getEventNameRes, 0);
 		//		$limitStart = ($i*30)+1;
 		$selectIdQuery = "SELECT DISTINCT `events_participants`.`user_pid`,`events_result`.`user_rank` FROM `events_participants`,`events_result`
 				WHERE `events_participants`.`event_id`='{$eventId}' AND `events_result`.`event_id`='{$eventId}' AND `events_result`.`user_id`=`events_participants`.`user_pid` AND `events_participants`.`page_moduleComponentId`='{$pmcId}' AND
 				`events_result`.`page_moduleComponentId`='{$pmcId}'  ORDER BY `events_participants`.`user_team_id`,`events_result`.`user_rank`";
-		$selectIdRes = mysql_query($selectIdQuery) or displayerror(mysql_error());
+		$selectIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}
 
 	else if($eventAction == 'workshop'){
 		$getEventNameQuery = "SELECT `workshop_name` FROM `events_workshop_details` WHERE `workshop_id` = '{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-		$getEventNameRes = mysql_query($getEventNameQuery) or displayerror(mysql_error());
-		$eventName = mysql_result($getEventNameRes,0);
+		$getEventNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getEventNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$eventName = mysqli_result($getEventNameRes, 0);
 
 		$selectIdQuery = "SELECT DISTINCT `user_id` FROM `events_workshop_participants`,`events_result` WHERE `page_modulecomponentid`='{$pmcId}' AND `workshop_id`='{$eventId}'";
-		$selectIdRes = mysql_query($selectIdQuery) or displayerror(mysql_error());
+		$selectIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}
 //return $selectIdQuery;
 	$certiImagePage = "";
@@ -1471,7 +1471,7 @@ function printCertificates($eventAction,$pmcId,$eventId){
       return false;
     }*/
 
-	while($printParticipant = mysql_fetch_assoc($selectIdRes)){
+	while($printParticipant = mysqli_fetch_assoc($selectIdRes)){
 		if($eventAction == 'event'){
 			$userId = $printParticipant['user_pid'];
 			$userRank = $printParticipant['user_rank'];
@@ -1524,11 +1524,11 @@ function generateCerti($eventAction,$eventId,$pmcId,$userId,$userRank){
 	}
 	else if($eventAction == 'workshop')
 		$getCertiImgQuery = "SELECT `certificate_id`,`certificate_image` FROM `events_certificate` WHERE `user_rank` = '{$eventId}' AND `page_moduleComponentId`='{$pmcId}' AND `event_id` = '-1'";
-	$getCertiImgRes = mysql_query($getCertiImgQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($getCertiImgRes) == 0){
+	$getCertiImgRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCertiImgQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($getCertiImgRes) == 0){
 	  $getEventsCertiQuery = "SELECT `certificate_id`,`certificate_image` FROM `events_certificate` WHERE `user_rank` = '{$userCertiRank}' AND `page_moduleComponentId`='{$pmcId}' AND `event_id` = '-1'";
 	  //	  return $getEventsCertiQuery;
-	  $getCertiImgRes = mysql_query($getEventsCertiQuery) or displayerror(mysql_error());
+	  $getCertiImgRes = mysqli_query($GLOBALS["___mysqli_ston"], $getEventsCertiQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}
 
 	$certiImage = "";
@@ -1538,7 +1538,7 @@ function generateCerti($eventAction,$eventId,$pmcId,$userId,$userRank){
 	$posY2String="";
 	$certiValueString="";
 	
-	while($certiDetails = mysql_fetch_assoc($getCertiImgRes)){
+	while($certiDetails = mysqli_fetch_assoc($getCertiImgRes)){
 	  $certiImage = $certiDetails['certificate_image'];
 		$certiId = $certiDetails['certificate_id'];
 		//	return $certiImage;
@@ -1546,14 +1546,14 @@ function generateCerti($eventAction,$eventId,$pmcId,$userId,$userRank){
 		//Get Certificate Details From evets_certficate_details
 		$getCertiDetailsQuery = "SELECT `certificate_posx`,`certificate_posy`,`certificate_posx2`,`certificate_posy2`,`form_value_id` FROM `events_certificate_details` WHERE `page_moduleComponentId`='{$pmcId}' AND `certificate_id`='{$certiId}'";
 		//		return $getCertiDetailsQuery;
-		$getCertiDetailsRes = mysql_query($getCertiDetailsQuery) or displayerror(mysql_error());
+		$getCertiDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCertiDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		//		return mysql_num_rows($getCertiDetailsRes);
 		//Get Form Values From form_elementdesc
 		//Form_value_id=1 -> Rank
 		//Form_value_id=2 -> Event Name
 		//Form_value_id=3 -> PArticipant Name
 		//Form_value_id=4 -> Coll
-		while($getValues = mysql_fetch_assoc($getCertiDetailsRes)){
+		while($getValues = mysqli_fetch_assoc($getCertiDetailsRes)){
 			//User Rank
 
 		  // echo $getValues['form_value_id'];
@@ -1637,8 +1637,8 @@ function generateCerti($eventAction,$eventId,$pmcId,$userId,$userRank){
 				}
 			else if($getValues['form_value_id'] == 3){
 				$getUserNameQuery = "SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$userId}'";
-				$getUserNameRes = mysql_query($getUserNameQuery) or displayerror(mysql_error());
-				$userName = ucwords_specific(strtolower(mysql_result($getUserNameRes, 0)),".");
+				$getUserNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				$userName = ucwords_specific(strtolower(mysqli_result($getUserNameRes,  0)),".");
 				$posXString.=$getValues['certificate_posx']."::";
 				$posYString.=$getValues['certificate_posy']."::";
 				$posX2String.=$getValues['certificate_posx2']."::";
@@ -1655,15 +1655,15 @@ function generateCerti($eventAction,$eventId,$pmcId,$userId,$userRank){
 				//$getFormValuesQuery = "SELECT `form_elementdata`.`form_elementdata` FROM `form_elementdata` INNER JOIN `events_form` ON `form_elementdata`.`page_moduleComponentId`=`events_form`.`form_id` 
 				//	AND `events_form`.`event_id`='{$eventId}' AND `events_form`.`page_moduleComponentId`='{$pmcId}' AND `form_elementdata`.`user_id`='{$printParticipant['user_id']}' AND `form_elementdata`.`form_elementid`='{$getValues['form_value_id']}'";
 				$getFormValuesQuery = "SELECT `form_elementdata` FROM `form_elementdata` WHERE `page_moduleComponentId`='{$formPmcId}' AND `form_elementid`='{$collId}' AND `user_id`='{$userId}'";
-				$getFormValuesRes = mysql_query($getFormValuesQuery) or displayerror(mysql_error());
+				$getFormValuesRes = mysqli_query($GLOBALS["___mysqli_ston"], $getFormValuesQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			//	return mysql_num_rows($getFormValuesQuery);
-				while($formData = mysql_fetch_assoc($getFormValuesRes)){
+				while($formData = mysqli_fetch_assoc($getFormValuesRes)){
 				//	imagettftext($rotatedImage, 20, 90, $getValues['certificate_posx'], $getValues['certificate_posy'], $color, $font, $formData['form_elementdata']);
 					if($formData['form_elementdata'] == "Others"){
 						$collFormId = retOtherCollFormId();
 						$getCollNameQuery = "SELECT `form_elementdata` FROM `form_elementdata` WHERE `page_moduleComponentId`='{$formPmcId}' AND `user_id`='{$userId}' AND `form_elementid`='{$collFormId}'";
-						$getCollNameRes = mysql_query($getCollNameQuery) or displayerror(mysql_error());
-						$collName = ucwords_specific(strtolower(mysql_result($getCollNameRes,0)),".");
+						$getCollNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCollNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+						$collName = ucwords_specific(strtolower(mysqli_result($getCollNameRes, 0)),".");
 					} 
 					else
 					  $collName = ucwords_specific(strtolower($formData['form_elementdata']),".");
@@ -1691,8 +1691,8 @@ function generateCerti($eventAction,$eventId,$pmcId,$userId,$userRank){
 function getUserIdFromBookletId($bookletId,$mcId) {
   $bookletId = escape($bookletId);
   $checkUserRegisteredToPr = "SELECT * FROM `prhospi_pr_status` WHERE `page_modulecomponentid` = {$mcId} AND `booklet_id` = '{$bookletId}'";
-  $checkUserRegisteredToPrQuery = mysql_query($checkUserRegisteredToPr) or displayerror(mysql_error());
-  $row = mysql_fetch_assoc($checkUserRegisteredToPrQuery);
+  $checkUserRegisteredToPrQuery = mysqli_query($GLOBALS["___mysqli_ston"], $checkUserRegisteredToPr) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $row = mysqli_fetch_assoc($checkUserRegisteredToPrQuery);
   return $row['user_id'];
 
 }
@@ -1714,14 +1714,14 @@ OPTIONS;
 
 function getWorkshopsList($pmcId){
 	$selectWorkshopQuery = "SELECT `workshop_id`,`workshop_name` FROM `events_workshop_details` WHERE `page_moduleComponentId`='{$pmcId}' ORDER BY `workshop_name`";
-	$selectWorkshopRes = mysql_query($selectWorkshopQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($selectWorkshopRes) > 0){
+	$selectWorkshopRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectWorkshopQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($selectWorkshopRes) > 0){
 		$selectWorkshop = <<<FORM
 			<h3>Choose Workshop</h3>
 			<form method="POST" action="./+prhead&subaction=viewWorkshopDetails">
 				<select name='workshopId' id='workshopId'>
 FORM;
-		while($workshopList = mysql_fetch_assoc($selectWorkshopRes)){
+		while($workshopList = mysqli_fetch_assoc($selectWorkshopRes)){
 			$selectWorkshop.=<<<DROPDOWN
 			<option value="{$workshopList['workshop_id']}">{$workshopList['workshop_name']}</option>	
 DROPDOWN;
@@ -1746,8 +1746,8 @@ SCRIPT;
 	}
 
 	$checkParticipantsQuery = "SELECT `user_id` FROM `events_workshop_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `workshop_id`='{$workshopId}' LIMIT 1";
-	$checkParticipantsRes = mysql_query($checkParticipantsQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($checkParticipantsRes) == 0){
+	$checkParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($checkParticipantsRes) == 0){
 		//Show FileUpload Details
 		$fileUploadableField=getFileUploadField('fileUploadField',"events");
 
@@ -1792,27 +1792,27 @@ function displayWorkshopParticipants($pmcId,$workshopId){
 	$selectParticipantsQuery = "SELECT `events_workshop_participants`.`user_id`,`events_workshop_participants`.`user_team_id` FROM `events_workshop_participants` WHERE `events_workshop_participants`.`page_moduleComponentId`='{$pmcId}' 
 				AND `events_workshop_participants`.`workshop_id`='{$workshopId}' AND `events_workshop_participants`.`user_id` ORDER BY `events_workshop_participants`.`user_team_id`";
 //	return $selectParticipantsQuery;
-	$selectParticipantsRes = mysql_query($selectParticipantsQuery) or displayerror(mysql_error());
+	$selectParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	$participantsTable.=<<<TABLE
 				$smarttable<table id='participants_table' class='display' width='100%' border='1'><thead><tr><th>Team Id</th><th>FID</th><th>Name</th><th>College</th><th>Phone No.</th><th>Options</th><th>Print</th></tr></thead>
 TABLE;
-	while($participant = mysql_fetch_assoc($selectParticipantsRes)){
+	while($participant = mysqli_fetch_assoc($selectParticipantsRes)){
 		$editRowId = "";
 		$participantNameQuery = "SELECT `".MYSQL_DATABASE_PREFIX."users`.`user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$participant['user_id']}'";
-		$participantNameRes = mysql_query($participantNameQuery) or displayerror(mysql_error());
+		$participantNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
         if($participant['user_id']>20000&&$participant['user_id']<30000)
             $rep = $participant['user_id']+180000;
         else
             $rep=$participant['user_id'];
-		$participantsTable.="<tr id='partRow{$participant['user_id']}'><td>".$participant['user_team_id']."</td><td>".$rep."</td><td><span class='userDataDisp{$participant['user_id']}'>".mysql_result($participantNameRes, 0)."</span><input type='text' class='userDataEditVal{$participant['user_id']}' value='".mysql_result($participantNameRes, 0)."' style='display:none'></td>";
+		$participantsTable.="<tr id='partRow{$participant['user_id']}'><td>".$participant['user_team_id']."</td><td>".$rep."</td><td><span class='userDataDisp{$participant['user_id']}'>".mysqli_result($participantNameRes,  0)."</span><input type='text' class='userDataEditVal{$participant['user_id']}' value='".mysqli_result($participantNameRes,  0)."' style='display:none'></td>";
 		$editRowId.='-1,';
 		$phNoFormId = retPnoneNoFormId();
 		$collFormId = retCollFormId();
 		$otherCollFormId = retOtherCollFormId();
 		$participantsDetailsQuery = "SELECT `form_elementid`,`form_elementdata` FROM `form_elementdata` WHERE `page_moduleComponentId`='{retglobalPmcId()}' AND `user_id`='{$participant['user_id']}' AND `form_elementid` IN ($phNoFormId,$collFormId) ORDER BY `form_elementid`";
 		//1
-		$participantsDetailsRes = mysql_query($participantsDetailsQuery) or displayerror(mysql_error());
-		while($userDetails = mysql_fetch_assoc($participantsDetailsRes)){
+		$participantsDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $participantsDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		while($userDetails = mysqli_fetch_assoc($participantsDetailsRes)){
 			if($userDetails['form_elementid'] == $phNoFormId){
 				$phNoId = $userDetails['form_elementid'];
 				$phNo = $userDetails['form_elementdata'];
@@ -1822,8 +1822,8 @@ TABLE;
 				$collName = $userDetails['form_elementdata'];
 				if($collName == "Others"){
 					$getCollNameQuery = "SELECT `form_elementdata`,`form_elementid` FROM `form_elementdata` WHERE `form_elementid`='{$otherCollFormId}' AND `page_modulecomponentid`='{retglobalPmcId()}' AND `user_id`='{$participant['user_id']}'";
-					$getCollNameRes = mysql_query($getCollNameQuery) or displayerror(mysql_error());
-					while($otherCollDetails = mysql_fetch_assoc($getCollNameRes)){
+					$getCollNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getCollNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+					while($otherCollDetails = mysqli_fetch_assoc($getCollNameRes)){
 						$collNameId = $otherCollDetails['form_elementid'];
 						$collName = $otherCollDetails['form_elementdata'];
 					}
@@ -1873,10 +1873,10 @@ function syncExcelFileWorkshop($pmcId,$workshopId,$fileLoc){
 			}
 			if(!empty($excelData[$i][$j])){
 				$checkDuplicateQuery = "SELECT `user_id` FROM `events_workshop_participants` WHERE `page_moduleComponentId`='{$pmcId}' AND `workshop_id`='{$workshopId}' AND `user_id`='{$userPid}'";
-				$checkDuplicateRes = mysql_query($checkDuplicateQuery) or displayerror(mysql_error());
-				if(mysql_num_rows($checkDuplicateRes) == 0){
+				$checkDuplicateRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkDuplicateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_num_rows($checkDuplicateRes) == 0){
 					$saveUserIdQuery = "INSERT INTO `events_workshop_participants`(`page_moduleComponentId`,`workshop_id`,`user_id`,`user_team_id`) VALUES('{$pmcId}','{$workshopId}','{$userPid}','{$i}')";
-					$saveUserIdRes = mysql_query($saveUserIdQuery) or displayerror(mysql_error());
+					$saveUserIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $saveUserIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				}
 			}
 		}
@@ -1895,13 +1895,13 @@ function editWorkshopParticipant($gotoaction,$pmcId,$workshopId,$formId,$userId,
 		$insertEditedRowRes = mysql_query($insertEditedRowQuery) or displayerror(mysql_error());*/
 		if($rowIdArray[$i] == -1){
 			$editNameQuery = "UPDATE `".MYSQL_DATABASE_PREFIX."users` SET `user_fullname`='{$rowValueArray[$i]}' WHERE `user_id`='{$userId}'";
-			$editNameRes = mysql_query($editNameQuery) or displayerror(mysql_error());
+			$editNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $editNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		}
 		else{
 			$editValuesQuery = "UPDATE `form_elementdata` SET `form_elementdata`='{$rowValueArray[$i]}' 
 					WHERE `user_id`='{$userId}' AND `form_elementid`='{$rowIdArray[$i]}' AND `page_moduleComponentId`='{retglobalPmcId()}'";
 					//3
-			$editValuesRes = mysql_query($editValuesQuery) or displayerror(mysql_error());
+			$editValuesRes = mysqli_query($GLOBALS["___mysqli_ston"], $editValuesQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		}
 		$updatedRow.="<td><span class='userDataDisp{$userId}'>".$rowValueArray[$i]."</span><input type='text' class='userDataEditVal{$userId}' value='{$rowValueArray[$i]}' style='display:none'></td>";
 	}
@@ -1927,8 +1927,8 @@ BUTTON;
 
 function displayQA($pmcid){
 	$selectEventQuery = "SELECT DISTINCT `event_name` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcid}' AND `event_id` NOT IN (SELECT `event_id` FROM `events_locked` WHERE `page_moduleComponentId` = '{$pmcid}') ORDER BY `event_name`";
-	$selectEventRes = mysql_query($selectEventQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($selectEventRes) > 0){
+	$selectEventRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectEventQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($selectEventRes) > 0){
 	$gotoaction='qa';
 	$selectEvent=searchParticipant($gotoaction,$pmcId,1);
 		$selectEvent.= <<<FORM
@@ -1936,10 +1936,10 @@ function displayQA($pmcid){
 			<form method="POST" action="./+qa&subaction=viewEvent">
 				<select name='eventId' id='eventId'>
 FORM;
-		while($eventList = mysql_fetch_assoc($selectEventRes)){
+		while($eventList = mysqli_fetch_assoc($selectEventRes)){
 		  $selectIdQuery = "SELECT `event_id` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcid}' AND `event_name`='{$eventList['event_name']}' LIMIT 1";
-		  $selectIdRes = mysql_query($selectIdQuery) or displayerror(mysql_error());
-		  $eventId = mysql_result($selectIdRes,0);
+		  $selectIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		  $eventId = mysqli_result($selectIdRes, 0);
 			$selectEvent.=<<<DROPDOWN
 			<option value="{$eventId}">{$eventList['event_name']}</option>	
 DROPDOWN;
@@ -1958,7 +1958,7 @@ return $selectEvent;
 
 function editParticipantRank($gotoaction,$pmcId,$eventId,$userId,$newRank){
 	$updateRankQuery = "UPDATE `events_result` SET `user_rank` = '{$newRank}' WHERE `page_moduleComponentId`='{$pmcId}' AND `user_id`='{$userId}' AND `event_id`='{$eventId}'";
-	$updateRankRes = mysql_query($updateRankQuery) or displayerror(mysql_error());
+	$updateRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $updateRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	return $newRank;
 }
 
@@ -1969,8 +1969,8 @@ function editParticipantRank($gotoaction,$pmcId,$eventId,$userId,$newRank){
 
 function qaHeadOptions($pmcId){
 	$selectEventQuery = "SELECT DISTINCT `event_name` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcId}' ORDER BY `event_name`";
-	$selectEventRes = mysql_query($selectEventQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($selectEventRes) > 0){
+	$selectEventRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectEventQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($selectEventRes) > 0){
 	
  $gotoaction='qahead';
 $selectEvent=searchParticipant($gotoaction,$pmcId,1);	
@@ -1979,10 +1979,10 @@ $selectEvent .= <<<FORM
 			<form method="POST" action="./+qahead&subaction=viewEvent">
 				<select name='eventId'>
 FORM;
-		while($eventList = mysql_fetch_assoc($selectEventRes)){
+		while($eventList = mysqli_fetch_assoc($selectEventRes)){
 		  $selectEventIdQuery = "SELECT `event_id` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_name`='{$eventList['event_name']}' LIMIT 1";
-		  $selectEventIdRes = mysql_query($selectEventIdQuery) or displayerror(mysql_error());
-		  $eventId = mysql_result($selectEventIdRes,0);
+		  $selectEventIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectEventIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		  $eventId = mysqli_result($selectEventIdRes, 0);
 			$selectEvent.=<<<DROPDOWN
 			<option value="{$eventId}">{$eventList['event_name']}</option>	
 DROPDOWN;
@@ -2001,17 +2001,17 @@ function displayPR($gotoaction,$pmcId){
 	$selectLockedEventsQuery = "SELECT DISTINCT `events_details`.`event_name` FROM `events_details` INNER JOIN `events_locked` 
 		ON `events_locked`.`event_id` = `events_details`.`event_id` AND `events_locked`.`page_moduleComponentId` = `events_details`.`page_moduleComponentId` 
 		AND `events_details`.`page_moduleComponentId` = '{$pmcId}' ORDER BY `event_name`";
-	$selectLockedEventsRes = mysql_query($selectLockedEventsQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($selectLockedEventsRes) > 0){
+	$selectLockedEventsRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectLockedEventsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($selectLockedEventsRes) > 0){
 		$selectEvent = <<<FORM
 			<h3>Choose Event</h3>
 			<form method="POST" action="./+{$gotoaction}&subaction=viewEvent">
 				<select name='eventId'>
 FORM;
-		while($eventList = mysql_fetch_assoc($selectLockedEventsRes)){
+		while($eventList = mysqli_fetch_assoc($selectLockedEventsRes)){
 		  $selectEventIdQuery = "SELECT `event_id` FROM `events_details` WHERE `page_moduleComponentId`='{$pmcId}' AND `event_name`='{$eventList['event_name']}' LIMIT 1";
-		  $selectEventIdRes = mysql_query($selectEventIdQuery) or displayerror(mysql_error());
-		  $eventId = mysql_result($selectEventIdRes,0);
+		  $selectEventIdRes = mysqli_query($GLOBALS["___mysqli_ston"], $selectEventIdQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		  $eventId = mysqli_result($selectEventIdRes, 0);
 			$selectEvent.=<<<DROPDOWN
 			<option value="{$eventId}">{$eventList['event_name']}</option>	
 DROPDOWN;
@@ -2048,14 +2048,14 @@ function getUserDetails($gotoaction,$pmcId,$userBookletId){
 	else
 		$userId = $userBookletId;
 	$getUserDetailsQuery = "SELECT * FROM `events_participants` WHERE `user_pid`='{$userId}' AND `page_moduleComponentId`='{$pmcId}' AND `event_id` IN(SELECT `event_id` FROM `events_locked` WHERE `page_moduleComponentId`='{$pmcId}')";
-	$getUserDetailsRes = mysql_query($getUserDetailsQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($getUserDetailsRes) == 0)
+	$getUserDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($getUserDetailsRes) == 0)
 		displayerror("No info found.");
 	else{
 
 		$getUserNameQuery = "SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$userId}'";
-		$getUserNameRes = mysql_query($getUserNameQuery) or displayerror(mysql_error());
-		$userEventListTable.="<br/><h4>".mysql_result($getUserNameRes,0)."</h4><br/>";
+		$getUserNameRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$userEventListTable.="<br/><h4>".mysqli_result($getUserNameRes, 0)."</h4><br/>";
 		$userEventListTable.=<<<FORM
 			<form method='post' action='./+{$gotoaction}&subaction=printUserCerti'>
 				<input type='hidden' value='{$userId}' name='userId'/>
@@ -2063,11 +2063,11 @@ function getUserDetails($gotoaction,$pmcId,$userBookletId){
 			</form>
 FORM;
 		$userEventListTable.="$smarttable<table id='user_table' class='display' width='100%' border='1'><thead><th>User FID</th><th>Event Name</th><th>User Rank</th></thead>";
-		while($userEvent = mysql_fetch_assoc($getUserDetailsRes)){
+		while($userEvent = mysqli_fetch_assoc($getUserDetailsRes)){
 			$eventName = getEventName($pmcId,$userEvent['event_id']);
 			$getUserRankQuery = "SELECT `user_rank` FROM `events_result` WHERE `page_moduleComponentId`='{$pmcId}' AND `user_id`='{$userId}' AND `event_id`='{$userEvent['event_id']}'";
-			$getUserRankRes = mysql_query($getUserRankQuery) or displayerror(mysql_error());
-			$userRank = mysql_result($getUserRankRes,0);
+			$getUserRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$userRank = mysqli_result($getUserRankRes, 0);
 			$userEventListTable .= "<tr><td>".$userId."</td><td>".$eventName."</td><td>".$userRank."</td></tr>";
 		}
 		$userEventListTable.="</table>";
@@ -2082,13 +2082,13 @@ function printUserCerti($pmcId,$userId){
 	require_once("$sourceFolder/$moduleFolder/events/html2pdf/html2pdf.class.php");	
 	require_once("$sourceFolder/$moduleFolder/events/events_certi_image2.php");
 	$getUserDetailsQuery = "SELECT * FROM `events_participants` WHERE `user_pid`='{$userId}' AND `page_moduleComponentId`='{$pmcId}'";
-	$getUserDetailsRes = mysql_query($getUserDetailsQuery) or displayerror(mysql_error());
+	$getUserDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	$certiImagePage="";
-	if(mysql_num_rows($getUserDetailsRes) != 0){
-		while($userEvent = mysql_fetch_assoc($getUserDetailsRes)){
+	if(mysqli_num_rows($getUserDetailsRes) != 0){
+		while($userEvent = mysqli_fetch_assoc($getUserDetailsRes)){
 			$getUserRankQuery = "SELECT `user_rank` FROM `events_result` WHERE `page_moduleComponentId`='{$pmcId}' AND `user_id`='{$userId}' AND `event_id`='{$userEvent['event_id']}'";
-			$getUserRankRes = mysql_query($getUserRankQuery) or displayerror(mysql_error());
-			$userRank = mysql_result($getUserRankRes,0);
+			$getUserRankRes = mysqli_query($GLOBALS["___mysqli_ston"], $getUserRankQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$userRank = mysqli_result($getUserRankRes, 0);
 			$certiImagePage.=generateCerti('event',$userEvent['event_id'],$pmcId,$userId,$userRank);
 		}
 	}
@@ -2109,9 +2109,9 @@ OPTION;
 
 function deleteParticipant($pmcId,$userId,$eventId){
   $deleteParticipantQuery = "DELETE FROM `events_participants` WHERE `user_pid`='{$userId}' AND `event_id`='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-  $deleteParticipantRes = mysql_query($deleteParticipantQuery) or displayerror(mysql_error());
+  $deleteParticipantRes = mysqli_query($GLOBALS["___mysqli_ston"], $deleteParticipantQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $deleteParticipantResultQuery = "DELETE FROM `events_result` WHERE `event_id`='{$eventId}' AND `user_id`='{$userId}' AND `page_moduleComponentId`='{$pmcId}'";
-  $deleteParticipantResultRes = mysql_query($deleteParticipantResultQuery) or displayerror(mysql_error());
+  $deleteParticipantResultRes = mysqli_query($GLOBALS["___mysqli_ston"], $deleteParticipantResultQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $scriptFolder = "$urlRequestRoot/$cmsFolder/$moduleFolder/events";
   $eventForm = <<<FORM
     <script src="$scriptFolder/events.js"></script>
@@ -2171,9 +2171,9 @@ return $searchParticipantForm;
 function deleteEventQa($pmcId,$eventId){
   $scriptFolder = "$urlRequestRoot/$cmsFolder/$moduleFolder/events";
   $deleteEventParticipantsQuery = "DELETE FROM `events_participants` WHERE `event_id`='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-  $deleteEventParticipantsRes = mysql_query($deleteEventParticipantsQuery) or displayerror(mysql_error());
+  $deleteEventParticipantsRes = mysqli_query($GLOBALS["___mysqli_ston"], $deleteEventParticipantsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $deleteEventResultQuery = "DELETE FROM `events_result`WHERE `event_id`='{$eventId}' AND `page_moduleComponentId`='{$pmcId}'";
-  $deleteEventResultRes = mysql_query($deleteEventResultQuery) or displayerror(mysql_error());
+  $deleteEventResultRes = mysqli_query($GLOBALS["___mysqli_ston"], $deleteEventResultQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $eventForm = <<<FORM
     <script src="$scriptFolder/events.js"></script>
     <script src="$scriptFolder/jquery.js"></script>

--- a/cms/modules/events/events_forms.php
+++ b/cms/modules/events/events_forms.php
@@ -82,11 +82,11 @@ require_once("$sourceFolder/$moduleFolder/events/googleMapsConfig.php");
 
 //query to find event
 $findQuery="SELECT * FROM `events_details` WHERE `event_id`={$eid} AND `page_moduleComponentId`={$pmcid};";
-$insertRes=mysql_query($findQuery) or displayerror(mysql_error());
-$row=mysql_fetch_array($insertRes);
+$insertRes=mysqli_query($GLOBALS["___mysqli_ston"], $findQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+$row=mysqli_fetch_array($insertRes);
 
 $query="SELECT * FROM `events_details` WHERE `event_Id`={$eid} AND `page_moduleComponentId={$pcmid}";
-mysql_query($query);
+mysqli_query($GLOBALS["___mysqli_ston"], $query);
 
 $startTime=substr($row[event_start_time], 0, 5);
 $endTime=substr($row[event_end_time], 0, 5);
@@ -174,8 +174,8 @@ $addForm=<<<FORM
 				<tr><th><label for="eventName">Event name</label></th>        
 				<td><select id="eventName">
 FORM;
-				$array=mysql_query("SELECT `event_name` FROM `events_details`");                
-				while($row = mysql_fetch_assoc($array)) {
+				$array=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `event_name` FROM `events_details`");                
+				while($row = mysqli_fetch_assoc($array)) {
 				$addForm.="<option value={$row['event_name']}>{$row['event_name']}</option>";
 				}
 $addForm.=<<<FORM
@@ -184,8 +184,8 @@ $addForm.=<<<FORM
 				<tr><th><label for="procurementName">Procurement name</label></th>        
 				<td><select id="procurementName">
 FORM;
-				$array=mysql_query("SELECT `procurement_name` FROM `events_procurements`");
-				while($row = mysql_fetch_assoc($array)) {
+				$array=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `procurement_name` FROM `events_procurements`");
+				while($row = mysqli_fetch_assoc($array)) {
 				$addForm.="<option value={$row['procurement_name']}>{$row['procurement_name']}</option>";
 				}
 $addForm.=<<<FORM
@@ -241,8 +241,8 @@ $addForm=<<<FORM
                 <tr><th><label for="eventName">Event name</label></th>        
                 <td><select id="eventName">
 FORM;
-                $array=mysql_query("SELECT `event_name` FROM `events_details`");                
-                while($row = mysql_fetch_assoc($array)) {
+                $array=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `event_name` FROM `events_details`");                
+                while($row = mysqli_fetch_assoc($array)) {
                 $addForm.="<option value={$row['event_name']}>{$row['event_name']}</option>";
                 }
 $addForm.=<<<FORM
@@ -251,8 +251,8 @@ $addForm.=<<<FORM
                 <tr><th><label for="procurementName">Procurement name</label></th>        
                 <td><select id="procurementName">
 FORM;
-                $array=mysql_query("SELECT `procurement_name` FROM `events_procurements`");
-                while($row = mysql_fetch_assoc($array)) {
+                $array=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `procurement_name` FROM `events_procurements`");
+                while($row = mysqli_fetch_assoc($array)) {
                 $addForm.="<option value={$row['procurement_name']}>{$row['procurement_name']}</option>";
                 }
 $addForm.=<<<FORM

--- a/cms/modules/faculty.lib.php
+++ b/cms/modules/faculty.lib.php
@@ -53,11 +53,11 @@ class faculty implements module, fileuploadable {
 		if(isset($_POST['templateChange'])){
 		  $newTemplate=escape($_POST['template']);
 			$chkTemplateExistsQuery = "SELECT `template_name` FROM `faculty_template` WHERE `template_id`='$newTemplate'";
-			$chkTemplateExistsResult = mysql_query($chkTemplateExistsQuery);
-			if(mysql_num_rows($chkTemplateExistsResult)>0){
+			$chkTemplateExistsResult = mysqli_query($GLOBALS["___mysqli_ston"], $chkTemplateExistsQuery);
+			if(mysqli_num_rows($chkTemplateExistsResult)>0){
 				$changeQuery = "Update `faculty_module` SET `templateId`=$newTemplate";
-				$changeResult = mysql_query($changeQuery);
-				if (mysql_affected_rows() != 1)
+				$changeResult = mysqli_query($GLOBALS["___mysqli_ston"], $changeQuery);
+				if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 					displayerror("Unable to update. Try again after some time.");
 				else
 					displayinfo("Successfully updated template");
@@ -74,9 +74,9 @@ class faculty implements module, fileuploadable {
 			if(isset($_GET['templateEdit']))
 				$template=escape($_GET['template']);
 			$chkTemplateExistsQuery = "SELECT `template_name` FROM `faculty_template` WHERE `template_id`='$template'";
-			$chkTemplateExistsResult = mysql_query($chkTemplateExistsQuery);
-			if(mysql_num_rows($chkTemplateExistsResult)>0){
-				$templateName = mysql_fetch_array($chkTemplateExistsResult);
+			$chkTemplateExistsResult = mysqli_query($GLOBALS["___mysqli_ston"], $chkTemplateExistsQuery);
+			if(mysqli_num_rows($chkTemplateExistsResult)>0){
+				$templateName = mysqli_fetch_array($chkTemplateExistsResult);
 				require_once("$sourceFolder/$moduleFolder/faculty/template_edit.php");
 				$editTemplateForm = templateDesc($template,$templateName[0]);
 			}
@@ -85,20 +85,20 @@ class faculty implements module, fileuploadable {
 		}
 		// Get Selected Template for Page Start
 		$selectedTemplateQuery = "SELECT `templateId` FROM `faculty_module` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-		$selectedTemplateResult = mysql_query($selectedTemplateQuery) or displayerror("Error in getting Faculty Settings");
-		$selectedTemplate = mysql_fetch_row($selectedTemplateResult);	
+		$selectedTemplateResult = mysqli_query($GLOBALS["___mysqli_ston"], $selectedTemplateQuery) or displayerror("Error in getting Faculty Settings");
+		$selectedTemplate = mysqli_fetch_row($selectedTemplateResult);	
 		// Get Selected Template for Page Finish
 
 		$chkDataQuery = "SELECT * FROM `faculty_data` WHERE `faculty_sectionId` IN (SELECT `template_sectionId` FROM `faculty_template` WHERE `template_id`=$selectedTemplate[0])";
-		$chkDataResult = mysql_query($chkDataQuery) or displayerror("Error in checking for data");	
-		if(mysql_num_rows($chkDataResult)>0)
+		$chkDataResult = mysqli_query($GLOBALS["___mysqli_ston"], $chkDataQuery) or displayerror("Error in checking for data");	
+		if(mysqli_num_rows($chkDataResult)>0)
 			displaywarning("This page contains some data. If you change the template, all the data will be lost!!!");
 		// Get list of templates start
 		$options="";	
 		$templateQuery = "SELECT `template_id`,`template_name` FROM `faculty_template` GROUP BY `template_id`";
-		$templateResult = mysql_query($templateQuery) or displayerror("Error in selecting Templates");
-		if(mysql_num_rows($templateResult)>0){
-		  while($templateRow=mysql_fetch_array($templateResult)){
+		$templateResult = mysqli_query($GLOBALS["___mysqli_ston"], $templateQuery) or displayerror("Error in selecting Templates");
+		if(mysqli_num_rows($templateResult)>0){
+		  while($templateRow=mysqli_fetch_array($templateResult)){
 		    if($templateRow[0]==$selectedTemplate[0])
 				  $selected = 'selected="selected"';
 				else 		
@@ -151,7 +151,7 @@ PRE;
 	    $facultyId=addslashes($facultyId);
 	    $updateFacultyDataQuery="UPDATE `faculty_data` SET `faculty_data`='{$facultyDetail}' WHERE `faculty_dataId`={$facultyId} AND ";
 	    $upDateFacultyDataQuery.="`page_moduleComponentId`={$this->moduleComponentId}";
-	    $updateFacultyDataData=mysql_query($updateFacultyDataQuery);
+	    $updateFacultyDataData=mysqli_query($GLOBALS["___mysqli_ston"], $updateFacultyDataQuery);
 	  }	
 	
 	  if((isset($_POST["updateSectionDetail"]))&&(isset($_POST["SectionDetail"])))
@@ -162,7 +162,7 @@ PRE;
 	      $facultyId=addslashes($facultyId);
 	      $updateFacultyDataQuery="UPDATE `faculty_template` SET `template_sectionName`='{$facultyDetail}' WHERE ";
 	      $updateFacultyDataQuery.="`template_sectionId`={$facultyId} AND `page_moduleComponentId`={$this->moduleComponentId}";
-	      $updateFacultyDataData=mysql_query($updateFacultyDataQuery);	
+	      $updateFacultyDataData=mysqli_query($GLOBALS["___mysqli_ston"], $updateFacultyDataQuery);	
 	    }
 	
 	  if((isset($_POST["addFacultyData"]))&&($_POST["addFacultyData"]!="")&&(isset($_POST["sectionId"]))&&($_POST["sectionId"]!="")){
@@ -171,16 +171,16 @@ PRE;
 	    $addDetail=addslashes($_POST["addFacultyData"]);
 	    $sectionId=addslashes($sectionId);
 	    $checkMaxValReached="SELECT * FROM `faculty_template` WHERE `template_sectionId`={$sectionId}";
-	    $checkMaxValReachedQuery=mysql_query($checkMaxValReached);
-	    $maxSectionLimit=mysql_fetch_assoc($checkMaxValReachedQuery);
+	    $checkMaxValReachedQuery=mysqli_query($GLOBALS["___mysqli_ston"], $checkMaxValReached);
+	    $maxSectionLimit=mysqli_fetch_assoc($checkMaxValReachedQuery);
 	    $maxSection="SELECT * FROM `faculty_data` WHERE `faculty_sectionId`={$sectionId} AND ";
 	    $maxSection.="`page_moduleComponentId`={$this->moduleComponentId}";
-	    $maxSectionQuery=mysql_query($maxSection);
+	    $maxSectionQuery=mysqli_query($GLOBALS["___mysqli_ston"], $maxSection);
 	    
-	    if(mysql_num_rows($maxSectionQuery)<intval($maxSectionLimit['template_sectionLimit'])){
+	    if(mysqli_num_rows($maxSectionQuery)<intval($maxSectionLimit['template_sectionLimit'])){
 	      $addFacultyDetail="INSERT INTO `faculty_data` (`faculty_sectionId`,`faculty_data`,`page_moduleComponentId`) VALUES ";
 	      $addFacultyDetail.="({$sectionId},'{$addDetail}',{$this->moduleComponentId})";
-	      $addFacultyDetailQuery=mysql_query($addFacultyDetail);	
+	      $addFacultyDetailQuery=mysqli_query($GLOBALS["___mysqli_ston"], $addFacultyDetail);	
 	    }
 	    else {echo "Limit Exceeded";exit;}	
 	  }
@@ -189,7 +189,7 @@ PRE;
 	    $facultyId=intval($_POST["DeleteFacultyId"]);
 	    $facultyId=addslashes($facultyId);
 	    $deleteData="DELETE FROM `faculty_data` WHERE `page_moduleComponentId`={$this->moduleComponentId} AND `faculty_dataId`={$facultyId}";
-	    $deleteQuery=mysql_query($deleteData);
+	    $deleteQuery=mysqli_query($GLOBALS["___mysqli_ston"], $deleteData);
 	  }	
 	
 	  if((isset($_POST["facultyName"]))&&(isset($_POST["facultyEmail"]))){
@@ -197,14 +197,14 @@ PRE;
 	      $facultyName=addslashes($_POST["facultyName"]);
 	      $updateFacultyNameQuery="UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_title`='{$facultyName}' WHERE ";
 	      $updateFacultyNameQuery.="`page_modulecomponentid`={$this->moduleComponentId} AND `page_module`='faculty'";
-	      $updateFacultyNameData=mysql_query($updateFacultyNameQuery);	
+	      $updateFacultyNameData=mysqli_query($GLOBALS["___mysqli_ston"], $updateFacultyNameQuery);	
 	    }
 	
 	    if($_POST["facultyEmail"]!=""){
 	      $facultyEmail=addslashes($_POST["facultyEmail"]);
 	      $updateFacultyEmailQuery="UPDATE `faculty_module` SET `email`='{$facultyEmail}' WHERE ";
 	      $updateFacultyEmailQuery.="`page_moduleComponentId`={$this->moduleComponentId}";
-	      $updateFacultyEmailData=mysql_query($updateFacultyEmailQuery) or displayerror(mysql_error());
+	      $updateFacultyEmailData=mysqli_query($GLOBALS["___mysqli_ston"], $updateFacultyEmailQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	    }
 	  }
 	
@@ -213,8 +213,8 @@ PRE;
 	  require_once($sourceFolder."/upload.lib.php");
 	  $facultyDetail="";
 	  $getImage="SELECT * FROM `faculty_module` WHERE `page_moduleComponentId`={$this->moduleComponentId}";
-	  $getImageQuery=mysql_query($getImage);
-	  $isExistPh=mysql_fetch_assoc($getImageQuery);
+	  $getImageQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getImage);
+	  $isExistPh=mysqli_fetch_assoc($getImageQuery);
 	  $facultyDetail.=<<<IMG
 		<img src="{$isExistPh['photo']}" />
 IMG;
@@ -223,8 +223,8 @@ IMG;
 	  $facultyDetail.=getFileUploadForm($this->moduleComponentId,"faculty",'./+faculty',UPLOAD_SIZE_LIMIT,1,"facultyProfilePic").'</fieldset>';
 	  if(isset($_FILES["facultyProfilePic"])){	
 	    $checkImageExist="SELECT * FROM `faculty_module` WHERE `page_moduleComponentId`={$this->moduleComponentId}";
-	    $checkImageExistQuery=mysql_query($checkImageExist);
-	    $isExistPh=mysql_fetch_assoc($checkImageExistQuery);
+	    $checkImageExistQuery=mysqli_query($GLOBALS["___mysqli_ston"], $checkImageExist);
+	    $isExistPh=mysqli_fetch_assoc($checkImageExistQuery);
 	    if($isExistPh["photo"]!=NULL) {
 	      if(!(deleteFile($this->moduleComponentId,'faculty', $isExistPh["photo"]))) {
 		displayerror("Unable to Update");
@@ -240,7 +240,7 @@ IMG;
 	    
 	  $fileUpload=submitFileUploadForm($this->moduleComponentId,"faculty",$this->userId,UPLOAD_SIZE_LIMIT,$allowableTypes,'facultyProfilePic');
 	  $updatePhoto="UPDATE `faculty_module` SET `photo`='{$fileUpload[0]}' WHERE `page_moduleComponentId`={$this->moduleComponentId}";
-	  $updatePhotoQuery=mysql_query($updatePhoto) or displayerror(mysql_error());
+	  $updatePhotoQuery=mysqli_query($GLOBALS["___mysqli_ston"], $updatePhoto) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	  }
 	  
 	  $pageName=getPageTitle(getPageIdFromModuleComponentId("faculty",$this->moduleComponentId));
@@ -266,7 +266,7 @@ ChangeName;
 	  $templateId=getTemplateId($this->moduleComponentId);
 	  $sectionDetail=getTemplateDataFromModuleComponentId($this->moduleComponentId);
 	  
-	  while($sectionDetailArray=mysql_fetch_assoc($sectionDetail)) {
+	  while($sectionDetailArray=mysqli_fetch_assoc($sectionDetail)) {
 	    $sectionId=$sectionDetailArray['template_sectionId'];
 	    $facultyDetail.=<<<facultyName
 	      <h2>{$sectionDetailArray['template_sectionName']}
@@ -275,13 +275,13 @@ facultyName;
 	 $facultyDetail.=printFacultyDataWithLiFaculty($sectionId,$this->moduleComponentId,0);
 	 $sectionChildNode1DetailQuery="SELECT * FROM `faculty_template` WHERE `template_id`=$templateId AND ";
 	 $sectionChildNode1DetailQuery.="`template_sectionParentId`={$sectionDetailArray['template_sectionId']}";
-	 $sectionChildNode1DetailResult=mysql_query($sectionChildNode1DetailQuery);
-	 while($sectionChildNode1DetailArray=mysql_fetch_assoc($sectionChildNode1DetailResult)) {
+	 $sectionChildNode1DetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionChildNode1DetailQuery);
+	 while($sectionChildNode1DetailArray=mysqli_fetch_assoc($sectionChildNode1DetailResult)) {
 	   $facultyDetail.=printFacultyDataWithLiFaculty($sectionChildNode1DetailArray['template_sectionId'],$this->moduleComponentId,1);
 	   $sectionChildNode2DetailQuery="SELECT * FROM `faculty_template` WHERE `template_id`=$templateId AND ";
 	   $sectionChildNode2DetailQuery.="`template_sectionParentId`={$sectionChildNode1DetailArray['template_sectionId']}";
-	   $sectionChildNode2DetailResult=mysql_query($sectionChildNode2DetailQuery);
-	   while($sectionChildNode2DetailArray=mysql_fetch_assoc($sectionChildNode2DetailResult)) {
+	   $sectionChildNode2DetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionChildNode2DetailQuery);
+	   while($sectionChildNode2DetailArray=mysqli_fetch_assoc($sectionChildNode2DetailResult)) {
 	     $facultyDataChild=printFacultyDataWithLi($sectionChildNode2DetailArray['template_sectionId'],$this->moduleComponentId,1);
 	     $facultyDetail.=<<<facultyName
 	       <h4>{$facultyDataChild}</h4>
@@ -304,8 +304,8 @@ facultyName;
 	  $sectionDetail=getTemplateDataFromModuleComponentId($this->moduleComponentId);
 	  $title=getPageTitle(getPageIdFromModuleComponentId("faculty",$this->moduleComponentId));
 	  $getImage="SELECT * FROM `faculty_module` WHERE `page_moduleComponentId`={$this->moduleComponentId}";
-	  $getImageQuery=mysql_query($getImage);
-	  $isExistPh=mysql_fetch_assoc($getImageQuery);
+	  $getImageQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getImage);
+	  $isExistPh=mysqli_fetch_assoc($getImageQuery);
 	  $viewDetail.=<<<IMG
 	    <div style="text-align:center;">
 	    <img src="{$isExistPh['photo']}" />
@@ -316,7 +316,7 @@ IMG;
 	  $emailId=getEmailForFaculty($this->moduleComponentId);
 	  $ret = $render->transform("[tex]".$emailId."[/tex]");
 	  $viewDetail.="<h3 style='text-align:center;'>Email:{$ret}</h3>";
-	  while($sectionDetailArray=mysql_fetch_assoc($sectionDetail)) {
+	  while($sectionDetailArray=mysqli_fetch_assoc($sectionDetail)) {
 	    $sectionId=$sectionDetailArray['template_sectionId'];
 	    $printFacData=printFacultyData($sectionId,$this->moduleComponentId,0);
 	    if($printFacData!="")
@@ -326,17 +326,17 @@ facultyName;
 	    $viewDetail.="<br/><br/>";
 	    $sectionChildNode1DetailQuery="SELECT * FROM `faculty_template` WHERE `template_id`=$templateId AND ";
 	    $sectionChildNode1DetailQuery.="`template_sectionParentId`={$sectionDetailArray['template_sectionId']}";
-	    $sectionChildNode1DetailResult=mysql_query($sectionChildNode1DetailQuery);
+	    $sectionChildNode1DetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionChildNode1DetailQuery);
 	    $viewDetail.=$printFacData;
-	    while($sectionChildNode1DetailArray=mysql_fetch_assoc($sectionChildNode1DetailResult)) {
+	    while($sectionChildNode1DetailArray=mysqli_fetch_assoc($sectionChildNode1DetailResult)) {
 	      $facultyData=printFacultyData($sectionChildNode1DetailArray['template_sectionId'],$this->moduleComponentId,1);
 	      $viewDetail.=<<<facultyName
 		<h3>{$facultyData}</h3>
 facultyName;
 	      $sectionChildNode2DetailQuery="SELECT * FROM `faculty_template` WHERE `template_id`=$templateId AND ";
 	      $sectionChildNode2DetailQuery.="`template_sectionParentId`={$sectionChildNode1DetailArray['template_sectionId']}";
-	      $sectionChildNode2DetailResult=mysql_query($sectionChildNode2DetailQuery);
-	      while($sectionChildNode2DetailArray=mysql_fetch_assoc($sectionChildNode2DetailResult)) {
+	      $sectionChildNode2DetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionChildNode2DetailQuery);
+	      while($sectionChildNode2DetailArray=mysqli_fetch_assoc($sectionChildNode2DetailResult)) {
 		$facultyDataChild=printFacultyData($sectionChildNode2DetailArray['template_sectionId'],$this->moduleComponentId,1);
 		$viewDetail.=<<<facultyName
 		  <h4>{$facultyDataChild}</h4>
@@ -351,14 +351,14 @@ facultyName;
 
 	public function createModule($compId) {
 	  $query = "INSERT INTO `faculty_module` (`page_modulecomponentid`,`photo`,`email`,`templateId` )VALUES ('$compId',NULL,NULL,'1')";
-	  $result = mysql_query($query) or die(mysql_error() . " faculty.lib.php");
+	  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . " faculty.lib.php");
 	}
 	
 	public function deleteModule($moduleComponentId) {
 	  $deleteQuery="DELETE FROM `faculty_module` WHERE `page_moduleComponentId` = {$this->moduleComponentId}";
-	  $deleteResult=mysql_query($deleteQuery);
+	  $deleteResult=mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
 	  $deleteQuery="DELETE FROM `faculty_data` WHERE `page_moduleComponentId` = {$this->moduleComponentId}";
-	  $deleteResult=mysql_query($deleteQuery);
+	  $deleteResult=mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
 	  return true;
 	}
 

--- a/cms/modules/faculty/template_edit.php
+++ b/cms/modules/faculty/template_edit.php
@@ -21,9 +21,9 @@ function templateDesc($templateId,$templateName) {
 		$imagePath = "$urlRequestRoot/$cmsFolder/$templateFolder";
 		$sectionDesc = '';
 		$sectionQuery = "SELECT * FROM `faculty_template` WHERE `template_id`=$templateId ORDER BY `template_sectionOrder` ASC";
-		$sectionResult = mysql_query($sectionQuery) or displayerror(mysql_error());
+		$sectionResult = mysqli_query($GLOBALS["___mysqli_ston"], $sectionQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
-		while($sectionRow = mysql_fetch_array($sectionResult)) {
+		while($sectionRow = mysqli_fetch_array($sectionResult)) {
 			$sectionDesc .= convertToRow($sectionRow,$imagePath);
 		}
 		$formElementDescBody =<<<BODY
@@ -94,7 +94,7 @@ ROWSTRING;
 }
 function editSectionForm($sectionId,$templateId){
 	$availableSectionsQuery = "SELECT `template_sectionId` FROM `faculty_template` WHERE `template_id`=$templateId AND `template_sectionId` != $sectionId";
-	$availableSectionsResult = mysql_query($availableSectionsQuery) or displayerror("Unable to select available sections!!!");
+	$availableSectionsResult = mysqli_query($GLOBALS["___mysqli_ston"], $availableSectionsQuery) or displayerror("Unable to select available sections!!!");
 	
 		
 	
@@ -106,18 +106,18 @@ function editSectionForm($sectionId,$templateId){
 function getTemplateDataFromModuleComponentId($moduleComponentId)
 {
 	$templateIdQuery="SELECT `templateId` FROM `faculty_module` WHERE `page_moduleComponentId`=$moduleComponentId";
-	$templateIdResult=mysql_query($templateIdQuery) or displayerror("Unable to find required moduleComponentId");
-	$template=mysql_fetch_assoc($templateIdResult);
+	$templateIdResult=mysqli_query($GLOBALS["___mysqli_ston"], $templateIdQuery) or displayerror("Unable to find required moduleComponentId");
+	$template=mysqli_fetch_assoc($templateIdResult);
 	$templateId=$template["templateId"];
 	$sectionDetailQuery="SELECT * FROM `faculty_template` WHERE `template_id`=$templateId AND `template_sectionParentId`=0";
-	$sectionDetailResult=mysql_query($sectionDetailQuery) or displayerror("Unable to find required Template");
+	$sectionDetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDetailQuery) or displayerror("Unable to find required Template");
 	return $sectionDetailResult;
 }
 function getTemplateId($moduleComponentId)
 {
 	$templateIdQuery="SELECT `templateId` FROM `faculty_module` WHERE `page_moduleComponentId`=$moduleComponentId";
-	$templateIdResult=mysql_query($templateIdQuery) or displayerror("Unable to find required moduleComponentId");
-	$template=mysql_fetch_assoc($templateIdResult);
+	$templateIdResult=mysqli_query($GLOBALS["___mysqli_ston"], $templateIdQuery) or displayerror("Unable to find required moduleComponentId");
+	$template=mysqli_fetch_assoc($templateIdResult);
 	$templateId=$template["templateId"];
 	
 	return $templateId;
@@ -126,8 +126,8 @@ function printFacultyDataFaculty($sectionId,$moduleComponentId)
 {
 	$printData="";
 	$sectionDataQuery="SELECT * FROM `faculty_data` WHERE `faculty_sectionId`=$sectionId AND `page_moduleComponentId`=$moduleComponentId";
-	$sectionDataResult=mysql_query($sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
-	while($sectionDataArray=mysql_fetch_assoc($sectionDataResult))
+	$sectionDataResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
+	while($sectionDataArray=mysqli_fetch_assoc($sectionDataResult))
 	{
 		$printData.=<<<details
 			<div>
@@ -151,11 +151,11 @@ function printFacultyData($sectionId,$moduleComponentId,$toPrint)
 	$headPrint="";
 	$printData="";
 	$sectionDataQuery="SELECT * FROM `faculty_data` WHERE `faculty_sectionId`=$sectionId AND `page_moduleComponentId`={$moduleComponentId}";
-	$sectionDataResult=mysql_query($sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
+	$sectionDataResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
 	if($toPrint){
 		$sectionDetailQuery="SELECT * FROM `faculty_template` WHERE `template_sectionId`=$sectionId ";
-	$sectionDetailResult=mysql_query($sectionDetailQuery) or displayerror("Unable to find required Template");
-	$resultantArray=mysql_fetch_assoc($sectionDetailResult);
+	$sectionDetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDetailQuery) or displayerror("Unable to find required Template");
+	$resultantArray=mysqli_fetch_assoc($sectionDetailResult);
 	$headPrint.=<<<details
 		
 	
@@ -165,7 +165,7 @@ details;
 }
 $headPrint.='<ul style="margin-left:25px;">';
 
-	while($sectionDataArray=mysql_fetch_assoc($sectionDataResult))
+	while($sectionDataArray=mysqli_fetch_assoc($sectionDataResult))
 	{
 		$printData.=<<<details
 <li>{$sectionDataArray['faculty_data']}</li>	
@@ -184,11 +184,11 @@ function printFacultyDataWithLi($sectionId,$moduleComponentId)
 {
 	$printData="";
 	$sectionDataQuery="SELECT * FROM `faculty_data` WHERE `faculty_sectionId`=$sectionId AND `page_moduleComponentId`=$moduleComponentId";
-	$sectionDataResult=mysql_query($sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
+	$sectionDataResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
 	
 	
 	
-	while($sectionDataArray=mysql_fetch_assoc($sectionDataResult))
+	while($sectionDataArray=mysqli_fetch_assoc($sectionDataResult))
 	{
 		$printData.=<<<details
 		<li>{$sectionDataArray['faculty_data']}</li>
@@ -208,12 +208,12 @@ function printFacultyDataWithLiFaculty($sectionId,$moduleComponentId,$toPrint)
 	
 	$printData="";
 	$sectionDataQuery="SELECT * FROM `faculty_data` WHERE `faculty_sectionId`=$sectionId AND `page_moduleComponentId`=$moduleComponentId";
-	$sectionDataResult=mysql_query($sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
+	$sectionDataResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDataQuery) or displayerror("Unable to find required moduleComponentId");
 if($toPrint){
 
 	$sectionDetailQuery="SELECT * FROM `faculty_template` WHERE `template_sectionId`=$sectionId ";
-	$sectionDetailResult=mysql_query($sectionDetailQuery) or displayerror("Unable to find required Template");
-	$resultantArray=mysql_fetch_assoc($sectionDetailResult);
+	$sectionDetailResult=mysqli_query($GLOBALS["___mysqli_ston"], $sectionDetailQuery) or displayerror("Unable to find required Template");
+	$resultantArray=mysqli_fetch_assoc($sectionDetailResult);
 				$printData.=<<<details
 		
 	
@@ -231,7 +231,7 @@ details;
 	</tr>
 details;
 
-	while($sectionDataArray=mysql_fetch_assoc($sectionDataResult))
+	while($sectionDataArray=mysqli_fetch_assoc($sectionDataResult))
 	{
 		
 		$printData.=<<<details
@@ -279,8 +279,8 @@ details;
 function getEmailForFaculty($moduleComponentId)
 {
 	$moduleQuery="SELECT * FROM `faculty_module` WHERE `page_moduleComponentId`={$moduleComponentId}";
-	$moduleResult=mysql_query($moduleQuery);
-	$facultyResult=mysql_fetch_assoc($moduleResult);
+	$moduleResult=mysqli_query($GLOBALS["___mysqli_ston"], $moduleQuery);
+	$facultyResult=mysqli_fetch_assoc($moduleResult);
 	if($facultyResult["email"]) return $facultyResult["email"];
 	return "";
 }

--- a/cms/modules/form.lib.php
+++ b/cms/modules/form.lib.php
@@ -91,8 +91,8 @@ FROM `form_elementdata` d
 	JOIN `form_elementdesc` e ON (`d.page_modulecomponentid` = `e.page_modulecomponentid`
 		AND d.form_elementid = e.form_elementid )
 WHERE `d.page_modulecomponentid` = '$moduleComponentId' AND `d.user_id` = '$userId' AND `d.form_elementdata` = \"$fileName\"";
-		$uploadedResult = mysql_query($uploadedQuery) or displayerror(mysql_error() . "form.lib L:181");
-		if(mysql_num_rows($uploadedResult)>0 && getPermissions($userId, $pageId, "view"))
+		$uploadedResult = mysqli_query($GLOBALS["___mysqli_ston"], $uploadedQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "form.lib L:181");
+		if(mysqli_num_rows($uploadedResult)>0 && getPermissions($userId, $pageId, "view"))
 			return true;
 		else return false;
 	}
@@ -116,12 +116,12 @@ WHERE `d.page_modulecomponentid` = '$moduleComponentId' AND `d.user_id` = '$user
 		$formDescQuery='SELECT `form_loginrequired`, `form_expirydatetime`, (NOW() >= `form_expirydatetime`) AS `form_expired`, `form_sendconfirmation`, ' .
 				'`form_usecaptcha`, `form_allowuseredit`, `form_allowuserunregister`, `form_closelimit` ' .
 				'FROM `form_desc` WHERE `page_modulecomponentid`='."'".$this->moduleComponentId."'";
-		$formDescResult=mysql_query($formDescQuery);
+		$formDescResult=mysqli_query($GLOBALS["___mysqli_ston"], $formDescQuery);
 		if (!$formDescResult) {
-			displayerror('E69 : Invalid query: ' . mysql_error());
+			displayerror('E69 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			return '';
 		}
-		$formDescRow = mysql_fetch_assoc($formDescResult);
+		$formDescRow = mysqli_fetch_assoc($formDescResult);
 
 		if($formDescRow['form_loginrequired'] == 1) {
 			if($this->userId <= 0) {
@@ -145,7 +145,7 @@ WHERE `d.page_modulecomponentid` = '$moduleComponentId' AND `d.user_id` = '$user
 		}
 		if($formDescRow['form_closelimit']!= '-1'){
 			$usersRegisteredQuery = " SELECT COUNT( * ) FROM `form_regdata` WHERE `page_modulecomponentid` ='".$this->moduleComponentId."'";
-			$usersRegisteredResult = mysql_fetch_array(mysql_query($usersRegisteredQuery));
+			$usersRegisteredResult = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], $usersRegisteredQuery));
 			if(($usersRegisteredResult[0]>=$formDescRow['form_closelimit'])&&(!verifyUserRegistered($this->moduleComponentId,$this->userId))){
 				displayerror('Form registration limit has been reached.');
 				return '';	
@@ -178,24 +178,24 @@ WHERE `d.page_modulecomponentid` = '$moduleComponentId' AND `d.user_id` = '$user
 	 */
 	public static function getRegisteredUserArray($moduleComponentId) {
 		$userQuery = "SELECT `user_id` FROM `form_regdata` WHERE `page_modulecomponentid` = '$moduleComponentId'";
-		$userResult = mysql_query($userQuery);
+		$userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userQuery);
 		$registeredUsers = array();
-		while($userRow = mysql_fetch_row($userResult))
+		while($userRow = mysqli_fetch_row($userResult))
 			$registeredUsers[] = $userRow[0];
 		return $registeredUsers;
 	}
 
 	public static function getRegisteredUserCount($moduleComponentId) {
 		$userQuery = "SELECT COUNT(`user_id`) FROM `form_regdata` WHERE `page_modulecomponentid` = '$moduleComponentId'";
-		$userResult = mysql_query($userQuery);
-		$userRow = mysql_fetch_row($userResult);
+		$userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userQuery);
+		$userRow = mysqli_fetch_row($userResult);
 		return $userRow[0];
 	}
 
 	public static function isGroupAssociable($moduleComponentId) {
 		$validQuery = 'SELECT `form_loginrequired`, `form_allowuserunregister` FROM `form_desc` WHERE `page_modulecomponentid` = ' ."'". $moduleComponentId."'";
-		$validResult = mysql_query($validQuery);
-		$validRow = mysql_fetch_row($validResult);
+		$validResult = mysqli_query($GLOBALS["___mysqli_ston"], $validQuery);
+		$validRow = mysqli_fetch_row($validResult);
 
 		if(!$validResult || !$validRow) {
 			displayerror('Error trying to retrieve data from the database: form.lib.php:L163');
@@ -342,7 +342,7 @@ WHERE `d.page_modulecomponentid` = '$moduleComponentId' AND `d.user_id` = '$user
 	public function actionReports() {
 		 global $userId,$urlRequestRoot;
 		 $query = "SELECT `page_id`, `page_modulecomponentid` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_module`='form'";
-		 $resource = mysql_query($query);
+		 $resource = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		 $report=<<<CSS
 		  <style type="text/css">
 		  
@@ -360,7 +360,7 @@ WHERE `d.page_modulecomponentid` = '$moduleComponentId' AND `d.user_id` = '$user
 CSS;
 			$report .='<table id="reports"><tbody><tr><td>Form</td><td>No. of registrants</td></tr>'; 
 			$class = 'even';
-		 while($result = mysql_fetch_assoc($resource)) {
+		 while($result = mysqli_fetch_assoc($resource)) {
 		 	$permission = getPermissions($userId,$result[page_id],'viewRegistrant','form');
 			if($permission) {
 				$pageId = $result['page_id'];
@@ -370,8 +370,8 @@ CSS;
 				$formInfo = $parentTitle.'_'.$formTitle;
 				$formPath = getPagePath($pageId);
 				$query = "SELECT count(distinct(`user_id`)) FROM `form_regdata` WHERE `page_modulecomponentid`='$result[page_modulecomponentid]'";
-				$resource2 = mysql_query($query) ;//or die(mysql_error());
-				$result2 = mysql_fetch_row($resource2);
+				$resource2 = mysqli_query($GLOBALS["___mysqli_ston"], $query) ;//or die(mysql_error());
+				$result2 = mysqli_fetch_row($resource2);
 				
 				if(!strpos($formPath,'qaos'))
 				{
@@ -406,11 +406,11 @@ CSS;
 			"))))) AS `relevance`,	`user_email`, `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE " .
 			"`user_activated` = 1 AND (`user_email` LIKE \"%$pattern%\" OR `user_fullname` LIKE \"%$pattern%\") " .
 			"AND `user_id` NOT IN ($registeredUserArray) ORDER BY `relevance`";
-		$suggestionsResult = mysql_query($suggestionsQuery);
+		$suggestionsResult = mysqli_query($GLOBALS["___mysqli_ston"], $suggestionsQuery);
 		if(!$suggestionsResult) return $pattern;
 
 		$suggestions = array($pattern);
-		while($suggestionsRow = mysql_fetch_row($suggestionsResult)) {
+		while($suggestionsRow = mysqli_fetch_row($suggestionsResult)) {
 			$suggestions[] = $suggestionsRow[1] . ' - ' . $suggestionsRow[2];
 		}
 
@@ -421,7 +421,7 @@ CSS;
 		global $sourceFolder, $moduleFolder;
 		$query = "INSERT INTO `form_desc` (`page_modulecomponentid`, `form_heading`,`form_loginrequired`,`form_headertext`)
 					VALUES ('".$moduleComponentId."', '',1,'Coming up Soon');";
-		$result = mysql_query($query) or die(mysql_error()."form.lib L:157");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."form.lib L:157");
 		addDefaultFormElement($moduleComponentId);
 	}
 

--- a/cms/modules/form/editform.php
+++ b/cms/modules/form/editform.php
@@ -103,7 +103,7 @@ if(!defined('__PRAGYAN_CMS'))
 			if(count($updates) > 0) {
 				$updateQuery = 'UPDATE `form_desc` SET ' . join($updates, ', ') .
 				               ' WHERE `page_modulecomponentid` = \'' . $moduleCompId."'";
-				if(mysql_query($updateQuery)) {
+				if(mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery)) {
 					displayinfo("All changes in the form have been successfully saved!");
 
 				}
@@ -121,14 +121,14 @@ if(!defined('__PRAGYAN_CMS'))
 				'form_allowuserunregister,form_showuseremail, form_showuserfullname, form_showuserprofiledata, '. 
 				'form_showregistrationdate, form_showlastupdatedate, form_registrantslimit, form_closelimit ' .
 				'FROM `form_desc` WHERE `page_modulecomponentid` = \'' . $moduleCompId."'";
-		$formResult = mysql_query($formQuery);
+		$formResult = mysqli_query($GLOBALS["___mysqli_ston"], $formQuery);
 
 		$userEdit = $formHeading = $headerText = $expiryDate = $requireLogin =
 		$sendConfirmation = $useCaptcha = $userProfiledata = $userEmail = $userUnregister = 
 		$userFullname = $regDate = $lastUpdate = $footerText = '';
 
 		if($formResult) {
-			if($formResultRow = mysql_fetch_assoc($formResult)) {
+			if($formResultRow = mysqli_fetch_assoc($formResult)) {
 				$formHeading = $formResultRow['form_heading'];
 				$requireLogin = $formResultRow['form_loginrequired'] ? 'checked="checked"' : '';
 				$headerText = $formResultRow['form_headertext'];
@@ -325,9 +325,9 @@ BODY;
 		$imagePath = "$urlRequestRoot/$cmsFolder/$templateFolder";$calpath="$urlRequestRoot/$cmsFolder/$moduleFolder";
 
 		$elementsQuery = "SELECT * FROM `form_elementdesc` WHERE `page_modulecomponentid` =  '$moduleCompId' ORDER BY `form_elementrank` ASC";
-		$elementsResult = mysql_query($elementsQuery) or die(mysql_error());
+		$elementsResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementsQuery) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$elementData = '';
-		while($elementsRow = mysql_fetch_assoc($elementsResult)) {
+		while($elementsRow = mysqli_fetch_assoc($elementsResult)) {
 			$tmpElement = new FormElement();
 			$tmpElement->fromMysqlTableRow($elementsRow);
 
@@ -373,28 +373,28 @@ BODY;
 
 
 		$query = "SELECT * FROM `form_elementdesc` WHERE `form_elementrank` $compare(SELECT `form_elementrank` FROM `form_elementdesc` WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementid`='$elementId') AND `page_modulecomponentid`='$moduleCompId' AND `form_elementid`!='$elementId' ORDER BY `form_elementrank` $order LIMIT 0,1";
-		$result = mysql_query($query) or die(mysql_query());
-		if (mysql_num_rows($result) == 0) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(mysql_query());
+		if (mysqli_num_rows($result) == 0) {
 			displayerror("You cannot move up/down the first/last element in form");
 
 		} else {
-			$tempTarg = mysql_fetch_assoc($result);
+			$tempTarg = mysqli_fetch_assoc($result);
 			$query = "SELECT `form_elementrank` FROM `form_elementdesc` WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementid`='$elementId'";
-			$result = mysql_query($query) or die(mysql_query());
-			$tempSrc = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(mysql_query());
+			$tempSrc = mysqli_fetch_assoc($result);
 
 			if ($tempTarg['form_elementrank'] == $tempSrc['form_elementrank']) {
 				$query = "UPDATE `form_elementdesc` SET `form_elementrank` = `form_elementid` WHERE `page_modulecomponentid`='$tempTarg[page_modulecomponentid]'";
-				$result = mysql_query($query) or die(mysql_error());
-				if (mysql_affected_rows() > 0)
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) > 0)
 					displayinfo("Error in form element rank corrected. Please reorder them");
 				else
 					displayerror("Failed to correct error in form element ranks!");
 			} else {
 				$query = "UPDATE `form_elementdesc` SET `form_elementrank` = '$tempSrc[form_elementrank]' WHERE `page_modulecomponentid`='$tempTarg[page_modulecomponentid]' AND `form_elementid`='$tempTarg[form_elementid]'";
-				$result = mysql_query($query) or die(mysql_error());
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				$query = "UPDATE `form_elementdesc` SET `form_elementrank` = '$tempTarg[form_elementrank]' WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementid`='$elementId'";
-				$result = mysql_query($query) or die(mysql_error());
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			}
 		}
 
@@ -406,14 +406,14 @@ BODY;
 	 */
 	function deleteFormElement($moduleCompId,$elementId) {
 		$query="DELETE FROM `form_elementdesc` WHERE `page_modulecomponentid` = '$moduleCompId' AND `form_elementid`='$elementId'";
-		$resultDel=mysql_query($query);
-		if(mysql_affected_rows()>0)
+		$resultDel=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 		$query1=1;
 		else $query1=0;
 		$queryDelData="DELETE FROM `form_elementdata` WHERE `page_modulecomponentid` = '$moduleCompId' AND `form_elementid`='$elementId'";
-		$resultDelData=mysql_query($queryDelData);
-		if(!$resultDelData)	{ displayerror('Invalid query: ' . mysql_error()); 	return false; }
-		$queryAffectedRows=mysql_affected_rows();
+		$resultDelData=mysqli_query($GLOBALS["___mysqli_ston"], $queryDelData);
+		if(!$resultDelData)	{ displayerror('Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; }
+		$queryAffectedRows=mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
 		if($queryAffectedRows>0)
 		$query2=1;
 		else $query2=0;
@@ -426,8 +426,8 @@ BODY;
 	/**Adds an empty form element */
 	function addDefaultFormElement($moduleCompId) {
 		$query="SELECT MAX(`form_elementid`) FROM `form_elementdesc` WHERE `page_modulecomponentid`='$moduleCompId'";
-		$result=mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 
 		$elementId = 0;
 		if(!is_null($row[0])) {
@@ -440,13 +440,13 @@ BODY;
 				"`form_elementmorethan`, `form_elementlessthan`, `form_elementcheckint`, `form_elementtooltiptext`," .
 				"`form_elementisrequired` ,`form_elementrank`) VALUES " .
 				"('$moduleCompId', '$elementId', 'register', 'Are you sure you want to register ?', 'radio', 100, 'Yes|No' , NULL , NULL , NULL , 0, '', 0, '$elementId')";
-		$resultAdd=mysql_query($queryInsert);
+		$resultAdd=mysqli_query($GLOBALS["___mysqli_ston"], $queryInsert);
 
 
 
 
 
-		if(mysql_affected_rows()>0)
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 			return true;
 		else return false;
 	}

--- a/cms/modules/form/editformelement.php
+++ b/cms/modules/form/editformelement.php
@@ -20,8 +20,8 @@ if(!defined('__PRAGYAN_CMS'))
 										'`page_modulecomponentid` = \'' . $moduleCompId . '\' AND ' .
 										'`form_elementid` = \'' . $elementId."'";
 
-		if($elementResult = mysql_query($elementQuery)) {
-			if($elementRow = mysql_fetch_assoc($elementResult)) {
+		if($elementResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementQuery)) {
+			if($elementRow = mysqli_fetch_assoc($elementResult)) {
 				$myElement -> fromMysqlTableRow($elementRow);
 				return $myElement -> toHtmlForm('elementDataForm', $action);
 			}
@@ -37,7 +37,7 @@ if(!defined('__PRAGYAN_CMS'))
 		$myElement -> fromHtmlForm();
 		$updateQuery = $myElement -> toMysqlUpdateQuery($moduleCompId);
 
-		if(mysql_query($updateQuery)) {
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery)) {
 			return true;
 		}
 		else {

--- a/cms/modules/form/registrationformgenerate.php
+++ b/cms/modules/form/registrationformgenerate.php
@@ -66,9 +66,9 @@ if(!defined('__PRAGYAN_CMS'))
 		/// SELECT form details
 		$formQuery = 'SELECT `form_heading`, `form_headertext`, `form_footertext`, `form_usecaptcha` FROM `form_desc` WHERE ' .
 								 "`page_modulecomponentid` = '$moduleCompId'";
-		$formResult = mysql_query($formQuery);
-		if(!$formResult)	{ displayerror('E52 : Invalid query: ' . mysql_error()); 	return false; }
-		if($formRow = mysql_fetch_assoc($formResult)) {
+		$formResult = mysqli_query($GLOBALS["___mysqli_ston"], $formQuery);
+		if(!$formResult)	{ displayerror('E52 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; }
+		if($formRow = mysqli_fetch_assoc($formResult)) {
 			$body .= '<fieldset><legend><h2>' . $formRow['form_heading'] . '</h2></legend><br /><div style="text-align:center;font-size:20px;">' . $formRow['form_headertext'] . '</div><br />';
 		}
 		else {
@@ -82,7 +82,7 @@ if(!defined('__PRAGYAN_CMS'))
 		if(!$disableCaptcha && $formRow['form_usecaptcha'] == 1)
 			$body .= getCaptchaHtml();
 		$req_query = "SELECT count(*) FROM `form_elementdesc` WHERE `form_elementisrequired`=1 AND `page_modulecomponentid`='$moduleCompId'";
-		$res_req = mysql_fetch_array(mysql_query($req_query)) or displayerror("Error at registrationformgenerate.lib.php Line 85 ".mysql_error());
+		$res_req = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], $req_query)) or displayerror("Error at registrationformgenerate.lib.php Line 85 ".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		if($res_req[0]>0)
 			$body .= '<tr>'.
 				'<td colspan="2">* - Required Fields&nbsp;</td></tr>';
@@ -107,7 +107,7 @@ SCRIPT;
 	function getCaptchaHtml() {
 			global $uploadFolder, $sourceFolder, $moduleFolder, $cmsFolder, $urlRequestRoot;
 			$captcha_query = "SELECT * FROM `". MYSQL_DATABASE_PREFIX."global` WHERE `attribute` = 'recaptcha'";
-			$captcha_res = mysql_fetch_assoc(mysql_query($captcha_query));
+			$captcha_res = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], $captcha_query));
 			$recaptcha =0;			
 			if($captcha_res['value'])
 			{
@@ -116,10 +116,10 @@ SCRIPT;
 			else {
 			$recaptcha =1;
 			$query = "SELECT `value` FROM `". MYSQL_DATABASE_PREFIX ."global` WHERE `attribute`='recaptcha_public'";
-			$res = mysql_fetch_assoc(mysql_query($query));
+			$res = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], $query));
 			$public_key = $res['value']; 
 			$query = "SELECT `value` FROM `". MYSQL_DATABASE_PREFIX ."global` WHERE `attribute`='recaptcha_private'";
-			$res = mysql_fetch_assoc(mysql_query($query));
+			$res = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], $query));
 			$private_key = $res['value'];
 			if(($public_key==NULL)||($private_key==NULL))
 				$recaptcha = 0;
@@ -157,10 +157,10 @@ SCRIPT;
 		if(verifyUserRegistered($moduleCompId,$userId)) {
 			$dataQuery = 'SELECT `form_elementid`, `form_elementdata` FROM `form_elementdata` WHERE ' .
 									 "`page_modulecomponentid` = '$moduleCompId' AND `user_id` = '$userId'";
-			$dataResult = mysql_query($dataQuery);
+			$dataResult = mysqli_query($GLOBALS["___mysqli_ston"], $dataQuery);
 			
-			if(!$dataResult)	{ displayerror('E35 : Invalid query: ' . mysql_error()); 	return false; }
-			while($dataRow = mysql_fetch_assoc($dataResult)) {
+			if(!$dataResult)	{ displayerror('E35 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; }
+			while($dataRow = mysqli_fetch_assoc($dataResult)) {
 			
 				$formValues[$dataRow['form_elementid']] = $dataRow['form_elementdata'];
 			}
@@ -168,10 +168,10 @@ SCRIPT;
 		else {
 			$dataQuery = 'SELECT `form_elementid`, `form_elementdefaultvalue` FROM `form_elementdesc` WHERE ' .
 									 "`page_modulecomponentid` = '$moduleCompId'";
-			$dataResult = mysql_query($dataQuery);
+			$dataResult = mysqli_query($GLOBALS["___mysqli_ston"], $dataQuery);
 			
-			if(!$dataResult)	{ displayerror('E132 : Invalid query: ' . mysql_error()); 	return false; }
-			while($dataRow = mysql_fetch_assoc($dataResult)) {
+			if(!$dataResult)	{ displayerror('E132 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; }
+			while($dataRow = mysqli_fetch_assoc($dataResult)) {
 			
 				$formValues[$dataRow['form_elementid']] = $dataRow['form_elementdefaultvalue'];
 			}
@@ -179,11 +179,11 @@ SCRIPT;
 	
 		$elementQuery = 'SELECT `form_elementid`, `form_elementtype` FROM `form_elementdesc` WHERE ' .
 										"`page_modulecomponentid` ='$moduleCompId' ORDER BY `form_elementrank`";
-		$elementResult = mysql_query($elementQuery);
+		$elementResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementQuery);
 		$formElements = array();
 		$jsValidationFunctions = array();
 
-		while($elementRow = mysql_fetch_row($elementResult)) {
+		while($elementRow = mysqli_fetch_row($elementResult)) {
 			$jsOutput = '';
 			if($elementRow[1] == 'file') {
 				$containsFileUploadFields = true;
@@ -206,9 +206,9 @@ SCRIPT;
 function getFormElementInputField($moduleComponentId, $elementId, $value="", &$javascriptCheckFunctions) {
 	$elementQuery = "SELECT * FROM `form_elementdesc` WHERE `page_modulecomponentid` = " .
 	                "'$moduleComponentId' AND `form_elementid` = '$elementId'";
-	$elementResult = mysql_query($elementQuery);
+	$elementResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementQuery);
 
-	if($elementResult && $elementRow = mysql_fetch_assoc($elementResult)) {
+	if($elementResult && $elementRow = mysqli_fetch_assoc($elementResult)) {
 		$htmlOutput = '<td>' . $elementRow['form_elementdisplaytext'];
 		$jsOutput = array();
 

--- a/cms/modules/form/registrationformsubmit.bak.php
+++ b/cms/modules/form/registrationformsubmit.bak.php
@@ -27,9 +27,9 @@ if(!defined('__PRAGYAN_CMS'))
 		///-------------------------Get anonymous unique negative user id---------------
 		if($userId==0) {
 			$useridQuery = "SELECT MIN(`user_id`) - 1 AS MIN FROM `form_regdata` WHERE 1";
-			$useridResult = mysql_query($useridQuery);
-			if(mysql_num_rows($useridResult)>0) {
-				$useridRow = mysql_fetch_assoc($useridResult);
+			$useridResult = mysqli_query($GLOBALS["___mysqli_ston"], $useridQuery);
+			if(mysqli_num_rows($useridResult)>0) {
+				$useridRow = mysqli_fetch_assoc($useridResult);
 				$userId = $useridRow['MIN'];
 			}
 			else
@@ -39,8 +39,8 @@ if(!defined('__PRAGYAN_CMS'))
 		///---------------------------- CAPTCHA Validation ----------------------------------
 		if(!$disableCaptcha) {
 			$captchaQuery = 'SELECT `form_usecaptcha` FROM `form_desc` WHERE `page_modulecomponentid` = ' . $moduleCompId;
-			$captchaResult = mysql_query($captchaQuery);
-			$captchaRow = mysql_fetch_row($captchaResult);
+			$captchaResult = mysqli_query($GLOBALS["___mysqli_ston"], $captchaQuery);
+			$captchaRow = mysqli_fetch_row($captchaResult);
 			if($captchaRow[0] == 1)
 				if(!submitCaptcha())
 					return false;
@@ -49,9 +49,9 @@ if(!defined('__PRAGYAN_CMS'))
 		///------------------------ CAPTCHA Validation Ends Here ----------------------------
 
 		$query="SELECT `form_elementid`,`form_elementtype` FROM `form_elementdesc` WHERE `page_modulecomponentid`=$moduleCompId";
-		$result=mysql_query($query);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$allFieldsUpdated = true;
-		while($elementRow=mysql_fetch_assoc($result)) {
+		while($elementRow=mysqli_fetch_assoc($result)) {
 			$type = $elementRow['form_elementtype'];
 			$elementId = $elementRow['form_elementid'];
 			$postVarName = "form_".$moduleCompId."_element_".$elementRow['form_elementid'];
@@ -60,10 +60,10 @@ if(!defined('__PRAGYAN_CMS'))
 			$elementDescQuery="SELECT `form_elementname`,`form_elementsize`,`form_elementtypeoptions`,`form_elementmorethan`," .
 					"`form_elementlessthan`,`form_elementcheckint`,`form_elementisrequired` FROM `form_elementdesc` " .
 					"WHERE `page_modulecomponentid`=$moduleCompId AND `form_elementid` =$elementId";
-			$elementDescResult=mysql_query($elementDescQuery);
-			if (!$elementDescResult) {	displayerror('E69 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$elementDescResult=mysqli_query($GLOBALS["___mysqli_ston"], $elementDescQuery);
+			if (!$elementDescResult) {	displayerror('E69 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-			$elementDescRow = mysql_fetch_assoc($elementDescResult);
+			$elementDescRow = mysqli_fetch_assoc($elementDescResult);
 
 			$elementName = $elementDescRow['form_elementname'];
 			$elementSize = $elementDescRow['form_elementsize'];
@@ -85,7 +85,7 @@ if(!defined('__PRAGYAN_CMS'))
 			else {
 				if (!verifyUserRegistered($moduleCompId, $userId)) {
 					$deleteelementdata_query = "DELETE FROM `form_elementdata` WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId ";
-					$deleteelementdata_result = mysql_query($deleteelementdata_query);
+					$deleteelementdata_result = mysqli_query($GLOBALS["___mysqli_ston"], $deleteelementdata_query);
 				}
 				return false;
 			}
@@ -167,12 +167,12 @@ MSG;
 		$submitData = trim($_POST[$postVarName]);
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E46 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E46 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
 		$query="SELECT * FROM `form_elementdesc` WHERE `page_modulecomponentid`=$moduleCompId AND `form_elementid` =$elementId";
-		$result=mysql_query($query);
-		$fetch=mysql_fetch_assoc($result);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$fetch=mysqli_fetch_assoc($result);
 		if($elementSize>0)
 		{
 			if(strlen($submitData) > $elementSize) {
@@ -203,16 +203,16 @@ MSG;
 				}
 			}
 		}
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".$submitData."' ".
 								"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E67 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E67 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '". $submitData ."')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E13 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E13 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 	}
@@ -229,19 +229,19 @@ MSG;
 
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E34 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E34 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '$submitData' ".
 								"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '$submitData')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 
@@ -255,8 +255,8 @@ MSG;
 
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E73 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E73 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
 		$optionNumber = $_POST[$postVarName];
 		$options = explode("|",$elementTypeOptions);
@@ -266,16 +266,16 @@ MSG;
 			return false;
 		}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '" . $options[$optionNumber] . "' ".
 								"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E28 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E28 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $options[$optionNumber] . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E90 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E90 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 
@@ -304,20 +304,20 @@ MSG;
 
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 							"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E91 : Invalid query: '.$textQuery . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E91 : Invalid query: '.$textQuery . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '$valuesString' ".
 								"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E78 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E78 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '$valuesString')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E55 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E55 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 
 		return true;
@@ -331,8 +331,8 @@ MSG;
 		}
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E64 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E64 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		$optionNumber = $_POST[$postVarName];
 		$options = explode("|",$elementTypeOptions);
 
@@ -341,16 +341,16 @@ MSG;
 			return false;
 		}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '" . $options[$optionNumber] ."' ".
 								"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E102 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E102 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $options[$optionNumber] . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E121 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E121 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 
@@ -363,19 +363,19 @@ MSG;
 		}
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E234 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E234 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".$_POST[$postVarName]."' ".
 								"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E39 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E39 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $_POST[$postVarName] . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E42 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E42 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 	}
@@ -388,17 +388,17 @@ MSG;
 
 		$existsQuery = "SELECT `form_elementdata` from `form_elementdata` WHERE `user_id` = $userId AND " .
 					"`page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-		$existsResult = mysql_query($existsQuery);
+		$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
 
 		global $sourceFolder;
 		require_once("$sourceFolder/upload.lib.php");
 		/// if the user is uploading a file with any name again, delete existing file
 		if($_FILES[$postVarName]['error'][0] != UPLOAD_ERR_NO_FILE) {
-			if(mysql_num_rows($existsResult)>0) {
-				$existsRow = mysql_fetch_array($existsResult);
+			if(mysqli_num_rows($existsResult)>0) {
+				$existsRow = mysqli_fetch_array($existsResult);
 				if(deleteFile( $moduleCompId,'form', $existsRow[0])) {
 					$deleteQuery = "DELETE FROM `form_elementdata` WHERE `form_elementid` = $elementId AND `page_modulecomponentid` = $moduleCompId";
-					mysql_query($deleteQuery);
+					mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
 				}
 			}
 		}
@@ -417,7 +417,7 @@ MSG;
 
 		$submitQuery = 'INSERT INTO `form_elementdata`(`user_id`, `page_modulecomponentid`, `form_elementid`, `form_elementdata`) ' .
 									"VALUES($userId, $moduleCompId, $elementId, '$uploadFileName')";
-		if(!mysql_query($submitQuery) || mysql_affected_rows() != 1) {
+		if(!mysqli_query($GLOBALS["___mysqli_ston"], $submitQuery) || mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1) {
 			displayerror('Error updating information in the database.');
 			return false;
 		}
@@ -433,19 +433,19 @@ MSG;
 		if(!verifyDate($_POST[$postVarName])) return false;
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 							"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E134 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E134 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".$_POST[$postVarName]."' ".
 									"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 				$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 									"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $_POST[$postVarName] . "')";
-				$textInsertResult = mysql_query($textInsertQuery);
-				if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . mysql_error()); 	return false; 	}
+				$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+				if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 			return true;
 
@@ -467,19 +467,19 @@ MSG;
 				return false;
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 							"WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId AND `form_elementid` =$elementId";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E234 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E234 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".$_POST[$postVarName]."' ".
 									"WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $_POST[$postVarName] . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 			return true;
 	}
@@ -541,35 +541,35 @@ MSG;
 
 	function insertFormView($moduleComponentId, $userId) {
 		$existsQuery = "SELECT COUNT(*) FROM `form_visits` WHERE `page_modulecomponentid` = $moduleComponentId AND `user_id` = $userId";
-		$existsResult = mysql_query($existsQuery);
-		$existsRow = mysql_fetch_row($existsResult);
+		$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
+		$existsRow = mysqli_fetch_row($existsResult);
 
 		if ($existsRow[0] == 0) {
 			$insertQuery = "INSERT INTO `form_visits`(`page_modulecomponentid`, `user_id`, `user_submitcount`, `user_firstvisit`) VALUES " .
 					"($moduleComponentId, $userId, 0, NOW())";
-			mysql_query($insertQuery);
+			mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery);
 		}
 	}
 
 	function updateFormSubmitCount($moduleComponentId, $userId) {
 		$existsQuery = "SELECT COUNT(*) FROM `form_visits` WHERE `page_modulecomponentid` = $moduleComponentId AND `user_id` = $userId";
-		$existsResult = mysql_query($existsQuery);
-		$existsRow = mysql_fetch_row($existsResult);
+		$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
+		$existsRow = mysqli_fetch_row($existsResult);
 
 		if ($existsRow[0] == 1)
 			$updateQuery = "UPDATE `form_visits` SET `user_submitcount` = `user_submitcount` + 1 WHERE `page_modulecomponentid` = $moduleComponentId AND `user_id` = $userId";
 		else
 			$updateQuery = "INSERT INTO `form_visits`(`page_modulecomponentid`, `user_id`, `user_submitcount`, `user_firstvisit`) VALUES " .
 					"($moduleComponentId, $userId, 1, NOW())";
-		mysql_query($updateQuery);
+		mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 	}
 
 	/** Register a user in form_regdata table*/
 	function registerUser($moduleCompId,$userId) {
 		$registeruser_query = "INSERT INTO `form_regdata` (`user_id` ,`page_modulecomponentid` ,`form_firstupdated` ,`form_lastupdated`) " .
 				"VALUES ('$userId', '$moduleCompId', CURRENT_TIMESTAMP , CURRENT_TIMESTAMP)";
-		$registeruser_result = mysql_query($registeruser_query);
-		if(mysql_affected_rows()>0){
+		$registeruser_result = mysqli_query($GLOBALS["___mysqli_ston"], $registeruser_query);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0){
 
 			/** ABHILASH'S EDIT FOR TUX VENTURE BEGINS HERE */
 
@@ -611,8 +611,8 @@ MSG;
 		/** ABHILASH'S EDIT FOR TUX VENTURE ENDS HERE */
 
 		$updateuser_query = "UPDATE `form_regdata` SET `form_lastupdated` = CURRENT_TIMESTAMP WHERE `user_id` =$userId AND `page_modulecomponentid` =$moduleCompId";
-		$updateuser_result = mysql_query($updateuser_query);
-		if(mysql_affected_rows()>0)
+		$updateuser_result = mysqli_query($GLOBALS["___mysqli_ston"], $updateuser_query);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 			return true;
 		else
 			return false;
@@ -621,13 +621,13 @@ MSG;
 	function verifyUserRegistered($moduleCompId,$userId) {
 		if($userId == 0)	return false;
 		$verifyuser_query = " SELECT 1 FROM `form_regdata` WHERE `user_id` =$userId AND `page_modulecomponentid` = $moduleCompId";
-		$verifyuser_result = mysql_query($verifyuser_query);
+		$verifyuser_result = mysqli_query($GLOBALS["___mysqli_ston"], $verifyuser_query);
 		if (!$verifyuser_result) {
-			displayerror('E39 : Invalid query: '.$verifyuser_query . mysql_error());
+			displayerror('E39 : Invalid query: '.$verifyuser_query . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			return false;
 		}
 		/** NOT SURE IF THIS WILL WORK. it was if(mysql_affected_rows()>0))*/
-		if(mysql_num_rows($verifyuser_result)>0)
+		if(mysqli_num_rows($verifyuser_result)>0)
 			return true;
 		else
 			return false;
@@ -639,10 +639,10 @@ MSG;
 				'	ON s.form_elementid = d.form_elementid AND s.page_modulecomponentid = d.page_modulecomponentid AND d.user_id='.$userId.' ' .
 				'   WHERE s.form_elementisrequired = 1 AND s.page_modulecomponentid = 0 ' .
 				'	AND (d.form_elementdata IS NULL OR d.form_elementdata = "")';
-		$verifyprofile_result = mysql_query($verifyprofile_query);
+		$verifyprofile_result = mysqli_query($GLOBALS["___mysqli_ston"], $verifyprofile_query);
 		if(!$verifyprofile_result)
 			return false;
-		if(mysql_num_rows($verifyprofile_result)>0)
+		if(mysqli_num_rows($verifyprofile_result)>0)
 			return false;
 		else
 			return true;
@@ -651,23 +651,23 @@ MSG;
 	function unregisterUser($moduleCompId, $userId, $silentOnSuccess = false) {
 		if(verifyUserRegistered($moduleCompId,$userId)){
 			$unregisteruser_query = "DELETE FROM `form_regdata` WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId";
-			$unregisteruser_result = mysql_query($unregisteruser_query);
+			$unregisteruser_result = mysqli_query($GLOBALS["___mysqli_ston"], $unregisteruser_query);
 
 			/// Remove any files uploaded by the user
 			$fileFieldQuery = 'SELECT `form_elementdata` FROM `form_elementdata`, `form_elementdesc` WHERE ' .
 						"`form_elementdata`.`page_modulecomponentid` = $moduleCompId AND `form_elementtype` = 'file' AND " .
 						"`form_elementdata`.`user_id` = $userId AND `form_elementdesc`.`page_modulecomponentid` = `form_elementdata`.`page_modulecomponentid` AND " .
 						"`form_elementdata`.`form_elementid` = `form_elementdesc`.`form_elementid`";
-			$fileFieldResult = mysql_query($fileFieldQuery);
+			$fileFieldResult = mysqli_query($GLOBALS["___mysqli_ston"], $fileFieldQuery);
 
 			global $sourceFolder;
 			require_once("$sourceFolder/upload.lib.php");
-			while($fileFieldRow = mysql_fetch_row($fileFieldResult)) {
+			while($fileFieldRow = mysqli_fetch_row($fileFieldResult)) {
 				deleteFile($moduleCompId, 'form', $fileFieldRow[0]);
 			}
 
 			$deleteelementdata_query = "DELETE FROM `form_elementdata` WHERE `user_id` = $userId AND `page_modulecomponentid` = $moduleCompId ";
-			$deleteelementdata_result = mysql_query($deleteelementdata_query);
+			$deleteelementdata_result = mysqli_query($GLOBALS["___mysqli_ston"], $deleteelementdata_query);
 
 			if($deleteelementdata_result) {
 				global $sourceFolder;

--- a/cms/modules/form/registrationformsubmit.php
+++ b/cms/modules/form/registrationformsubmit.php
@@ -27,9 +27,9 @@ if(!defined('__PRAGYAN_CMS'))
 		///-------------------------Get anonymous unique negative user id---------------
 		if($userId==0) {
 			$useridQuery = "SELECT MIN(`user_id`) - 1 AS MIN FROM `form_regdata` WHERE 1";
-			$useridResult = mysql_query($useridQuery);
-			if(mysql_num_rows($useridResult)>0) {
-				$useridRow = mysql_fetch_assoc($useridResult);
+			$useridResult = mysqli_query($GLOBALS["___mysqli_ston"], $useridQuery);
+			if(mysqli_num_rows($useridResult)>0) {
+				$useridRow = mysqli_fetch_assoc($useridResult);
 				$userId = $useridRow['MIN'];
 			}
 			else
@@ -39,8 +39,8 @@ if(!defined('__PRAGYAN_CMS'))
 		///---------------------------- CAPTCHA Validation ----------------------------------
 		if(!$disableCaptcha) {
 			$captchaQuery = 'SELECT `form_usecaptcha` FROM `form_desc` WHERE `page_modulecomponentid` = \'' . $moduleCompId."'";
-			$captchaResult = mysql_query($captchaQuery);
-			$captchaRow = mysql_fetch_row($captchaResult);
+			$captchaResult = mysqli_query($GLOBALS["___mysqli_ston"], $captchaQuery);
+			$captchaRow = mysqli_fetch_row($captchaResult);
 			if($captchaRow[0] == 1)
 				if(!submitCaptcha())
 					return false;
@@ -49,9 +49,9 @@ if(!defined('__PRAGYAN_CMS'))
 		///------------------------ CAPTCHA Validation Ends Here ----------------------------
 
 		$query="SELECT `form_elementid`,`form_elementtype` FROM `form_elementdesc` WHERE `page_modulecomponentid`='$moduleCompId'";
-		$result=mysql_query($query);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$allFieldsUpdated = true;
-		while($elementRow=mysql_fetch_assoc($result)) {
+		while($elementRow=mysqli_fetch_assoc($result)) {
 			$type = $elementRow['form_elementtype'];
 			$elementId = $elementRow['form_elementid'];
 			$postVarName = "form_".$moduleCompId."_element_".$elementRow['form_elementid'];
@@ -60,10 +60,10 @@ if(!defined('__PRAGYAN_CMS'))
 			$elementDescQuery="SELECT `form_elementname`,`form_elementsize`,`form_elementtypeoptions`,`form_elementmorethan`," .
 					"`form_elementlessthan`,`form_elementcheckint`,`form_elementisrequired` FROM `form_elementdesc` " .
 					"WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementid` ='$elementId'";
-			$elementDescResult=mysql_query($elementDescQuery);
-			if (!$elementDescResult) {	displayerror('E69 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$elementDescResult=mysqli_query($GLOBALS["___mysqli_ston"], $elementDescQuery);
+			if (!$elementDescResult) {	displayerror('E69 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-			$elementDescRow = mysql_fetch_assoc($elementDescResult);
+			$elementDescRow = mysqli_fetch_assoc($elementDescResult);
 
 			$elementName = $elementDescRow['form_elementname'];
 			$elementSize = $elementDescRow['form_elementsize'];
@@ -86,7 +86,7 @@ if(!defined('__PRAGYAN_CMS'))
 			else {
 				if (!verifyUserRegistered($moduleCompId, $userId)) {
 					$deleteelementdata_query = "DELETE FROM `form_elementdata` WHERE `user_id` = '$userId' AND `page_modulecomponentid` ='$moduleCompId' ";
-					$deleteelementdata_result = mysql_query($deleteelementdata_query);
+					$deleteelementdata_result = mysqli_query($GLOBALS["___mysqli_ston"], $deleteelementdata_query);
 				}
 				return false;
 			}
@@ -102,8 +102,8 @@ if(!defined('__PRAGYAN_CMS'))
 			if(!$silent)
 			{
 				$footerQuery = "SELECT `form_footertext`, `form_sendconfirmation`, `form_registrantslimit`, `form_closelimit` FROM `form_desc` WHERE `page_modulecomponentid` = '$moduleCompId'";
-				$footerResult = mysql_query($footerQuery);
-				$footerRow = mysql_fetch_row($footerResult);
+				$footerResult = mysqli_query($GLOBALS["___mysqli_ston"], $footerQuery);
+				$footerRow = mysqli_fetch_row($footerResult);
 
 				$footerText = $footerRow[0];
 				$footerTextLength = strlen($footerText);
@@ -121,7 +121,7 @@ if(!defined('__PRAGYAN_CMS'))
 				if(!$update){
 					if($footerRow[2]!='-1'){
 						$usersRegisteredQuery = " SELECT COUNT( * ) FROM `form_regdata` WHERE `page_modulecomponentid` ='".$moduleCompId."'";
-						$usersRegisteredResult = mysql_fetch_array(mysql_query($usersRegisteredQuery));
+						$usersRegisteredResult = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], $usersRegisteredQuery));
 						if($usersRegisteredResult[0]==$footerRow[3])
 							displayerror('Form registration limit has been reached.');
 						else 
@@ -169,7 +169,7 @@ if(!defined('__PRAGYAN_CMS'))
 			global $sourceFolder, $moduleFolder, $cmsFolder;
 			require_once("$sourceFolder/$moduleFolder/form/captcha/recaptcha/recaptchalib.php");
 			$query = "SELECT `value` FROM `". MYSQL_DATABASE_PREFIX ."global` WHERE `attribute`='recaptcha_private'";
-			$res = mysql_fetch_assoc(mysql_query($query));
+			$res = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], $query));
 			$private_key = $res['value'];
 			if ($_POST["recaptcha_response_field"]) {
        					$resp = recaptcha_check_answer ($private_key,
@@ -200,12 +200,12 @@ if(!defined('__PRAGYAN_CMS'))
 		$submitData = escape(trim($_POST[$postVarName]));
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E46 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E46 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
 		$query="SELECT * FROM `form_elementdesc` WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$result=mysql_query($query);
-		$fetch=mysql_fetch_assoc($result);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$fetch=mysqli_fetch_assoc($result);
 		if($elementSize>0)
 		{
 			if(strlen($submitData) > $elementSize) {
@@ -239,16 +239,16 @@ if(!defined('__PRAGYAN_CMS'))
 				}
 			}
 		}
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".$submitData."' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E67 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E67 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '". $submitData ."')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E13 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E13 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 	}
@@ -265,19 +265,19 @@ if(!defined('__PRAGYAN_CMS'))
 
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E34 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E34 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '$submitData' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '$submitData')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 
@@ -291,8 +291,8 @@ if(!defined('__PRAGYAN_CMS'))
 
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E73 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E73 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
 		$optionNumber = escape($_POST[$postVarName]);
 		$options = explode("|",$elementTypeOptions);
@@ -302,16 +302,16 @@ if(!defined('__PRAGYAN_CMS'))
 			return false;
 		}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '" . $options[$optionNumber] . "' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = '$elementId'";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E28 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E28 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $options[$optionNumber] . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E90 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E90 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 
@@ -340,20 +340,20 @@ if(!defined('__PRAGYAN_CMS'))
 
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 							"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E91 : Invalid query: '.$textQuery . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E91 : Invalid query: '.$textQuery . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '$valuesString' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = '$elementId'";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E78 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E78 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '$valuesString')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E55 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E55 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 
 		return true;
@@ -367,8 +367,8 @@ if(!defined('__PRAGYAN_CMS'))
 		}
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E64 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E64 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		$optionNumber = escape($_POST[$postVarName]);
 		$options = explode("|",escape($elementTypeOptions));
 
@@ -377,16 +377,16 @@ if(!defined('__PRAGYAN_CMS'))
 			return false;
 		}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '" . $options[$optionNumber] ."' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = '$elementId'";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E102 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E102 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . $options[$optionNumber] . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E121 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E121 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 
@@ -399,19 +399,19 @@ if(!defined('__PRAGYAN_CMS'))
 		}
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` =$userId AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E234 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E234 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".escape($_POST[$postVarName])."' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E39 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E39 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . escape($_POST[$postVarName]) . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E42 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E42 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		return true;
 	}
@@ -424,17 +424,17 @@ if(!defined('__PRAGYAN_CMS'))
 
 		$existsQuery = "SELECT `form_elementdata` from `form_elementdata` WHERE `user_id` = $userId AND " .
 					"`page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = '$elementId'";
-		$existsResult = mysql_query($existsQuery);
+		$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
 
 		global $sourceFolder;
 		require_once("$sourceFolder/upload.lib.php");
 		/// if the user is uploading a file with any name again, delete existing file
 		if($_FILES[$postVarName]['error'][0] != UPLOAD_ERR_NO_FILE) {
-			if(mysql_num_rows($existsResult)>0) {
-				$existsRow = mysql_fetch_array($existsResult);
+			if(mysqli_num_rows($existsResult)>0) {
+				$existsRow = mysqli_fetch_array($existsResult);
 				if(deleteFile( $moduleCompId,'form', $existsRow[0])) {
 					$deleteQuery = "DELETE FROM `form_elementdata` WHERE `form_elementid` = '$elementId' AND `page_modulecomponentid` = '$moduleCompId' AND `user_id`=$userId";
-					mysql_query($deleteQuery);
+					mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
 				}
 			}
 		}
@@ -453,8 +453,8 @@ if(!defined('__PRAGYAN_CMS'))
 
 		$submitQuery = 'INSERT INTO `form_elementdata`(`user_id`, `page_modulecomponentid`, `form_elementid`, `form_elementdata`) ' .
 									"VALUES('$userId', '$moduleCompId', '$elementId', '$uploadFileName')";
-		if(!mysql_query($submitQuery) || mysql_affected_rows() != 1) {
-			displayerror('Error updating information in the database.'.mysql_error());
+		if(!mysqli_query($GLOBALS["___mysqli_ston"], $submitQuery) || mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1) {
+			displayerror('Error updating information in the database.'.((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			return false;
 		}
 		return true;
@@ -476,24 +476,24 @@ if(!defined('__PRAGYAN_CMS'))
 		      return false;
 		    }
 		    $query = 'SELECT `user_id` FROM `'.MYSQL_DATABASE_PREFIX."users` WHERE `user_email` = '".$submitData."'";
-		    $result = mysql_query($query);
-		    $row = mysql_fetch_row($result);
-		    if(!mysql_num_rows($result)) {
+		    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		    $row = mysqli_fetch_row($result);
+		    if(!mysqli_num_rows($result)) {
 		      displayerror("The User with this Email Id is not registered in pragyan site.");
 		      return false;
 		    }
 		    $submitData = $row[0];
 		  }
 		  $query = 'SELECT * FROM `'.MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".$submitData."'";
-		  $result = mysql_query($query);
-		  if(!mysql_num_rows($result)) {
+		  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		  if(!mysqli_num_rows($result)) {
 		    displayerror("Not a Valid Pragyan Id.");
 		    return false;
 		  }
 		    
 		  $query="SELECT * FROM `form_elementdata` WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementdata` ='{$submitData}'";
-		  $result=mysql_query($query);
-		  if(mysql_num_rows($result)>1) {
+		  $result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		  if(mysqli_num_rows($result)>1) {
 		    displayerror("User ".$submitData." has already enrolled for this event");
 		    return false;
 		  }    
@@ -501,25 +501,25 @@ if(!defined('__PRAGYAN_CMS'))
 		}
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 						"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E46 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E46 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		
 		
 		$query="SELECT * FROM `form_elementdesc` WHERE `page_modulecomponentid`='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$result=mysql_query($query);
-		$fetch=mysql_fetch_assoc($textResult);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$fetch=mysqli_fetch_assoc($textResult);
 		
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".$submitData."' ".
 								"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = $elementId";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E67 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E67 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 		  
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '". $submitData ."')";
-		$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E13 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E13 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 		
 	
@@ -535,19 +535,19 @@ if(!defined('__PRAGYAN_CMS'))
 		if(!verifyDate(escape($_POST[$postVarName]))) return false;
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 							"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E134 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E134 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".escape($_POST[$postVarName])."' ".
 									"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = '$elementId'";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 				$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 									"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . escape($_POST[$postVarName]) . "')";
-				$textInsertResult = mysql_query($textInsertQuery);
-				if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . mysql_error()); 	return false; 	}
+				$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+				if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 			return true;
 
@@ -569,19 +569,19 @@ if(!defined('__PRAGYAN_CMS'))
 				return false;
 		$textQuery = "SELECT 1 FROM `form_elementdata` " .
 							"WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId' AND `form_elementid` ='$elementId'";
-		$textResult = mysql_query($textQuery);
-		if (!$textResult) {	displayerror('E234 : Invalid query: ' . mysql_error()); 	return false; 	}
+		$textResult = mysqli_query($GLOBALS["___mysqli_ston"], $textQuery);
+		if (!$textResult) {	displayerror('E234 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 
-		if(mysql_num_rows($textResult)>0) {
+		if(mysqli_num_rows($textResult)>0) {
 			$textUpdateQuery = "UPDATE `form_elementdata` SET `form_elementdata` = '".escape($_POST[$postVarName])."' ".
 									"WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' AND `form_elementid` = '$elementId'";
-			$textUpdateResult = mysql_query($textUpdateQuery);
-			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textUpdateResult = mysqli_query($GLOBALS["___mysqli_ston"], $textUpdateQuery);
+			if (!$textUpdateResult) {	displayerror('E12 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		} else {
 			$textInsertQuery = "INSERT INTO `form_elementdata` ( `user_id` , `page_modulecomponentid` , `form_elementid` , `form_elementdata` ) ".
 								"VALUES ( '$userId', '$moduleCompId', '$elementId', '" . escape($_POST[$postVarName]) . "')";
-			$textInsertResult = mysql_query($textInsertQuery);
-			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . mysql_error()); 	return false; 	}
+			$textInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $textInsertQuery);
+			if (!$textInsertResult) {	displayerror('E89 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; 	}
 		}
 			return true;
 	}
@@ -643,35 +643,35 @@ if(!defined('__PRAGYAN_CMS'))
 
 	function insertFormView($moduleComponentId, $userId) {
 		$existsQuery = "SELECT COUNT(*) FROM `form_visits` WHERE `page_modulecomponentid` = '$moduleComponentId' AND `user_id` = '$userId'";
-		$existsResult = mysql_query($existsQuery);
-		$existsRow = mysql_fetch_row($existsResult);
+		$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
+		$existsRow = mysqli_fetch_row($existsResult);
 
 		if ($existsRow[0] == 0) {
 			$insertQuery = "INSERT INTO `form_visits`(`page_modulecomponentid`, `user_id`, `user_submitcount`, `user_firstvisit`) VALUES " .
 					"('$moduleComponentId', '$userId', 0, NOW())";
-			mysql_query($insertQuery);
+			mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery);
 		}
 	}
 
 	function updateFormSubmitCount($moduleComponentId, $userId) {
 		$existsQuery = "SELECT COUNT(*) FROM `form_visits` WHERE `page_modulecomponentid` = '$moduleComponentId' AND `user_id` = '$userId'";
-		$existsResult = mysql_query($existsQuery);
-		$existsRow = mysql_fetch_row($existsResult);
+		$existsResult = mysqli_query($GLOBALS["___mysqli_ston"], $existsQuery);
+		$existsRow = mysqli_fetch_row($existsResult);
 
 		if ($existsRow[0] == 1)
 			$updateQuery = "UPDATE `form_visits` SET `user_submitcount` = `user_submitcount` + 1 WHERE `page_modulecomponentid` = $moduleComponentId AND `user_id` = $userId";
 		else
 			$updateQuery = "INSERT INTO `form_visits`(`page_modulecomponentid`, `user_id`, `user_submitcount`, `user_firstvisit`) VALUES " .
 					"('$moduleComponentId', '$userId', 1, NOW())";
-		mysql_query($updateQuery);
+		mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 	}
 
 	/** Register a user in form_regdata table*/
 	function registerUser($moduleCompId,$userId) {
 		$registeruser_query = "INSERT INTO `form_regdata` (`user_id` ,`page_modulecomponentid` ,`form_firstupdated` ,`form_lastupdated`) " .
 				"VALUES ('$userId', '$moduleCompId', CURRENT_TIMESTAMP , CURRENT_TIMESTAMP)";
-		$registeruser_result = mysql_query($registeruser_query);
-		if(mysql_affected_rows()>0){
+		$registeruser_result = mysqli_query($GLOBALS["___mysqli_ston"], $registeruser_query);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0){
 
 
 			global $sourceFolder;
@@ -697,8 +697,8 @@ if(!defined('__PRAGYAN_CMS'))
 		
 
 		$updateuser_query = "UPDATE `form_regdata` SET `form_lastupdated` = CURRENT_TIMESTAMP WHERE `user_id` ='$userId' AND `page_modulecomponentid` ='$moduleCompId'";
-		$updateuser_result = mysql_query($updateuser_query);
-		if(mysql_affected_rows()>0)
+		$updateuser_result = mysqli_query($GLOBALS["___mysqli_ston"], $updateuser_query);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 			return true;
 		else
 			return false;
@@ -707,13 +707,13 @@ if(!defined('__PRAGYAN_CMS'))
 	function verifyUserRegistered($moduleCompId,$userId) {
 		if($userId == 0)	return false;
 		$verifyuser_query = " SELECT 1 FROM `form_regdata` WHERE `user_id` ='$userId' AND `page_modulecomponentid` = '$moduleCompId'";
-		$verifyuser_result = mysql_query($verifyuser_query);
+		$verifyuser_result = mysqli_query($GLOBALS["___mysqli_ston"], $verifyuser_query);
 		if (!$verifyuser_result) {
-			displayerror('E39 : Invalid query: '.$verifyuser_query . mysql_error());
+			displayerror('E39 : Invalid query: '.$verifyuser_query . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			return false;
 		}
 		/** NOT SURE IF THIS WILL WORK. it was if(mysql_affected_rows()>0))*/
-		if(mysql_num_rows($verifyuser_result)>0)
+		if(mysqli_num_rows($verifyuser_result)>0)
 			return true;
 		else
 			return false;
@@ -725,10 +725,10 @@ if(!defined('__PRAGYAN_CMS'))
 				'	ON s.form_elementid = d.form_elementid AND s.page_modulecomponentid = d.page_modulecomponentid AND d.user_id=\''.$userId.'\' ' .
 				'   WHERE s.form_elementisrequired = 1 AND s.page_modulecomponentid = 0 ' .
 				'	AND (d.form_elementdata IS NULL OR d.form_elementdata = "")';
-		$verifyprofile_result = mysql_query($verifyprofile_query);
+		$verifyprofile_result = mysqli_query($GLOBALS["___mysqli_ston"], $verifyprofile_query);
 		if(!$verifyprofile_result)
 			return false;
-		if(mysql_num_rows($verifyprofile_result)>0)
+		if(mysqli_num_rows($verifyprofile_result)>0)
 			return false;
 		else
 			return true;
@@ -737,23 +737,23 @@ if(!defined('__PRAGYAN_CMS'))
 	function unregisterUser($moduleCompId, $userId, $silentOnSuccess = false) {
 		if(verifyUserRegistered($moduleCompId,$userId)){
 			$unregisteruser_query = "DELETE FROM `form_regdata` WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId'";
-			$unregisteruser_result = mysql_query($unregisteruser_query);
+			$unregisteruser_result = mysqli_query($GLOBALS["___mysqli_ston"], $unregisteruser_query);
 
 			/// Remove any files uploaded by the user
 			$fileFieldQuery = 'SELECT `form_elementdata` FROM `form_elementdata`, `form_elementdesc` WHERE ' .
 						"`form_elementdata`.`page_modulecomponentid` = '$moduleCompId' AND `form_elementtype` = 'file' AND " .
 						"`form_elementdata`.`user_id` = '$userId' AND `form_elementdesc`.`page_modulecomponentid` = `form_elementdata`.`page_modulecomponentid` AND " .
 						"`form_elementdata`.`form_elementid` = `form_elementdesc`.`form_elementid`";
-			$fileFieldResult = mysql_query($fileFieldQuery);
+			$fileFieldResult = mysqli_query($GLOBALS["___mysqli_ston"], $fileFieldQuery);
 
 			global $sourceFolder;
 			require_once("$sourceFolder/upload.lib.php");
-			while($fileFieldRow = mysql_fetch_row($fileFieldResult)) {
+			while($fileFieldRow = mysqli_fetch_row($fileFieldResult)) {
 				deleteFile($moduleCompId, 'form', $fileFieldRow[0]);
 			}
 
 			$deleteelementdata_query = "DELETE FROM `form_elementdata` WHERE `user_id` = '$userId' AND `page_modulecomponentid` = '$moduleCompId' ";
-			$deleteelementdata_result = mysql_query($deleteelementdata_query);
+			$deleteelementdata_result = mysqli_query($GLOBALS["___mysqli_ston"], $deleteelementdata_query);
 
 			if($deleteelementdata_result) {
 				global $sourceFolder;

--- a/cms/modules/form/viewregistrants.php
+++ b/cms/modules/form/viewregistrants.php
@@ -33,15 +33,15 @@ if(!defined('__PRAGYAN_CMS'))
 
 function getLastUpdateDate($moduleComponentId, $userId) {
 	$query = 'SELECT `form_lastupdated` FROM `form_regdata` WHERE `page_modulecomponentid` = \'' . $moduleComponentId . '\' AND `user_id` = \'' . $userId."'";
-	$result = mysql_query($query);
-	$row = mysql_fetch_row($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	$row = mysqli_fetch_row($result);
 	return $row[0];
 }
 
 function getRegistrationDate($moduleComponentId, $userId) {
 	$query = 'SELECT `form_firstupdated` FROM `form_regdata` WHERE `page_modulecomponentid` = \'' . $moduleComponentId . '\' AND `user_id` = \'' . $userId."'";
-	$result = mysql_query($query);
-	$row = mysql_fetch_row($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	$row = mysqli_fetch_row($result);
 	return $row[0];
 }
 
@@ -54,8 +54,8 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 					'`form_elementdata`.`page_modulecomponentid` = `form_elementdesc`.`page_modulecomponentid` AND ' .
 					'`form_elementdata`.`form_elementid` = `form_elementdesc`.`form_elementid` ' .
 					'ORDER BY `form_elementrank` ASC';
-	$elementDataResult = mysql_query($elementDataQuery) or die($elementDataQuery . ' ' . mysql_error());
-	while($elementDataRow = mysql_fetch_row($elementDataResult)) {
+	$elementDataResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementDataQuery) or die($elementDataQuery . ' ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	while($elementDataRow = mysqli_fetch_row($elementDataResult)) {
 	  //displayinfo(print_r($elementDataRow,true));
 	    $elementRow['elementid_' . $elementDataRow[1]] = $elementDataRow[0];
 		if($elementDataRow[2] == 'file') {
@@ -67,8 +67,8 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 						"`form_elementdata`.`page_modulecomponentid` = 0 AND `user_id` = '".$elementDataRow[0]."' AND " .
 						"`form_elementdata`.`page_modulecomponentid` = `form_elementdesc`.`page_modulecomponentid` AND " .
 						"`form_elementdata`.`form_elementid` = `form_elementdesc`.`form_elementid` ORDER BY `form_elementrank`";
-			$elementDataResu = mysql_query($elementDataQuery) or die($elementDataQuery . '<br />' . mysql_error());
-			while($elementDataRes = mysql_fetch_assoc($elementDataResu)) {
+			$elementDataResu = mysqli_query($GLOBALS["___mysqli_ston"], $elementDataQuery) or die($elementDataQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			while($elementDataRes = mysqli_fetch_assoc($elementDataResu)) {
 				$elementRow['form' .$elementDataRow[1].'_'. $elementDataRes['form_elementname']] = $elementDataRes['form_elementdata'];
 				if($elementDataRes['form_elementtype'] == 'file') {
 					$elementRow['form' .$elementDataRow[1].'_'. $elementDataRes['form_elementname']] = '<a href="./'.$elementDataRes['form_elementdata'].'">' . $elementDataRes['form_elementdata'] . '</a>';
@@ -76,8 +76,8 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 			}
 			if($elementDataRow[0]!='') {
 			  $userProfile = "SELECT * FROM " . MYSQL_DATABASE_PREFIX . "users WHERE `user_id` = ".$elementDataRow[0];	
-			  $userResult = mysql_query($userProfile) or displayerror(mysql_error());
-			  $res = mysql_fetch_assoc($userResult);
+			  $userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userProfile) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			  $res = mysqli_fetch_assoc($userResult);
 			  $elementRow['form' .$elementDataRow[1].'_userEmail'] = $res['user_email'];
 			  $elementRow['form' .$elementDataRow[1].'_userFullName'] = $res['user_fullname'];
 			}
@@ -94,16 +94,16 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 						"`form_elementdata`.`page_modulecomponentid` = 0 AND `user_id` = '$userId' AND " .
 						"`form_elementdata`.`page_modulecomponentid` = `form_elementdesc`.`page_modulecomponentid` AND " .
 						"`form_elementdata`.`form_elementid` = `form_elementdesc`.`form_elementid` ORDER BY `form_elementrank`";
-			$elementDataResult = mysql_query($elementDataQuery) or die($elementDataQuery . '<br />' . mysql_error());
-			while($elementDataRow = mysql_fetch_assoc($elementDataResult)) {
+			$elementDataResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementDataQuery) or die($elementDataQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			while($elementDataRow = mysqli_fetch_assoc($elementDataResult)) {
 				$elementRow['form0_' . $elementDataRow['form_elementname']] = $elementDataRow['form_elementdata'];
 				if($elementDataRow['form_elementtype'] == 'file') {
 					$elementRow['form0_' . $elementDataRow['form_elementname']] = '<a href="./'.$elementDataRow['form_elementdata'].'">' . $elementDataRow['form_elementdata'] . '</a>';
 				}
 			}
 			$userProfile = "SELECT * FROM " . MYSQL_DATABASE_PREFIX . "users WHERE `user_id` = {$userId}";	
-			$userResult = mysql_query($userProfile) or displayerror(mysql_error());
-			$res = mysql_fetch_assoc($userResult);
+			$userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userProfile) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$res = mysqli_fetch_assoc($userResult);
 			$elementRow['form0_userEmail'] = $res['user_email'];
 			$elementRow['form0_userFullName'] = $res['user_fullname'];
 	
@@ -112,8 +112,8 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 		}
 		else {
 			$elementDataQuery = 'SELECT `form_elementname` FROM `form_elementdesc` WHERE `page_modulecomponentid` = 0';
-			$elementDataResult = mysql_query($elementDataQuery);
-			while($elementDataRow = mysql_fetch_row($elementDataResult)) {
+			$elementDataResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementDataQuery);
+			while($elementDataRow = mysqli_fetch_row($elementDataResult)) {
 				$elementDataRow['form0_' . $elementDataRow['form_elementname']] = '&nbsp;';
 			}
 		}
@@ -165,8 +165,8 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 			$columns['lastupdated'] = 'Last Updated';
 		if($showUserProfileData) {
 			$profileQuery = 'SELECT `form_elementname` FROM `form_elementdesc` WHERE `page_modulecomponentid` = 0 ORDER BY `form_elementrank`';
-			$profileResult = mysql_query($profileQuery);
-			while($profileRow = mysql_fetch_row($profileResult)) {
+			$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
+			while($profileRow = mysqli_fetch_row($profileResult)) {
 				$columns['form0_' . $profileRow[0]] = $profileRow[0];
 			}
 			$columns['form0_userEmail'] = 'Email';
@@ -176,16 +176,16 @@ function generateFormDataRow($moduleCompId, $userId, $columnList, $showProfileDa
 
 		$columnQuery = 'SELECT `form_elementid`, `form_elementname` FROM `form_elementdesc` WHERE `page_modulecomponentid` = \'' .
 									 $moduleCompId . '\' ORDER BY `form_elementrank` ASC';
-		$columnResult = mysql_query($columnQuery);
+		$columnResult = mysqli_query($GLOBALS["___mysqli_ston"], $columnQuery);
 		$cnt = 0;
-		while($columnRow = mysql_fetch_assoc($columnResult)) {
+		while($columnRow = mysqli_fetch_assoc($columnResult)) {
 			$columns['elementid_' . $columnRow['form_elementid']] = $columnRow['form_elementname'];
 			$query = "SELECT `form_elementid`, `form_elementname` FROM `form_elementdesc` WHERE `page_modulecomponentid` = {$moduleCompId} AND `form_elementtype` = 'member' AND `form_elementid`={$columnRow['form_elementid']}";
-			$res = mysql_query($query) or displayerror(mysql_error());
-			if(mysql_num_rows($res)>0) {
+			$res = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			if(mysqli_num_rows($res)>0) {
 				$profileQuery = 'SELECT `form_elementname` FROM `form_elementdesc` WHERE `page_modulecomponentid` = 0 ORDER BY `form_elementrank`';
-				$profileResult = mysql_query($profileQuery);
-				while($profileRow = mysql_fetch_row($profileResult)) {
+				$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
+				while($profileRow = mysqli_fetch_row($profileResult)) {
 					$columns['form' .$columnRow['form_elementid']. '_'. $profileRow[0]] = $columnRow['form_elementname'].'_'.$profileRow[0];
 				}
 				$elementRow['form' .$columnRow['form_elementid'].'_userEmail'] = $columnRow['form_elementname'].'_'.$res['user_email'];
@@ -245,8 +245,8 @@ WHERE dat.`form_elementid` = 3 ORDER BY dat.form_elementdata
 		}
 
 
-		$userResult = mysql_query($userQuery) or die ($userQuery . ' ' . mysql_error());
-		while($userRow = mysql_fetch_row($userResult)) {
+		$userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userQuery) or die ($userQuery . ' ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		while($userRow = mysqli_fetch_row($userResult)) {
 			$users[] = $userRow[0];
 		}
 
@@ -267,13 +267,13 @@ function generateFormDataTable($moduleComponentId, $sortField, $sortOrder, $acti
 
 	$formDescQuery = 'SELECT  `form_showuseremail`, `form_showuserfullname`, `form_showregistrationdate`, `form_showlastupdatedate`, `form_showuserprofiledata`,`form_heading` FROM `form_desc` ' .
 					'WHERE `page_modulecomponentid` = \'' . $moduleComponentId."'";
-	$formDescResult = mysql_query($formDescQuery);
+	$formDescResult = mysqli_query($GLOBALS["___mysqli_ston"], $formDescQuery);
 	
 	$showUserEmail = $showUserFullName = false;
 	$showRegistrationDate = $showLastUpdateDate = true;
 	$showUserProfileData = false;
 	$formName='';
-	if($formDescRow = mysql_fetch_row($formDescResult)) {
+	if($formDescRow = mysqli_fetch_row($formDescResult)) {
 		
 		$showUserEmail = $formDescRow[0] == 1;
 		$showUserFullName = $formDescRow[1] == 1;
@@ -442,10 +442,10 @@ EDITREGISTRANTSVIEW;
 		if(verifyUserRegistered($moduleCompId,$userId)) {
 			$dataQuery = 'SELECT `form_elementid`, `form_elementdata` FROM `form_elementdata` WHERE ' .
 									 "`page_modulecomponentid` = '$moduleCompId' AND `user_id` = '$userId'";
-			$dataResult = mysql_query($dataQuery);
+			$dataResult = mysqli_query($GLOBALS["___mysqli_ston"], $dataQuery);
 			
-			if(!$dataResult)	{ displayerror('E35 : Invalid query: ' . mysql_error()); 	return false; }
-			while($dataRow = mysql_fetch_assoc($dataResult)) {
+			if(!$dataResult)	{ displayerror('E35 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; }
+			while($dataRow = mysqli_fetch_assoc($dataResult)) {
 			
 				$formValues[$dataRow['form_elementid']] = $dataRow['form_elementdata'];
 			}
@@ -453,19 +453,19 @@ EDITREGISTRANTSVIEW;
 		else {
 			$dataQuery = 'SELECT `form_elementid`, `form_elementdefaultvalue` FROM `form_elementdesc` WHERE ' .
 									 "`page_modulecomponentid` = '$moduleCompId'";
-			$dataResult = mysql_query($dataQuery);
+			$dataResult = mysqli_query($GLOBALS["___mysqli_ston"], $dataQuery);
 			
-			if(!$dataResult)	{ displayerror('E132 : Invalid query: ' . mysql_error()); 	return false; }
-			while($dataRow = mysql_fetch_assoc($dataResult)) {
+			if(!$dataResult)	{ displayerror('E132 : Invalid query: ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 	return false; }
+			while($dataRow = mysqli_fetch_assoc($dataResult)) {
 			
 				$formValues[$dataRow['form_elementid']] = $dataRow['form_elementdefaultvalue'];
 			}
 		}
 		$elementQuery = 'SELECT `form_elementid`, `form_elementtype`, `form_elementdisplaytext` FROM `form_elementdesc` WHERE ' .
 										"`page_modulecomponentid` ='$moduleCompId' ORDER BY `form_elementrank`";
-		$elementResult = mysql_query($elementQuery);
+		$elementResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementQuery);
 		$formElements = array();
-		while($elementRow = mysql_fetch_assoc($elementResult)) {
+		while($elementRow = mysqli_fetch_assoc($elementResult)) {
 				if($elementRow['form_elementtype']=='file'){
 					global $urlRequestRoot;
 					$fileLink=$formValues[$elementRow['form_elementid']];

--- a/cms/modules/forum.lib.php
+++ b/cms/modules/forum.lib.php
@@ -53,18 +53,18 @@ class forum implements module {
 	 */
 	public function getTotalPosts($userID) {
 		$q1 = "SELECT * FROM `forum_threads` WHERE `forum_thread_user_id`='$userID' AND `page_modulecomponentid`='$this->moduleComponentId'";
-		$res1 = mysql_query($q1);
-		$posts = mysql_num_rows($res1);
+		$res1 = mysqli_query($GLOBALS["___mysqli_ston"], $q1);
+		$posts = mysqli_num_rows($res1);
 		$q2 = "SELECT * FROM `forum_posts` WHERE `forum_post_user_id`='$userID' AND `page_modulecomponentid`='$this->moduleComponentId'";
-		$res2 = mysql_query($q2);
-		$posts += mysql_num_rows($res2);
+		$res2 = mysqli_query($GLOBALS["___mysqli_ston"], $q2);
+		$posts += mysqli_num_rows($res2);
 		return $posts;
 	}
 
 	public function getLastLogin($userId) {
 		$query = "SELECT `user_lastlogin` FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` = '$userId'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 		return $row[0];
 	}
 	/**
@@ -76,8 +76,8 @@ class forum implements module {
 		if ($userID == 0)
 			return 0;
 		$query = 'SELECT `user_regdate` FROM `' . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` = '$userID'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 		return $row[0];
 	}
 	public function actionForumsettings(){
@@ -108,21 +108,21 @@ class forum implements module {
 					$access_level = 0;
 					$approve = 1;
 					$q1 = "UPDATE `$table_name` SET `forum_post_approve`='$approve' WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-					$res1 = mysql_query($q1);
+					$res1 = mysqli_query($GLOBALS["___mysqli_ston"], $q1);
 					$q2 = "UPDATE `$table1_name` SET `forum_post_approve`='$approve' WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-					$res2 = mysql_query($q2);
+					$res2 = mysqli_query($GLOBALS["___mysqli_ston"], $q2);
 				}
 			else
 				{$access_level = 1;}
 			$pageId=getPageIdFromModuleComponentId("forum",$this->moduleComponentId);
 			$q = "UPDATE `$table2_name` SET `forum_moderated`='$access_level',  " .
 					"`forum_description`='$forum_description',`allow_delete_posts`='$del_post',`allow_like_posts`='$like_post' WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$res = mysql_query($q) or displayerror(mysql_error() . "Update failed L:113");
+			$res = mysqli_query($GLOBALS["___mysqli_ston"], $q) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "Update failed L:113");
 			displayinfo("Forum settings updated successfully!");
 		}
 				$query = "SELECT * FROM `$table2_name` WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$result = mysql_query($query);
-				$rows = mysql_fetch_array($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$rows = mysqli_fetch_array($result);
 				$forum_description = stripslashes($rows['forum_description']);
 				$forum_moderated = $rows['forum_moderated'];
 				$allow_delete_posts = $rows['allow_delete_posts'];
@@ -193,12 +193,12 @@ PRE;
 			if (!isset ($_GET['post_id'])) {
 				$thread_id = escape($_GET['thread_id']);
 				$query = "UPDATE `$table_name` SET `forum_post_approve`='$approval' WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$result = mysql_query($query);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			} else {
 				$thread_id = escape($_GET['forum_id']);
 				$post_id = escape($_GET['post_id']);
 				$query = "UPDATE `$table1_name` SET `forum_post_approve`='$approval' WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$result = mysql_query($query);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			}
 			if (!$result)
 				displayerror("Could not perform the desired action(approve/disapprove)!");
@@ -207,11 +207,11 @@ PRE;
 			if (!isset ($_GET['post_id'])) {
 				$thread_id = escape($_GET['thread_id']);
 				$query = "DELETE FROM `$table_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$result = mysql_query($query);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				$query1 = "DELETE FROM `forum_posts` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId'";
-				$result1 = mysql_query($query1);
+				$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 				$query2 = "DELETE FROM `forum_like` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId'";
-				$result2 = mysql_query($query2);
+				$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
 				if (!$result)
 					displayerror("Could not perform the delete operation!");
 				else
@@ -221,9 +221,9 @@ PRE;
 				$thread_id = escape($_GET['forum_id']);
 				$post_id = escape($_GET['post_id']);
 				$query1 = "DELETE FROM `forum_posts` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$result1 = mysql_query($query1);
+				$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 				$query1 = "DELETE FROM `forum_like` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$result1 = mysql_query($query1);
+				$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 				if (!$result1)
 					displayerror("Could not perform the delete operation!");
 				else
@@ -234,12 +234,12 @@ PRE;
 		if (!isset ($_GET['forum_id'])) {
 			$query = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId . "" .
 					"' AND `forum_thread_category`='general' ORDER BY `forum_thread_lastpost_date` DESC";
-			$result = mysql_query($query);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			$query1 = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId . "" .
 					"' AND `forum_thread_category`='sticky' ORDER BY `forum_thread_datetime` DESC";
-			$result1 = mysql_query($query1);
-			$num_rows = mysql_num_rows($result);
-			$num_rows1 = mysql_num_rows($result1);
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			$num_rows = mysqli_num_rows($result);
+			$num_rows1 = mysqli_num_rows($result1);
 			global $ICONS;
 			if ($result) {
 			
@@ -259,10 +259,10 @@ PRE;
 PRE;
 				if ($result1 && $num_rows1 > 0) {
 					for ($i = 1; $i <= $num_rows1; $i++) {
-						$rows = mysql_fetch_array($result1);
+						$rows = mysqli_fetch_array($result1);
 						$query2 = "SELECT `forum_post_id` FROM `$table1_name` WHERE `forum_thread_id`='" . $rows['forum_thread_id'] . "' AND `forum_post_approve`='1' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$result2 = mysql_query($query2);
-						$reply_count = mysql_num_rows($result2);
+						$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+						$reply_count = mysqli_num_rows($result2);
 						$topic = ucfirst(parseubb(parsesmileys(htmlspecialchars($rows['forum_thread_topic']))));
 						$name = ucfirst(getUserName($rows['forum_thread_user_id']));
 						$last_post_author = ucfirst(getUserName($rows['forum_thread_last_post_userid']));
@@ -297,15 +297,15 @@ PRE;
 				if ($num_rows < 1)
 					$moderate .= "<tr><td colspan=\"5\" class='forumTableRow'><strong>No Post</strong></td></tr>";
 				for ($i = 1; $i <= $num_rows; $i++) {
-					$rows = mysql_fetch_array($result);
+					$rows = mysqli_fetch_array($result);
 					if($userId>0 && ($_SESSION['last_to_last_login_datetime']<$rows['forum_thread_lastpost_date']))
 						$img_src = "thread_new.gif";
 					else
 						$img_src = "thread_hot.gif";
 
 					$query1 = "SELECT `forum_post_id` FROM `$table1_name` WHERE `forum_thread_id`='" . $rows['forum_thread_id'] . "' AND `forum_post_approve`='1'";
-					$result1 = mysql_query($query1);
-					$reply_count = mysql_num_rows($result1);
+					$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+					$reply_count = mysqli_num_rows($result1);
 					$topic = ucfirst(parseubb(parsesmileys($rows['forum_thread_topic'])));
 					$name = ucfirst(getUserName($rows['forum_thread_user_id']));
 					$last_post_author = ucfirst(getUserName($rows['forum_thread_last_post_userid']));
@@ -347,12 +347,12 @@ PRE;
 			return $moderate;
 		} else {
 			$q = "SELECT * FROM `forum_module` WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$r = mysql_query($q) or displayerror(mysql_error() . "Moderate failed L:343");
-			$r = mysql_fetch_array($r);
+			$r = mysqli_query($GLOBALS["___mysqli_ston"], $q) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "Moderate failed L:343");
+			$r = mysqli_fetch_array($r);
 			$forum_id = escape($_GET['forum_id']); //Parent Thread ID
 			$sql = "SELECT * FROM `$table_name` WHERE `forum_thread_id`='$forum_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$result1 = mysql_query($sql);
-			$rows = mysql_fetch_array($result1);
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $sql);
+			$rows = mysqli_fetch_array($result1);
 			$forum_topic = ucfirst(parseubb(parsesmileys($rows['forum_thread_topic'])));
 			$forum_detail = parseubb(parsesmileys($rows['forum_detail']));
 			$name = ucfirst(getUserName($rows['forum_thread_user_id']));
@@ -411,8 +411,8 @@ PRE;
 PRE;
 
 			$sql2 = "SELECT * FROM `$table1_name` WHERE `forum_thread_id`='$forum_id' AND `page_modulecomponentid`='$this->moduleComponentId' ORDER BY forum_post_id ASC";
-			$result2 = mysql_query($sql2);
-			while ($rows = mysql_fetch_array($result2)) {
+			$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $sql2);
+			while ($rows = mysqli_fetch_array($result2)) {
 				$count = $count + 1;
 				$post_title = ucfirst(parseubb(parsesmileys($rows['forum_post_title'])));
 				$post_content = (parseubb(parsesmileys($rows['forum_post_content'])));
@@ -441,11 +441,11 @@ PRE;
 PRE;
 			if($r['allow_like_posts'] == 1){
 					$likequery = "SELECT * from `forum_like` WHERE `forum_thread_id`='$rows[forum_thread_id]' AND `forum_post_id`='".$rows['forum_post_id']."' AND `like_status`='1' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-					$likeres = mysql_query($likequery) or displayerror(mysql_error() . "Moderate failed L:438");;
-					$likeres = mysql_num_rows($likeres);
+					$likeres = mysqli_query($GLOBALS["___mysqli_ston"], $likequery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "Moderate failed L:438");;
+					$likeres = mysqli_num_rows($likeres);
 					$dlikequery = "SELECT * from `forum_like` WHERE `forum_thread_id`='$rows[forum_thread_id]' AND `forum_post_id`='".$rows['forum_post_id']."' AND `like_status`='0' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-					$dlikeres = mysql_query($dlikequery) or displayerror(mysql_error() . "Moderate failed L:441");
-					$dlikeres = mysql_num_rows($dlikeres);
+					$dlikeres = mysqli_query($GLOBALS["___mysqli_ston"], $dlikequery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "Moderate failed L:441");
+					$dlikeres = mysqli_num_rows($dlikeres);
 					$postpart .= '<br /><small> ' . $likeres . ' people like this post</small> &nbsp&nbsp&nbsp';
 					$postpart .= '<small> ' . $dlikeres . ' people dislike this post</small><br />';
 					}
@@ -479,13 +479,13 @@ PRE;
 			}
 			$postpart .='</table>';
 			$query3 = "SELECT `forum_thread_viewcount` FROM `$table_name` WHERE forum_thread_id='$forum_id' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-			$result3 = mysql_query($query3);
-			$rows = mysql_fetch_array($result3);
+			$result3 = mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+			$rows = mysqli_fetch_array($result3);
 			$view = $rows['forum_thread_viewcount'];
 			// count more value
 			$addview = $view +1; 
 			$query5 = "UPDATE `$table_name` SET `forum_thread_viewcount`='$addview' WHERE forum_thread_id='$forum_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$result5 = mysql_query($query5);
+			$result5 = mysqli_query($GLOBALS["___mysqli_ston"], $query5);
 			$postpart .= '<br>
 			        <p align="left"><a href="+post&subaction=post_reply&thread_id='.$forum_id.'"><img title="Reply" src="'.$temp.'/reply.gif" />' .
 			        		'</a>&nbsp;<a href="+post&subaction=create_thread"><img title="New Thread" src="'.$temp.'/newthread.gif" /></a></p>';
@@ -514,8 +514,8 @@ PRE;
 		require_once ("$sourceFolder/$moduleFolder/forum/bbeditor.php");
 		require_once ("$sourceFolder/$moduleFolder/forum/bbparser.php");
 		$q = "SELECT * FROM `$table2_name` WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-		$res = mysql_query($q);
-		$rows = mysql_fetch_array($res);
+		$res = mysqli_query($GLOBALS["___mysqli_ston"], $q);
+		$rows = mysqli_fetch_array($res);
 		$access_level = $rows['forum_moderated'];
 		if ($access_level) {
 			$approve = 0;
@@ -544,8 +544,8 @@ PRE;
 					else
 						$category = "general";
 					$query="SELECT MAX(`forum_thread_id`) AS MAX FROM `forum_threads`";
-					$result=mysql_query($query);
-					$row1 = mysql_fetch_assoc($result);
+					$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					$row1 = mysqli_fetch_assoc($result);
 					$threadid = $row1['MAX'] + 1;
 
 					$sql = "INSERT INTO `$table_name`(`forum_thread_id` ,`page_modulecomponentid` ,`forum_thread_category` ,`forum_access_status` ," .
@@ -553,17 +553,17 @@ PRE;
 							"`forum_thread_viewcount` ,`forum_thread_last_post_userid` ,`forum_thread_lastpost_date`)" .
 							" VALUES('$threadid', '$this->moduleComponentId', '$category', '$access', '$subject', '$message'," .
 							" '$userId', '$datetime', '$approve', '1','$userId', '$datetime')";
-					$result = mysql_query($sql) or displayerror(mysql_error() . "Create New Thread failed L:550");
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $sql) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "Create New Thread failed L:550");
 					if ($result) {
 						$sql1 = "SELECT * FROM `$table2_name` WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-						$result1 = mysql_query($sql1);
-						$rows1 = mysql_fetch_array($result1);
+						$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $sql1);
+						$rows1 = mysqli_fetch_array($result1);
 						$total_thread_count = $rows['total_thread_count'];
 						// count more value
 						$net_thread_count = $total_thread_count +1;
 						$sql2 = "UPDATE `$table2_name` SET `total_thread_count`='$net_thread_count', `last_post_userid`='$userId'," .
 								" `last_post_datetime`='$datetime' WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-						$result2 = mysql_query($sql2);
+						$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $sql2);
 						if(($access=="moderated")&& (!$moderator))
 								displayinfo("You have successfully created a new thread.It will be published after getting the moderator's approval." .
 										"<br />");
@@ -586,8 +586,8 @@ PRE;
 						$subject = addslashes(htmlspecialchars($_POST['subject']));
 						$message = addslashes(htmlspecialchars(parsenewline(nl2br($message))));
 						$sql7 = "SELECT MAX(`forum_post_id`) AS Maxpost_id FROM `$table1_name` WHERE `forum_thread_id` = '$forum_id'";
-						$res = mysql_query($sql7);
-						$rows = mysql_fetch_array($res);
+						$res = mysqli_query($GLOBALS["___mysqli_ston"], $sql7);
+						$rows = mysqli_fetch_array($res);
 						// add + 1 to highest answer number and keep it in variable name "$Max_id". if there no answer yet set it = 1
 						if ($rows) {
 							$Max_id = $rows['Maxpost_id'] + 1;
@@ -597,22 +597,22 @@ PRE;
 						$sql = "INSERT INTO `$table1_name`( `page_modulecomponentid` , `forum_thread_id` , `forum_post_id` , `forum_post_user_id` , `forum_post_title` , " .
 								"`forum_post_content` , `forum_post_datetime` , `forum_post_approve` ) VALUES( '$this->moduleComponentId','$forum_id', '$Max_id'," .
 								" '$userId', '$subject', '$message', '$datetime', '$approve')";
-						$result = mysql_query($sql) or displayerror(mysql_error() . "Post failed L:594");
+						$result = mysqli_query($GLOBALS["___mysqli_ston"], $sql) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "Post failed L:594");
 						if ($result) {
 							$sql1 = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='$this->moduleComponentId' AND `forum_thread_id`=$forum_id" .
 									" LIMIT 1";
-							$result1 = mysql_query($sql1);
-							$rows1 = mysql_fetch_array($result1);
+							$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $sql1);
+							$rows1 = mysqli_fetch_array($result1);
 							$sql2 = "UPDATE `$table_name` SET  `forum_thread_last_post_userid`='$userId', " .
 									"`forum_thread_lastpost_date`='$datetime' " .
 									"WHERE `page_modulecomponentid`='$this->moduleComponentId' AND `forum_thread_id`='$forum_id' LIMIT 1";
-							$result2 = mysql_query($sql2);
+							$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $sql2);
 							$sql3 = "SELECT * FROM `$table2_name` WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-							$result3 = mysql_query($sql3);
-							$rows3 = mysql_fetch_array($result3);
+							$result3 = mysqli_query($GLOBALS["___mysqli_ston"], $sql3);
+							$rows3 = mysqli_fetch_array($result3);
 							$sql4 = "UPDATE `$table2_name` SET  `last_post_userid`='$userId', " .
 									"`last_post_datetime`='$datetime' WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-							$result4 = mysql_query($sql4);
+							$result4 = mysqli_query($GLOBALS["___mysqli_ston"], $sql4);
 							if(($rows1['forum_access_status']=="moderated")&& (!$moderator))
 								displayinfo("You have successfully posted your reply.It will be published after getting the moderator's approval." .
 										"<br />");
@@ -625,8 +625,8 @@ PRE;
 						$forumHtml = '';
 						$thread_id = $forum_id;
 						$sql = "SELECT * FROM `$table_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-						$result1 = mysql_query($sql);
-						$rows = mysql_fetch_array($result1);
+						$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $sql);
+						$rows = mysqli_fetch_array($result1);
 						$threadUserId = $rows['forum_thread_user_id'];
 						$forum_topic = parseubb(parsesmileys($rows['forum_thread_topic']));
 						$forum_detail = parseubb(parsesmileys($rows['forum_detail']));
@@ -637,17 +637,17 @@ PRE;
 						if ($rows['forum_post_approve'] == 1)
 						$forumHtml .= $this->forumHtml($rows,'threadMain');
 						$sql2 = "SELECT * FROM `$table1_name` WHERE `forum_thread_id`='$thread_id' AND `forum_post_approve` = 1 AND `page_modulecomponentid`='$this->moduleComponentId' ORDER BY `forum_post_id` ASC";
-						$result2 = mysql_query($sql2);
-						while ($rows = mysql_fetch_array($result2)) 
+						$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $sql2);
+						while ($rows = mysqli_fetch_array($result2)) 
 							$forumHtml .= $this->forumHtml($rows,'threadMain',1);
 						$sql3 = "SELECT `forum_thread_viewcount` FROM `$table_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$result3 = mysql_query($sql3);
-						$rows = mysql_fetch_array($result3);
+						$result3 = mysqli_query($GLOBALS["___mysqli_ston"], $sql3);
+						$rows = mysqli_fetch_array($result3);
 						$view = $rows['forum_thread_viewcount'];
 						// count more value
 						$addview = $view +1;
 						$sql5 = "UPDATE `$table_name` SET `forum_thread_viewcount`='$addview' WHERE forum_thread_id='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-						$result5 = mysql_query($sql5);
+						$result5 = mysqli_query($GLOBALS["___mysqli_ston"], $sql5);
 						$forumHtml .= '</table> ';
 						return $forumHtml;
 					}
@@ -687,9 +687,9 @@ PRE;
 		//to check last visit to the forum
 		$table_visit = "forum_visits";
 		$query_checkvisit = "SELECT * from `$table_visit` WHERE `user_id`='$userId' AND `page_modulecomponentid`='$this->moduleComponentId'";
-		$result_checkvisit = mysql_query($query_checkvisit);
-		$check_visits = mysql_fetch_array($result_checkvisit);
-		if(mysql_num_rows($result_checkvisit)<1) {
+		$result_checkvisit = mysqli_query($GLOBALS["___mysqli_ston"], $query_checkvisit);
+		$check_visits = mysqli_fetch_array($result_checkvisit);
+		if(mysqli_num_rows($result_checkvisit)<1) {
 			$forum_lastviewed = date("Y-m-d H:i:s");
 		}
 		else {
@@ -698,15 +698,15 @@ PRE;
 		//set user's last visit
 		$time_visit = date("Y-m-d H:i:s");
 		$query_visit = "SELECT * FROM `$table_visit` WHERE `user_id`='$userId' AND `page_modulecomponentid`='$this->moduleComponentId'";
-		$result_visit = mysql_query($query_visit);
-		$num_rows_visit = mysql_num_rows($result_visit);
+		$result_visit = mysqli_query($GLOBALS["___mysqli_ston"], $query_visit);
+		$num_rows_visit = mysqli_num_rows($result_visit);
 		if($num_rows_visit<1) {
 		  $query_setvisit = "INSERT INTO `$table_visit`(`page_modulecomponentid`,`user_id`,`last_visit`) VALUES('$this->moduleComponentId','$userId','$time_visit')";
 		}
 		else {
 		  $query_setvisit = "UPDATE `$table_visit` SET `last_visit`='$time_visit' WHERE `user_id`='$userId' AND `page_modulecomponentid`='$this->moduleComponentId'"; 
 		}
-		mysql_query($query_setvisit);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query_setvisit);
 
 		require_once ("$sourceFolder/$moduleFolder/forum/bbeditor.php");
 		require_once ("$sourceFolder/$moduleFolder/forum/bbparser.php");
@@ -714,9 +714,9 @@ PRE;
 			if ((isset($_GET['subaction']))&&($_GET['subaction'] == "delete_thread")) {
 				$thread_id = escape($_GET['forum_id']);
 				$query = "DELETE FROM `$table_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-				$res = mysql_query($query);
+				$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				$query1 = "DELETE FROM `$table1_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId'";
-				$res1 = mysql_query($query1);
+				$res1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 				if (!res || !res1)
 					displayerror("Could not perform the delete operation on the selected thread!");
 			}
@@ -729,18 +729,18 @@ PRE;
 			if($moderator)
 			{
 			$qum_0 = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId ."' AND `forum_post_approve` = 0";
-			$resm_0 = mysql_query($qum_0);
-			$numm_0 = mysql_num_rows($resm_0);
+			$resm_0 = mysqli_query($GLOBALS["___mysqli_ston"], $qum_0);
+			$numm_0 = mysqli_num_rows($resm_0);
 			for ($j = 1; $j <= $numm_0; $j++) {
-				$rows = mysql_fetch_array($resm_0,MYSQL_ASSOC);
+				$rows = mysqli_fetch_array($resm_0, MYSQLI_ASSOC);
 				if($forum_lastVisit<$rows['forum_thread_datetime'])
 					$new_mt = $new_mt + '1';
 			}
 			$qum_1 = "SELECT * FROM `$table1_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId ."' AND `forum_post_approve` = 0";
-			$resm_1 = mysql_query($qum_1);
-			$numm_1 = mysql_num_rows($resm_1);
+			$resm_1 = mysqli_query($GLOBALS["___mysqli_ston"], $qum_1);
+			$numm_1 = mysqli_num_rows($resm_1);
 			for ($j = 1; $j <= $numm_1; $j++) {
-				$rows = mysql_fetch_array($resm_1,MYSQL_ASSOC);
+				$rows = mysqli_fetch_array($resm_1, MYSQLI_ASSOC);
 				if($forum_lastVisit<$rows['forum_post_datetime'])
 					$new_mp = $new_mp + '1';
 			}
@@ -752,18 +752,18 @@ PRE;
 			displayinfo($show_p);}
 			}
 			$qu_0 = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId ."' AND `forum_post_approve` = 1 AND `forum_thread_user_id` !='$this->userId'";
-			$res_0 = mysql_query($qu_0);
-			$num_0 = mysql_num_rows($res_0);
+			$res_0 = mysqli_query($GLOBALS["___mysqli_ston"], $qu_0);
+			$num_0 = mysqli_num_rows($res_0);
 			for ($j = 1; $j <= $num_0; $j++) {
-				$rows = mysql_fetch_array($res_0,MYSQL_ASSOC);
+				$rows = mysqli_fetch_array($res_0, MYSQLI_ASSOC);
 				if($forum_lastVisit<$rows['forum_thread_datetime'])
 					$new_t = $new_t + '1';
 			}
 			$qu_1 = "SELECT * FROM `$table1_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId ."' AND `forum_post_approve` = 1 AND `forum_post_user_id` !='$this->userId'";
-			$res_1 = mysql_query($qu_1) or die(mysql_error());
-			$num_1 = mysql_num_rows($res_1);
+			$res_1 = mysqli_query($GLOBALS["___mysqli_ston"], $qu_1) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$num_1 = mysqli_num_rows($res_1);
 			for ($j = 1; $j <= $num_1; $j++) {
-				$rows = mysql_fetch_array($res_1,MYSQL_ASSOC);
+				$rows = mysqli_fetch_array($res_1, MYSQLI_ASSOC);
 				if($forum_lastVisit<$rows['forum_post_datetime'])
 					$new_p = $new_p + '1';
 			}
@@ -775,18 +775,18 @@ PRE;
 			displayinfo($show_p);}
 			}
 			$query_d = "SELECT `forum_description` FROM `forum_module` WHERE `page_modulecomponentid`='" . $this->moduleComponentId ."' LIMIT 1";
-			$result_d = mysql_query($query_d) or die(mysql_error());
-			$result_d = mysql_fetch_array($result_d);
+			$result_d = mysqli_query($GLOBALS["___mysqli_ston"], $query_d) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			$result_d = mysqli_fetch_array($result_d);
 			$query = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId . "' AND " .
 					"`forum_thread_category`='general' ORDER BY `forum_thread_lastpost_date` DESC";
-			$result = mysql_query($query) or displayerror(mysql_error() . "View of General Threads failed L:776");
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "View of General Threads failed L:776");
 			$query1 = "SELECT * FROM `$table_name` WHERE `page_modulecomponentid`='" . $this->moduleComponentId . "' AND " .
 					"`forum_thread_category`='sticky' ORDER BY `forum_thread_datetime` DESC";
-			$result1 = mysql_query($query1)or displayerror(mysql_error() . "View of sticjy Threads failed L:779");
-			$num_rows1 = mysql_num_rows($result1); //counts the total no of sticky threads
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1)or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "View of sticjy Threads failed L:779");
+			$num_rows1 = mysqli_num_rows($result1); //counts the total no of sticky threads
 			if ($result) {
 				$action = "+post&subaction=create_thread";
-				$num_rows = mysql_num_rows($result); //counts the total no of general threads				
+				$num_rows = mysqli_num_rows($result); //counts the total no of general threads				
 				$forum_header =<<<PRE
 			<p align="left"><a href="$action"><img title="New Thread" src="$temp/newthread.gif" /></a></p>
 			<div style="text-align:center;"><b>" $result_d[0] "</b></div>
@@ -801,10 +801,10 @@ PRE;
 				$forumHtml .= $forum_header;
 				if ($result1 && $num_rows1 > 0) {
 					for ($j = 1; $j <= $num_rows1; $j++) {
-						$rows = mysql_fetch_array($result1,MYSQL_ASSOC);
+						$rows = mysqli_fetch_array($result1, MYSQLI_ASSOC);
 						$query2 = "SELECT `forum_post_id` FROM `$table1_name` WHERE `forum_thread_id`='" . $rows['forum_thread_id'] . "' AND `forum_post_approve`='1' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$result2 = mysql_query($query2);
-						$reply_count = mysql_num_rows($result2);
+						$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+						$reply_count = mysqli_num_rows($result2);
 						$topic = parseubb(parsesmileys(stripslashes($rows['forum_thread_topic'])));
 						$name = getUserName($rows['forum_thread_user_id']);
 						$last_post_author = getUserName($rows['forum_thread_last_post_userid']);
@@ -816,10 +816,10 @@ PRE;
 			if ($num_rows < 1)
 					$forum_header .= "<tr><td colspan=\"5\" class='forumTableRow'><strong>No Post</strong></td></tr>";
 				for ($i = 1; $i <= $num_rows; $i++) {
-					$rows = mysql_fetch_array($result);
+					$rows = mysqli_fetch_array($result);
 					$query1 = "SELECT `forum_post_id` FROM `$table1_name` WHERE `forum_thread_id`='" . $rows['forum_thread_id'] . "' AND `forum_post_approve`='1' AND `page_modulecomponentid`='$this->moduleComponentId'";
-					$result1 = mysql_query($query1);
-					$reply_count = mysql_num_rows($result1);
+					$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+					$reply_count = mysqli_num_rows($result1);
 					$topic = parseubb(parsesmileys($rows['forum_thread_topic']));
 					$name = getUserName($rows['forum_thread_user_id']);
 					$last_post_author = getUserName($rows['forum_thread_last_post_userid']);
@@ -836,19 +836,19 @@ PRE;
 				if ($_GET['subaction'] == "delete_post") {
 					$post_id = escape($_GET['post_id']);
 					$query = "DELETE FROM `$table1_name` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-					$res = mysql_query($query);
+					$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					if ( !$res )
 						displayerror("Could not perform the delete operation on the selected post!");
 					$query = "DELETE FROM `forum_like` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId'";
-					$res = mysql_query($query);
+					$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			}
 				if ($_GET['subaction'] == "like_post") {
 					$post_id = escape($_GET['post_id']);
 					$query = "SELECT * FROM `forum_like` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-					$res = mysql_query($query);
-					if(mysql_num_rows($res)==0) {
+					$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					if(mysqli_num_rows($res)==0) {
 					$query = "INSERT INTO`forum_like` (`page_modulecomponentid`,`forum_thread_id`,`forum_post_id`,`forum_like_user_id`,`like_status`) VALUES ('$this->moduleComponentId','$thread_id','$post_id','$userId','1')";
-					$res = mysql_query($query);
+					$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					if ( !$res )
 						displayerror("Could not perform the like operation on the selected post!");
 					}	
@@ -856,18 +856,18 @@ PRE;
 				if ($_GET['subaction'] == "dislike_post") {
 					$post_id = escape($_GET['post_id']);
 					$query = "SELECT * FROM `forum_like` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='$post_id' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-					$res = mysql_query($query);
-					if(mysql_num_rows($res)==0) {
+					$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					if(mysqli_num_rows($res)==0) {
 					$query = "INSERT INTO`forum_like` (`page_modulecomponentid`,`forum_thread_id`,`forum_post_id`,`forum_like_user_id`,`like_status`) VALUES ('$this->moduleComponentId','$thread_id','$post_id','$userId','0')";
-					$res = mysql_query($query);
+					$res = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					if ( !$res )
 						displayerror("Could not perform the dislike operation on the selected post!");
 						}
 			}			
 			}
 			$sql = "SELECT * FROM `$table_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$result1 = mysql_query($sql);
-			$rows = mysql_fetch_array($result1);
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $sql);
+			$rows = mysqli_fetch_array($result1);
 			$threadUserId = $rows['forum_thread_user_id'];
 			$forum_topic = parseubb(parsesmileys($rows['forum_thread_topic']));
 			$forum_detail = parseubb(parsesmileys($rows['forum_detail']));
@@ -879,19 +879,19 @@ PRE;
 			if ($rows['forum_post_approve'] == 1)
 				$forumHtml .= $this->forumHtml($rows,'threadMain',0,0);
 			$sql2 = "SELECT * FROM `$table1_name` WHERE `forum_thread_id`='$thread_id' AND `forum_post_approve` = 1 AND `page_modulecomponentid`='$this->moduleComponentId' ORDER BY `forum_post_id` ASC";
-			$result2 = mysql_query($sql2);
-			while ($rows1 = mysql_fetch_array($result2)) {
+			$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $sql2);
+			while ($rows1 = mysqli_fetch_array($result2)) {
 				$count = $count + 1;
 				$forumHtml .= $this->forumHtml($rows1,'threadMain',1,$count);
 			}
 			$sql3 = "SELECT `forum_thread_viewcount` FROM `$table_name` WHERE `forum_thread_id`='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			$result3 = mysql_query($sql3);
-			$rows2 = mysql_fetch_array($result3);
+			$result3 = mysqli_query($GLOBALS["___mysqli_ston"], $sql3);
+			$rows2 = mysqli_fetch_array($result3);
 			$view = $rows2['forum_thread_viewcount'];
 			// count more value
 			$addview = $view +1;
 			$sql5 = "UPDATE `$table_name` SET `forum_thread_viewcount`='$addview' WHERE forum_thread_id='$thread_id' AND `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$result5 = mysql_query($sql5);
+			$result5 = mysqli_query($GLOBALS["___mysqli_ston"], $sql5);
 			$forumHtml .= '</table><br />';
 			if($rows['forum_thread_category']!='sticky'){
 			$forumHtml .= '<p align="left"><a href="+post&subaction=post_reply&thread_id='.$thread_id.'"><img alt="Reply" title="Reply" src="'.$temp.'/reply.gif" /></a></p>';
@@ -936,8 +936,8 @@ PRE;
 						$img_src = 'sticky.gif';
 						}
 				$query1 = "SELECT `forum_post_id` FROM `$table1_name` WHERE `forum_thread_id`='" . $rows['forum_thread_id'] . "' AND `forum_post_approve`='1' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-				$result1 = mysql_query($query1);
-				$reply_count = mysql_num_rows($result1);
+				$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+				$reply_count = mysqli_num_rows($result1);
 				$forum_threads .=<<<PRE1
 			            <tr class="forumThreadRow">
 			            <td class="forumThreadRow forumTableIcon" width="3%"><img src="$temp/$img_src" /></td>
@@ -965,8 +965,8 @@ PRE;
 		}
 		if($type == 'threadMain') {
 			$q = "SELECT * FROM `forum_module` WHERE `page_modulecomponentid`='$this->moduleComponentId' LIMIT 1";
-			$r = mysql_query($q) or displayerror(mysql_error() . "View of Thread failed L:962");
-			$r = mysql_fetch_array($r);
+			$r = mysqli_query($GLOBALS["___mysqli_ston"], $q) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "View of Thread failed L:962");
+			$r = mysqli_fetch_array($r);
 		if($post == 0){
 			$topic = censor_words(ucfirst(parseubb(parsesmileys($rows['forum_thread_topic']))));
 			$name = ucfirst(getUserName($rows['forum_thread_user_id']));
@@ -995,11 +995,11 @@ PRE;
 					if($post == 1)						
 					if($r['allow_like_posts'] == 1){
 					$likequery = "SELECT * from `forum_like` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='".$rows['forum_post_id']."' AND `like_status`='1' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-					$likeres = mysql_query($likequery);
-					$likeres = mysql_num_rows($likeres);
+					$likeres = mysqli_query($GLOBALS["___mysqli_ston"], $likequery);
+					$likeres = mysqli_num_rows($likeres);
 					$dlikequery = "SELECT * from `forum_like` WHERE `forum_thread_id`='$thread_id' AND `forum_post_id`='".$rows['forum_post_id']."' AND `like_status`='0' AND `page_modulecomponentid`='$this->moduleComponentId' ";
-					$dlikeres = mysql_query($dlikequery);
-					$dlikeres = mysql_num_rows($dlikeres);
+					$dlikeres = mysqli_query($GLOBALS["___mysqli_ston"], $dlikequery);
+					$dlikeres = mysqli_num_rows($dlikeres);
 						$threadHtml .= '<br /><small> ' . $likeres . ' people like this post</small> &nbsp&nbsp&nbsp';
 						$threadHtml .= '<small> ' . $dlikeres . ' people dislike this post</small><br />';
 					}
@@ -1037,10 +1037,10 @@ if($post==1 && $userId>0 && ( ($r['allow_delete_posts'] == 1) ||($r['allow_like_
 						{
 						$postId=$rows['forum_post_id'];
 						$qu = " SELECT * FROM `forum_like` WHERE `forum_like_user_id` = '$userId' AND`forum_thread_id` = '$thread_id' AND `forum_post_id` = '$postId' AND `page_modulecomponentid`='$this->moduleComponentId' AND `like_status`='1'";
-						$re = mysql_query($qu) ;
+						$re = mysqli_query($GLOBALS["___mysqli_ston"], $qu) ;
 						$qu1 = " SELECT * FROM `forum_like` WHERE `forum_like_user_id` = '$userId' AND`forum_thread_id` = '$thread_id' AND `forum_post_id` = '$postId' AND `page_modulecomponentid`='$this->moduleComponentId' AND `like_status`='0'";
-						$re1 = mysql_query($qu1);
-						if(mysql_num_rows($re)==0 && mysql_num_rows($re1)==0)
+						$re1 = mysqli_query($GLOBALS["___mysqli_ston"], $qu1);
+						if(mysqli_num_rows($re)==0 && mysqli_num_rows($re1)==0)
 							{
 							$threadHtml .= '  <a href="+view&subaction=like_post&thread_id=' . $thread_id . '&post_id=' . $rows['forum_post_id'] . '">' .
 										'  <img title="Like this post" src="'.$temp.'/like.gif"></a></span>';
@@ -1048,7 +1048,7 @@ if($post==1 && $userId>0 && ( ($r['allow_delete_posts'] == 1) ||($r['allow_like_
 										'  <img title="Dislike this post" src="'.$temp.'/unlike.gif"></a></span>';
 							}
 						else {
-						if(mysql_num_rows($re)>0)
+						if(mysqli_num_rows($re)>0)
 							$threadHtml .= '<br /> You Like this post';
 						else
 							$threadHtml .= '<br /> You Dislike this post';
@@ -1080,9 +1080,9 @@ PRE;
 		if(!isset($_SESSION['forum_lastVisit'])){
 		$table_visit = "forum_visits";
 		$query_checkvisit = "SELECT * from `$table_visit` WHERE `user_id`='$userId' AND `page_modulecomponentid`='$this->moduleComponentId'";
-		$result_checkvisit = mysql_query($query_checkvisit);
-		$check_visits = mysql_fetch_array($result_checkvisit);
-		if(mysql_num_rows($result_checkvisit)<1) {
+		$result_checkvisit = mysqli_query($GLOBALS["___mysqli_ston"], $query_checkvisit);
+		$check_visits = mysqli_fetch_array($result_checkvisit);
+		if(mysqli_num_rows($result_checkvisit)<1) {
 			$forum_lastViewed = date("Y-m-d H:i:s");
 		}
 		else {
@@ -1092,15 +1092,15 @@ PRE;
 		//set user's last visit
 		$time_visit = date("Y-m-d H:i:s");
 		$query_visit = "SELECT * FROM `$table_visit` WHERE `user_id`='$userId' AND `page_modulecomponentid`='$this->moduleComponentId'";
-		$result_visit = mysql_query($query_visit);
-		$num_rows_visit = mysql_num_rows($result_visit);
+		$result_visit = mysqli_query($GLOBALS["___mysqli_ston"], $query_visit);
+		$num_rows_visit = mysqli_num_rows($result_visit);
 		if($num_rows_visit<1) {
 		  $query_setvisit = "INSERT INTO `$table_visit`(`page_modulecomponentid`,`user_id`,`last_visit`) VALUES('$this->moduleComponentId','$userId','$time_visit')";
 		}
 		else {
 		  $query_setvisit = "UPDATE `$table_visit` SET `last_visit`='$time_visit' WHERE `user_id`=$userId AND `page_modulecomponentid`=$this->moduleComponentId"; 
 		}
-		mysql_query($query_setvisit);//or die(mysql_error());
+		mysqli_query($GLOBALS["___mysqli_ston"], $query_setvisit);//or die(mysql_error());
 		}
 		else {
 			$forum_lastViewed = $_SESSION['forum_lastVisit'];
@@ -1110,7 +1110,7 @@ PRE;
 	}
 public function createModule($compId) {
 		$query = "INSERT INTO `forum_module` (`page_modulecomponentid`,`forum_description`,`last_post_userid` )VALUES ('$compId','Forum Description Here!!!','1')";
-		$result = mysql_query($query) or die(mysql_error() . " forum.lib L:1113");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . " forum.lib L:1113");
 	}
 
 	public function deleteModule($moduleComponentId) {

--- a/cms/modules/gallery.lib.php
+++ b/cms/modules/gallery.lib.php
@@ -63,40 +63,40 @@ class gallery implements module, fileuploadable {
 			$arr=explode("/",$_GET['ref']);
 			$arr = $arr[sizeof($arr)-1];
 			$query="SELECT* FROM `gallery_pics` WHERE upload_filename='".$arr."' AND page_modulecomponentid='$this->moduleComponentId' LIMIT 1";
-			$result=mysql_query($query);
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			if($result){
-				$newrate = mysql_result($result,0,'pic_rate')+1;
+				$newrate = mysqli_result($result, 0, 'pic_rate')+1;
 				$query="UPDATE `gallery_pics` SET `pic_rate`='".$newrate."' WHERE upload_filename='".$arr."' AND page_modulecomponentid='$this->moduleComponentId'";
-				mysql_query($query);
+				mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			}}
 		else if($_GET['getView']){
 			$arr1=explode("/",$_GET['getView']);
 			$arr1 = $arr1[sizeof($arr1)-1];
 			$query="SELECT* FROM `gallery_pics` WHERE upload_filename='".$arr1."' AND page_modulecomponentid='$this->moduleComponentId' LIMIT 1";
-			$result1=mysql_query($query);
+			$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			if($result1){
-				$view = mysql_result($result1,0,'pic_rate');
+				$view = mysqli_result($result1, 0, 'pic_rate');
 				echo $view;
 			}
 			}
 		else if($_GET['rateIt']){
 			$arr3 = $_GET['rateRef'];
 			$query="SELECT `vote_avg`,`voters` FROM `gallery_pics` WHERE upload_filename='".$arr3."' AND page_modulecomponentid='$this->moduleComponentId' LIMIT 1";
-			$result3=mysql_query($query);
+			$result3=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			if($result3){
-				$voteAvg = mysql_result($result3,0,'vote_avg');
-				$voters = mysql_result($result3,0,'voters');
+				$voteAvg = mysqli_result($result3, 0, 'vote_avg');
+				$voters = mysqli_result($result3, 0, 'voters');
 				$newAvg = (($voters*$voteAvg)+$_GET['rateIt'])/($voters+1);
 				$voters=$voters+1;
 				$query="UPDATE `gallery_pics` SET `vote_avg`='".$newAvg."',`voters`='".$voters."' WHERE upload_filename='".$arr3."' AND page_modulecomponentid='$this->moduleComponentId'";
-				$result = mysql_query($query);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				if (!$result){echo "a";}
 				else{
 					$query="SELECT* FROM `gallery_pics` WHERE upload_filename='".$arr3."' AND page_modulecomponentid='$this->moduleComponentId' LIMIT 1";
-					$result3 = mysql_query($query);
+					$result3 = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					if($result3){
-						$rating = mysql_result($result3,0,'vote_avg');
-						$voters = mysql_result($result3,0,'voters');
+						$rating = mysqli_result($result3, 0, 'vote_avg');
+						$voters = mysqli_result($result3, 0, 'voters');
 						echo $rating."-".$voters;
 					}
 					else{
@@ -142,17 +142,17 @@ class gallery implements module, fileuploadable {
 			</script>
 JS;
 		$gallQuery = "SELECT * from `gallery_name` where `page_modulecomponentid`='$this->moduleComponentId'";
-		$gallResult = mysql_query($gallQuery);
-		$row = mysql_fetch_assoc($gallResult);
+		$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
+		$row = mysqli_fetch_assoc($gallResult);
 		$content .= "<h2><center>{$row['gallery_name']}</center></h2><br/><center><h3>{$row['gallery_desc']}</center></h3>";
 		$perPage = $row['imagesPerPage'];
 		$viewCheck = $row['allowViews'];
 		$ratingCheck = $row['allowRatings'];
 		include_once ("$sourceFolder/" . 'upload.lib.php');
 		$query = "SELECT `upload_filename` FROM `gallery_pics` WHERE `page_modulecomponentid` ='". $this->moduleComponentId."'";
-		$pic_result = mysql_query($query) or die(mysql_error());
+		$pic_result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$arr = array ();
-		while ($row = mysql_fetch_assoc($pic_result))
+		while ($row = mysqli_fetch_assoc($pic_result))
 			$arr[] = $row;
 		$numPic = count($arr);
 		if(isset($_GET['gallerypage']))
@@ -170,8 +170,8 @@ JS;
 		$content .= '<div class="highslide-gallery" style="width: 100%; margin: auto">';
 		for ($i = $start; $i < $end; $i++) {
 			$gallQuery2 = "SELECT * FROM `gallery_pics` where `upload_filename`='{$arr[$i]['upload_filename']}' AND `page_modulecomponentid`= '$this->moduleComponentId'";
-			$gallResult2 = mysql_query($gallQuery2);
-			$row2 = mysql_fetch_assoc($gallResult2);
+			$gallResult2 = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery2);
+			$row2 = mysqli_fetch_assoc($gallResult2);
 			if ($row2) {
 				$content .= "<input type=\"hidden\" id=\""."thumb_"."{$row2['upload_filename']}\" value=\"{$row2['pic_rate']}\" />";
 				$content .= "<input type=\"hidden\" id=\""."thumb1_"."{$row2['upload_filename']}\" value=\"{$row2['vote_avg']}\" />";
@@ -213,7 +213,7 @@ JS;
 	}
 	public function createModule($nextId) {
 		$gallQuery = "INSERT INTO `gallery_name` (`page_modulecomponentid`, `gallery_name`, `gallery_desc`) VALUES('$nextId', 'New Gallery', 'Edit your new gallery')";
-		$gallResult = mysql_query($gallQuery);
+		$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
 	}
 	public function actionEdit($moduleComponentId) {
 		global $sourceFolder;
@@ -225,13 +225,13 @@ JS;
 		if (isset ($_POST['btnDeleteImage']) && isset ($_POST['imagename']) && $_POST['imagename'] != '') {
 			deleteFile($moduleComponentId, 'gallery', $_POST['imagename']);
 			$gallQuery = "DELETE FROM `gallery_pics` WHERE `upload_filename`='".escape($_POST['imagename'])."'";
-			$gallResult = mysql_query($gallQuery);
+			$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
 		} 
 		else if (isset ($_POST['btnEditComment']) && isset ($_POST['imagename']) && $_POST['imagename'] != '') {
 			$imageName =  escape($_POST['imagename']);
 			$comment = escape($_POST['desc']);
 			$gallQuery = "UPDATE `gallery_pics` SET `gallery_filecomment`=\"$comment\" WHERE `upload_filename`=\"$imageName\"";
-			$gallResult = mysql_query($gallQuery);
+			$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
 		}
 		if (isset ($_POST['btnEditGallname']) && isset ($_POST['gallName']) && isset ($_POST['gallDesc']) && $_POST['gallName'] != '' && $_POST['gallDesc'] != '') {
 			if(is_numeric($_POST['imagesPerPage']))
@@ -239,7 +239,7 @@ JS;
 				$viewCount = ( $_POST['allowViews'] ? 1 : 0 );
 				$ratingCount = ( $_POST['allowRatings'] ? 1 : 0 );
 			$gallQuery = "UPDATE `gallery_name` SET `gallery_name`='".escape($_POST['gallName'])."',`gallery_desc`='".escape($_POST['gallDesc'])."', `imagesPerPage`='".$perPage."',`allowViews`='".$viewCount."',`allowRatings`='".$ratingCount."' WHERE `page_modulecomponentid`='$moduleComponentId'";
-			$gallResult = mysql_query($gallQuery);
+			$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
 		}
 
 		$content2 = getFileUploadForm($this->moduleComponentId, "gallery", './+edit', 10000000, 5);
@@ -254,14 +254,14 @@ JS;
 		if (is_array($uploadSuccess) && isset ($uploadSuccess[0])) {
 			for($i=0;$i<count($uploadSuccess);$i++){
 				$gallQuery3 = "INSERT INTO `gallery_pics` (`upload_filename`, `page_modulecomponentid`, `gallery_filecomment`) VALUES('$uploadSuccess[$i]', '$this->moduleComponentId', 'No Comment')";
-				$gallResult3 = mysql_query($gallQuery3);
+				$gallResult3 = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery3);
 			}
 		}
 		$arr = getUploadedFiles($this->moduleComponentId, 'gallery');
 		global $ICONS;
 		$content2="<fieldset><legend>{$ICONS['Gallery Edit']['small']}Edit Gallery</legend>".$content2;
 		
-		$result = mysql_fetch_array(mysql_query("SELECT * FROM `gallery_name` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
+		$result = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `gallery_name` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
 		if($result){
 			$checkViews = ($result['allowViews'] == 1 ? 'checked="checked" ': '' );
 			$checkRatings = ($result['allowRatings'] == 1 ? 'checked="checked" ': '' );
@@ -317,9 +317,9 @@ JS;
 					<br /><br />
 GALFORM;
 		$gallQuery2 = "SELECT * FROM `gallery_pics` where `page_modulecomponentid`= '$this->moduleComponentId'";
-		$gallResult2 = mysql_query($gallQuery2);
+		$gallResult2 = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery2);
 		$fileArray = array ();
-		while ($row2 = mysql_fetch_assoc($gallResult2))
+		while ($row2 = mysqli_fetch_assoc($gallResult2))
 			$fileArray[] = $row2;
 		if ($fileArray) {
 			for ($i = 0; $i < count($fileArray); $i++) {
@@ -354,15 +354,15 @@ IMGFORM;
 			$content = deleteFile($moduleComponentId, 'gallery', $arr[$c]['upload_filename']) && $content;
 		}
 		$gallQuery = "DELETE FROM `gall_name` where `page_modulecomponentid`='$moduleComponentId'";
-		$gallResult = mysql_query($gallQuery);
+		$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
 		$gallQuery2 = "DELETE FROM `gall_pics` where `page_modulecomponentid`='$moduleComponentId'";
-		$gallResult2 = mysql_query($gallQuery2);
+		$gallResult2 = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery2);
 		return $content;
 	}
 	public function copyModule($moduleComponentId,$newId) {
 		$gallQuery = "SELECT * FROM `gallery_pics` WHERE page_modulecomponentid = '" . $moduleComponentId."'";
-		$gallResult = mysql_query($gallQuery);
-		$gallRow = mysql_fetch_assoc($gallResult);
+		$gallResult = mysqli_query($GLOBALS["___mysqli_ston"], $gallQuery);
+		$gallRow = mysqli_fetch_assoc($gallResult);
 		$destinationPage_moduleComponentId = $newId;
 		while ($gallRow) {
 			fileCopy($moduleComponentId, 'gallery', $gallRow['upload_filename'], $destinationPage_moduleComponentId, 'gallery', $gallRow['upload_filename'], $this->userId);

--- a/cms/modules/hospi.lib.php
+++ b/cms/modules/hospi.lib.php
@@ -74,19 +74,19 @@ VIEW;
 
 private function getEmailSuggestions($input) {
 	$emailQuery ="SELECT `form_elementdata` FROM `form_elementdata` WHERE `page_modulecomponentid`=36 AND form_elementid IN (3,13,14,15)  AND form_elementdata LIKE '%$input%' ";
-	$emailResult = mysql_query($emailQuery);
+	$emailResult = mysqli_query($GLOBALS["___mysqli_ston"], $emailQuery);
 	$suggestions = array($input);
-	while($emailRow = mysql_fetch_row($emailResult)) {
+	while($emailRow = mysqli_fetch_row($emailResult)) {
 			$suggestions[] = $emailRow[0];
 	}
 	$query ="SELECT  `user_id` FROM `form_regdata` WHERE `page_modulecomponentid`=36 ";
-	$result = mysql_query($query);
-	while($temp=mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	while($temp=mysqli_fetch_array($result))
 	{
 		$query1 = 'SELECT `user_email` FROM `' . MYSQL_DATABASE_PREFIX . 'users` WHERE `user_email` LIKE "%'.$input.'%" AND `user_id`='.$temp[0];
-		$result1=mysql_query($query1);
-		if(mysql_num_rows($result1)){
-		$temp1=mysql_fetch_array($result1,MYSQL_NUM);
+		$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+		if(mysqli_num_rows($result1)){
+		$temp1=mysqli_fetch_array($result1, MYSQLI_NUM);
 		$suggestions[] = $temp1[0];
 		}
 	}
@@ -97,11 +97,11 @@ private function getEmailSuggestions($input) {
 public function getUserDetails($email)
 {
 	$query="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_guest_email`='$email' ORDER BY `hospi_actual_checkin` DESC  LIMIT 0,1";
-	$result=mysql_query($query) or die (mysql_error()."in function getUserDetails in hospi") ;
-	$temp=mysql_fetch_array($result,MYSQL_ASSOC);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."in function getUserDetails in hospi") ;
+	$temp=mysqli_fetch_array($result, MYSQLI_ASSOC);
 	$query="SELECT `hospi_hostel_name`,`hospi_room_no` FROM `hospi_hostel` WHERE `hospi_room_id`='$temp[hospi_room_id]'";
-	$result=mysql_query($query) or die (mysql_error()."in function getUserDetails in hospi") ;
-	$temp1=mysql_fetch_array($result,MYSQL_ASSOC);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."in function getUserDetails in hospi") ;
+	$temp1=mysqli_fetch_array($result, MYSQLI_ASSOC);
 	$userdetail=<<<UD
 <table border="1">
 <tr><td>Name</td><td>$temp[hospi_guest_name]</td></tr>
@@ -163,10 +163,10 @@ global $sourceFolder,$cmsFolder;
 		$scriptsFolder = "$urlRequestRoot/$cmsFolder/$templateFolder/common/scripts";
 		$imagesFolder = "$urlRequestRoot/$cmsFolder/$templateFolder/common/images";
 $query1="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_guest_email`='".escape($_POST['guest_email'])."'";
-$result1=mysql_query($query1);
-if(mysql_num_rows($result1))
+$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+if(mysqli_num_rows($result1))
 {
-	$row=mysql_fetch_row($result1);
+	$row=mysqli_fetch_row($result1);
 	if($row[10]!=0)
 	{
 		displayerror('Already Checked Out. Please Check In using another id');
@@ -176,9 +176,9 @@ if(mysql_num_rows($result1))
 	return $this->viewall();
 }
 $query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_email`='" . escape($_POST['guest_email']) . "'";
-		$result = mysql_query($query) or displayerror(mysql_error() . "in registration L:115");
-		if (mysql_num_rows($result)) {
-$profileRow = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "in registration L:115");
+		if (mysqli_num_rows($result)) {
+$profileRow = mysqli_fetch_row($result);
 $checkIn=<<<CHECKIN
 <link rel="stylesheet" type="text/css" media="all" href="$calpath/form/calendar/calendar.css" title="Aqua" />
 						 <script type="text/javascript" src="$calpath/form/calendar/calendar.js"></script>
@@ -219,25 +219,25 @@ User Id:
 CHECKIN;
 
 $query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel` ";
-		$result=mysql_query($query)or die(mysql_error());
-		while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query)or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 		{
 			$hostel=$temp['hospi_hostel_name'];
 			$checkIn.='<td><div><tr><td><b>'.$hostel.'</b></td><td>';
 			$checkIn.="<select name=\"hostel_$hostel\"><option>Room No.</option>";
 			$query1="SELECT `hospi_room_no` FROM `hospi_hostel` WHERE  `hospi_hostel_name`='$hostel' AND `hospi_room_no`<>0";
-			$result1=mysql_query($query1);
-			while($temp1=mysql_fetch_array($result1,MYSQL_NUM)){
+			$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			while($temp1=mysqli_fetch_array($result1, MYSQLI_NUM)){
 			foreach($temp1 as $room)
 
 			{
 
 				$query3="SELECT * FROM `hospi_hostel` WHERE `hospi_hostel_name`='$hostel' AND `hospi_room_no`='$room'";
-				$result3=mysql_query($query3);
-				$temp3=mysql_fetch_array($result3, MYSQL_ASSOC);
+				$result3=mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+				$temp3=mysqli_fetch_array($result3,  MYSQLI_ASSOC);
 				$query4="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`='$temp3[hospi_room_id]' AND `hospi_actual_checkout` IS NULL";
-				$result4=mysql_query($query4);
-				$num=mysql_num_rows($result4);
+				$result4=mysqli_query($GLOBALS["___mysqli_ston"], $query4);
+				$num=mysqli_num_rows($result4);
 
 				if ($num<$temp3['hospi_room_capacity'])
 				$status="VACANT";
@@ -282,8 +282,8 @@ if(isset($_POST['guest_name']))
 {
 		static $room_no,$hostel;
 		$query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel` ";
-		$result=mysql_query($query)or die(mysql_error());
-		while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query)or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 		{
 			$hostel_name="hostel_".$temp['hospi_hostel_name'];
 			if(is_numeric($_POST[''.$hostel_name.'']))
@@ -300,8 +300,8 @@ if(isset($_POST['guest_name']))
 		}
 
 		$query="SELECT `hospi_room_id` FROM `hospi_hostel` WHERE `hospi_hostel_name`='$hostel' AND `hospi_room_no`='$room_no'";
-		$result1=mysql_query($query);
-		$temp=mysql_fetch_assoc($result1);
+		$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$temp=mysqli_fetch_assoc($result1);
 		$room_Id=$temp['hospi_room_id'];
 		if($room_Id==0)
 		{
@@ -312,9 +312,9 @@ if(isset($_POST['guest_name']))
 		if(isset($_POST['cash_paid']))$paid=1;else $paid=0;
 
 	$query="INSERT INTO `hospi_accomodation_status` (`hospi_room_id`,`user_id`,`hospi_actual_checkin`,`hospi_checkedin_by`,`hospi_cash_collected`,`hospi_guest_name`,`hospi_guest_college`,`hospi_guest_phone`,`hospi_guest_email`) VALUES ('$room_Id','".escape($_POST[user_id])."',NOW(),'$this->userId','$paid','".escape($_POST[guest_name])."','".escape($_POST[guest_college])."','".escape($_POST[guest_phone])."','".escape($_POST[guest_email])."')";
-	$result=mysql_query($query) or displayerror(mysql_error());
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
-	if(!(mysql_error()))
+	if(!(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))))
 {
 	
 	displayinfo("$_POST[guest_name] checked in successfully");
@@ -337,8 +337,8 @@ if(isset($_GET['subaction']) && $_GET['subaction'] == 'getsuggestions' && isset(
 }
 elseif(!isset($_GET['hostel'])){
 $query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel` ";
-		$result=mysql_query($query);
-		while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 		{
 			$room.='<td > <a href="+accomodate&hostel='.$temp['hospi_hostel_name'].'">'. $temp['hospi_hostel_name'].' </td>';
 		}
@@ -348,18 +348,18 @@ $room.="</tr></table>";
 elseif(!isset($_GET['room_id']))
 {
 	$query="SELECT * FROM `hospi_hostel` WHERE `hospi_hostel_name`='".escape($_GET[hostel])."' AND `hospi_room_id`!=0";
-		$result=mysql_query($query);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$room.='</tr><tr ><td >'.$_GET['hostel'].'</td>';
-		while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+		while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 		{
 			$status="Vacant";
 			$query1="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`='$temp[hospi_room_id]' AND `hospi_actual_checkout` IS NULL";
-			$result1=mysql_query($query1);
-			$temp1=mysql_fetch_array($result1, MYSQL_ASSOC);
-			if(mysql_num_rows($result1)<$temp['hospi_room_capacity']);
+			$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			$temp1=mysqli_fetch_array($result1,  MYSQLI_ASSOC);
+			if(mysqli_num_rows($result1)<$temp['hospi_room_capacity']);
 			else $status="Full";
 			$room.='<td > <a href="+accomodate&hostel='.$temp['hospi_hostel_name'].'&room_id='.$temp['hospi_room_id'].'">'.$temp['hospi_room_no'].'              ' ;
-			$room.="$status      (".mysql_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
+			$room.="$status      (".mysqli_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
 			$room.='</td>';
 		}
 $room.="</tr></table>";
@@ -373,24 +373,24 @@ else{
 	$userId=getUserIdFromEmail(escape($_POST['txtUserEmail']));
 	if($userId!=0){
 	$query1="SELECT * FROM `hospi_accomodation_status` WHERE `user_id`='$userId' AND `hospi_actual_checkout` IS NULL ";
-	$result1=mysql_query($query1);
-	$room1=mysql_fetch_assoc($result1);
-	if(!(mysql_num_rows($result1))){
+	$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+	$room1=mysqli_fetch_assoc($result1);
+	if(!(mysqli_num_rows($result1))){
 		$name=getUserFullName($userId);
 		$email=getUserEmail($userId);
 
 
 	$query="INSERT INTO `hospi_accomodation_status` (`hospi_room_id`,`user_id`,`hospi_actual_checkin`,`hospi_checkedin_by`,`hospi_cash_collected`,`hospi_guest_name`,`hospi_guest_email`) VALUES ('".escape($_GET[room_id])."','$userId',NOW(),'$this->userId','$paid','$name','$email')";
-	$result=mysql_query($query) or displayerror(mysql_error());
-	if(!(mysql_error()))
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(!(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))))
 	displayinfo("$_POST[txtUserEmail] checked in successfully");
 	else displayerror("Failed to check in $_POST[txtUserEmail]");
 	}
 	else
 	{
 		$query="SELECT `hospi_hostel_name` FROM `hospi_hostel` WHERE `hospi_room_id`='$room1[hospi_room_id]'";
-		$result=mysql_query($query) or die (mysql_error());
-		$room2=mysql_fetch_row($result);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$room2=mysqli_fetch_row($result);
 		displayerror("User is already checked in <a href=\"+accomodate&hostel=$room2[0]&room_id=$room1[hospi_room_id]\">here</a>");
 	}
 }
@@ -403,8 +403,8 @@ if((isset($_GET['checkOut'])))
 	$cond='`user_id`=\''.escape($_GET['checkOut'])."'";
 	else $cond='`hospi_guest_name`=\''.escape($_GET['checkOut']).'\' AND `hospi_actual_checkin`=\''.escape($_GET['checkinTime']).'\' AND `hospi_checkedin_by`='.escape($_GET['by']).'';
 	$query="UPDATE `hospi_accomodation_status` SET `hospi_actual_checkout`=NOW(),`hospi_checkedout_by`= '$this->userId' WHERE `hospi_room_id`='".escape($_GET[room_id])."' AND $cond AND `hospi_actual_checkout` IS NULL ";
-	$result=mysql_query($query);
-	if(mysql_error())displayerror(mysql_error());
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)))displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
 
 }
@@ -414,12 +414,12 @@ if((isset($_GET['checkOut'])))
 	$scriptsFolder = "$urlRequestRoot/$cmsFolder/$templateFolder/common/scripts";
 	$imagesFolder = "$urlRequestRoot/$cmsFolder/$templateFolder/common/images";
 	$query1="SELECT * FROM `hospi_hostel` WHERE `hospi_room_id`='".escape($_GET[room_id])."'";
-	$result1=mysql_query($query1);
-	$temp1= mysql_fetch_array($result1,MYSQL_ASSOC);
+	$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+	$temp1= mysqli_fetch_array($result1, MYSQLI_ASSOC);
 	$query="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`='".escape($_GET[room_id])."' AND `hospi_actual_checkout` IS NULL ";
-	$result=mysql_query($query);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$room.='</tr><tr ><td >Hostel:'.$_GET['hostel'].'<br>Room Number:'.$temp1['hospi_room_no'].'</td></tr>';
-	while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+	while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 	{
 		if($temp['user_id']<>0)
 		$room.="<tr><td><a href=\"+accomodate&displayUserDetails=$temp[hospi_guest_email] \">".getUserFullName($temp['user_id'])."</a></td><td><input type=\"submit\" value=\"Check Out\" onclick=\"window.location='./+accomodate&hostel=$_GET[hostel]&room_id=$_GET[room_id]&checkOut=$temp[user_id]'\"></td></tr>";
@@ -539,22 +539,22 @@ public function actionAddroom() {
 				}
 				
 			$query="SELECT `hospi_room_no` FROM `hospi_hostel` WHERE `hospi_room_no`='".escape($_POST['roomNo1'])."' AND `hospi_hostel_name`='".escape($_POST['hostels'])."'";
-			$result=mysql_query($query);	
-			if(mysql_num_rows($result))
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);	
+			if(mysqli_num_rows($result))
 			{
 				displayerror('Room no. already exists in the database for the hostel.');
 				return $this->viewall();
 			}
 			$query = 'SELECT MAX(`hospi_room_id`) FROM `hospi_hostel`';
-	  		$result = mysql_query($query) or die('error');
-	  		$row = mysql_fetch_row($result);
+	  		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die('error');
+	  		$row = mysqli_fetch_row($result);
 //	  		$room_id = 1;
 	  		if(!is_null($row[0])) {
 	  			$room_id = $row[0] + 1;
 	  		}
 	  		$query="INSERT INTO `hospi_hostel` (`hospi_room_id`,`hospi_hostel_name`,`hospi_room_capacity`,`hospi_room_no`,`hospi_floor`)".
 					"VALUES('$room_id','".escape($_POST['hostels'])."','".escape($_POST['capacity'])."','".escape($_POST['roomNo1'])."','".escape($_POST['floor'])."') ";
-			$result=mysql_query($query);
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			if(!$result)
 			{
 				displayerror('Error while adding room data');
@@ -573,22 +573,22 @@ public function actionAddroom() {
 				for($room=$_POST['roomNo1'];$room<=$_POST['roomNo2'];$room++)
 				{
 			$query="SELECT `hospi_room_no` FROM `hospi_hostel` WHERE `hospi_room_no`='$room ' AND `hospi_hostel_name`='".escape($_POST['hostels'])."'";
-			$result=mysql_query($query);	
-			if(mysql_num_rows($result))
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);	
+			if(mysqli_num_rows($result))
 			{
 				displayerror("Room no.' $room ' already exists in the database for the hostel.");
 				continue;
 			}
 			$query = 'SELECT MAX(`hospi_room_id`) FROM `hospi_hostel`';
-	  		$result = mysql_query($query) or die('error');
-	  		$row = mysql_fetch_row($result);
+	  		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die('error');
+	  		$row = mysqli_fetch_row($result);
 //	  		$room_id = 1;
 	  		if(!is_null($row[0])) {
 	  			$room_id = $row[0] + 1;
 	  		}
 	  		$query="INSERT INTO `hospi_hostel` (`hospi_room_id`,`hospi_hostel_name`,`hospi_room_capacity`,`hospi_room_no`,`hospi_floor`)".
 					"VALUES('$room_id','".escape($_POST['hostels'])."','".escape($_POST['capacity'])."','$room','".escape($_POST['floor'])."') ";
-			$result=mysql_query($query);
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			if(!$result)
 			{
 				displayerror('Error while adding room data');
@@ -614,18 +614,18 @@ public function actionAddroom() {
 			}
 
 			$query = 'SELECT MAX(`hospi_room_id`) FROM `hospi_hostel`';
-	  		$result = mysql_query($query) or die('error');
-	  		$row = mysql_fetch_row($result);
+	  		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die('error');
+	  		$row = mysqli_fetch_row($result);
 //	  		$room_id = 1;
 	  		if(!is_null($row[0])) {
 	  			$room_id = $row[0] + 1;
 	  		}
 
 			$query="INSERT INTO `hospi_hostel` (`hospi_hostel_name`,`hospi_room_id`) VALUES ('".escape($_POST['hostel'])."','$room_id')";
-			$result=mysql_query($query);
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			if(!$result)
 			{
-				displayerror(mysql_error());
+				displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				return $this->viewall();
 			}
 			
@@ -645,13 +645,13 @@ HOSTEL;
 
 
 	 $query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel`";
-	 $result=mysql_query($query);
+	 $result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	 $hostel=<<<ROOM
 <form method="POST" action="./+addroom&subaction=submitaddroom">
 Hostel : 
 <select name="hostels" id="hostels" >
 ROOM;
-	 while($temp=mysql_fetch_array($result,MYSQL_NUM))
+	 while($temp=mysqli_fetch_array($result, MYSQLI_NUM))
 	 {
 	 	foreach($temp as $hostelname)
 	 	{
@@ -697,14 +697,14 @@ public function displayUser()
 				//$query="SELECT * FROM `hospi_accomodation_status` WHERE `user_id`=$userid";
 				//else
 				$query="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_guest_name` LIKE '%$search%' OR `hospi_guest_email` LIKE '%$search%' OR `hospi_guest_college` LIKE '%$search%'";
-				$result=mysql_query($query);
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				if(!$result)
 				{
 
-					displayerror(mysql_error());
+					displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 					return $this->viewall();
 				}
-				if(!mysql_num_rows($result))
+				if(!mysqli_num_rows($result))
 				{
 					displayinfo('The user has not checked into any room');
 					return $this->viewall();
@@ -714,11 +714,11 @@ public function displayUser()
 					$details=<<<USER
 					<b>User Email:{$_POST['txtUserEmail']}</b><br>		
 USER;
-					while($row=mysql_fetch_array($result))
+					while($row=mysqli_fetch_array($result))
 					{
 					$query="SELECT * FROM `hospi_hostel` WHERE `hospi_room_id`='{$row['hospi_room_id']}'";
-					$result1=mysql_query($query);
-					$row1=mysql_fetch_array($result1);
+					$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					$row1=mysqli_fetch_array($result1);
 					$details.=<<<USER1
 					<br>
 					<table border="1">
@@ -820,13 +820,13 @@ USER;
 			{
 					
 					$query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel` ";
-					$result4=mysql_query($query)or die(mysql_error());
+					$result4=mysqli_query($GLOBALS["___mysqli_ston"], $query)or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 					$statusall=<<<ROOM
 					
 
 ROOM;
 					static $i;
-					while($temp4=mysql_fetch_array($result4,MYSQL_ASSOC))
+					while($temp4=mysqli_fetch_array($result4, MYSQLI_ASSOC))
 					{
 						$statusall.=$temp4['hospi_hostel_name'];
 						$statusall.='<table border="1">';
@@ -838,25 +838,25 @@ ROOM;
 					
 						$query="
 						SELECT *  FROM `hospi_hostel` WHERE `hospi_hostel_name`='$temp4[hospi_hostel_name]' AND `hospi_room_no`<>0  AND `hospi_floor`=$i";
-						$result=mysql_query($query)or die(mysql_error());
-						$num=mysql_num_rows($result);
+						$result=mysqli_query($GLOBALS["___mysqli_ston"], $query)or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+						$num=mysqli_num_rows($result);
 						$x=$num/8;
 						$x++;
 						$statusall.="<td rowspan=$x>$i</td>";
-						while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+						while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 							{
 			
 							//	$statusall.="</tr>";
 
 							$status="<br>Vacant";
 							$query1="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`='$temp[hospi_room_id]' AND `hospi_actual_checkout` IS NULL";
-							$result1=mysql_query($query1);
+							$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 
-							if(mysql_num_rows($result1)<$temp['hospi_room_capacity']);
+							if(mysqli_num_rows($result1)<$temp['hospi_room_capacity']);
 							else $status="Full";
 					
 //							$statusall.='<tr>';
-							if(mysql_num_rows($result1)>=$temp['hospi_room_capacity'])
+							if(mysqli_num_rows($result1)>=$temp['hospi_room_capacity'])
 							{
 							$statusall.='<td id="asdf">';
 							}
@@ -866,7 +866,7 @@ ROOM;
 							}
 							$statusall.='<a href="+accomodate&hostel='.$temp['hospi_hostel_name'].'&room_id='.$temp['hospi_room_id'].'">'.$temp['hospi_room_no'].'              ' ;
 						
-							$statusall.="$status      (".mysql_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
+							$statusall.="$status      (".mysqli_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
 							
 							$statusall.=<<<RED
 							<style type="text/css">
@@ -912,16 +912,16 @@ $j++;
 			{
 				if($_POST['roomno']<>'')$cond="`hospi_room_no`='".escape($_POST['roomno'])."' AND";
 				$query="SELECT * FROM `hospi_hostel` WHERE $cond `hospi_hostel_name`='".escape($_POST['hostels'])."'";
-				$result=mysql_query($query);
-				if(!mysql_num_rows($result))
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				if(!mysqli_num_rows($result))
 				{
 					displayerror('Room not present');
 					return $this->viewall();
 				}
-				$row=mysql_fetch_array($result);
+				$row=mysqli_fetch_array($result);
 				$query="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`={$row['hospi_room_id']} AND `hospi_actual_checkout` IS NULL";
-				$result1=mysql_query($query);
-				if(!mysql_num_rows($result1))
+				$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				if(!mysqli_num_rows($result1))
 				{
 					displayinfo('Room Vacant');
 					return $this->viewall();
@@ -943,7 +943,7 @@ DETAILS;
 
 				$room.="Guests alloted:<br>";
 
-					while($row1=mysql_fetch_assoc($result1))
+					while($row1=mysqli_fetch_assoc($result1))
 					{
 						$username=$row1['hospi_guest_email'];
 						$room.=<<<DETAILS
@@ -979,12 +979,12 @@ DETAILS;
 			if($subaction=='findroom')
 			{
 				$query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel`";
-	 			$result=mysql_query($query);
+	 			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				$room=<<<ROOM
 				<form method="POST" action="./+view&subaction=displayroom">
 				Hostels:<select name="hostels" id="hostels" >
 ROOM;
-				 while($temp=mysql_fetch_array($result,MYSQL_NUM))
+				 while($temp=mysqli_fetch_array($result, MYSQLI_NUM))
 	 			{
 	 				foreach($temp as $hostelname)
 	 				{
@@ -1007,23 +1007,23 @@ ROOM;
 				if($_POST['hostels']=="all")
 				{
 					$query="SELECT DISTINCT `hospi_hostel_name` FROM `hospi_hostel`";
-	 				$res=mysql_query($query);
-	 				while($row=mysql_fetch_array($res))
+	 				$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	 				while($row=mysqli_fetch_array($res))
 	 				{
 	 					$query="SELECT * FROM `hospi_hostel` WHERE `hospi_hostel_name`='{$row[hospi_hostel_name]}'  ";
-						$result=mysql_query($query);
+						$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 						$room.='<table border="1"><tr>';
 						$room.='</tr><tr ><td >'.$row['hospi_hostel_name'].'</td>';
-						while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+						while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 						{
 						$status="Vacant";
 						$query1="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`='$temp[hospi_room_id]' AND `hospi_actual_checkout` IS NULL";
-						$result1=mysql_query($query1);
-						$temp1=mysql_fetch_array($result1, MYSQL_ASSOC);
-						if(mysql_num_rows($result1)<$temp['hospi_room_capacity'])
+						$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+						$temp1=mysqli_fetch_array($result1,  MYSQLI_ASSOC);
+						if(mysqli_num_rows($result1)<$temp['hospi_room_capacity'])
 						{
 						$room.='<td width="95" height="95"> <a href="+accomodate&hostel='.$temp['hospi_hostel_name'].'&room_id='.$temp['hospi_room_id'].'">'.$temp['hospi_room_no'].'              ' ;
-						$room.="$status (".mysql_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
+						$room.="$status (".mysqli_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
 						$room.='</td>';
 						}
 						}
@@ -1034,20 +1034,20 @@ ROOM;
 				else
 				{
 					$query="SELECT * FROM `hospi_hostel` WHERE `hospi_hostel_name`='".escape($_POST[hostels])."'  ";
-					$result=mysql_query($query);
+					$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					$room.='<table border="1"><tr>';
 					$room.='</tr><tr ><td >'.$_POST['hostels'].'</td>';
-					while($temp=mysql_fetch_array($result,MYSQL_ASSOC))
+					while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC))
 					{
 						$status="Vacant";
 						$query1="SELECT * FROM `hospi_accomodation_status` WHERE `hospi_room_id`='$temp[hospi_room_id]' AND `hospi_actual_checkout` IS NULL";
-						$result1=mysql_query($query1);
-						$temp1=mysql_fetch_array($result1, MYSQL_ASSOC);
-						if(mysql_num_rows($result1)<$temp['hospi_room_capacity']);
+						$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+						$temp1=mysqli_fetch_array($result1,  MYSQLI_ASSOC);
+						if(mysqli_num_rows($result1)<$temp['hospi_room_capacity']);
 						else $status="Full";
 						if($status!='Full'){
 						$room.='<td width="95" height="95"> <a href="+accomodate&hostel='.$temp['hospi_hostel_name'].'&room_id='.$temp['hospi_room_id'].'">'.$temp['hospi_room_no'].'              ' ;
-						$room.="$status (".mysql_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
+						$room.="$status (".mysqli_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
 						$room.='</td>';}
 					}
 				    $room.="</tr></table>";

--- a/cms/modules/news.lib.php
+++ b/cms/modules/news.lib.php
@@ -23,8 +23,8 @@ if(!defined('__PRAGYAN_CMS'))
 
 
 	private function getNews() {
-		$result=mysql_query("SELECT * FROM `news_desc` WHERE `page_modulecomponentid` = '$this->moduleComponentId'");
-		$query=mysql_fetch_array($result);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `news_desc` WHERE `page_modulecomponentid` = '$this->moduleComponentId'");
+		$query=mysqli_fetch_array($result);
 
 		$rss_output1 ="<?xml version=\"1.0\" encoding=\"ISO-8859-1\" ?><rss version=\"2.0\" xmlns:media=\"http://search.yahoo.com/mrss/\">";
 		$rss_output1 .= <<<TTT
@@ -36,8 +36,8 @@ if(!defined('__PRAGYAN_CMS'))
     <copyright> {$query['news_copyright']} </copyright>
 TTT;
 
-		$query1=mysql_query("SELECT * FROM `news_data` WHERE `page_modulecomponentid` = '$this->moduleComponentId' ORDER BY `news_rank`");
-		while($myrow=mysql_fetch_array($query1)){
+		$query1=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `news_data` WHERE `page_modulecomponentid` = '$this->moduleComponentId' ORDER BY `news_rank`");
+		while($myrow=mysqli_fetch_array($query1)){
 
 			$rss_output1.=<<<RSSOUTPUT
 
@@ -83,9 +83,9 @@ RSSOUTPUT;
 		  $query="SELECT * FROM `news_data` WHERE `page_modulecomponentid`='$moduleCompId'  ORDER BY `news_rank`,`news_id`";
 		else
 		  $query="SELECT * FROM `news_data` ORDER BY `news_rank`,`news_id`";
-		$result=mysql_query($query) or die (mysql_error());
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$i=0;
-		while($news=mysql_fetch_assoc($result)){
+		while($news=mysqli_fetch_assoc($result)){
 			foreach($news as $var=>$val)
 				$newsArray[$i][$var]=$val;
 			$i++;
@@ -137,17 +137,17 @@ VALSCRIPT;
 			if(isset($_GET['newsid']) && ctype_digit($_GET['newsid'])) {
 				if($_GET['subaction'] == 'deletenews') {
 					$query1 = "SELECT * FROM `news_data` WHERE `news_id`='".escape($_GET['newsid'])."' AND `page_modulecomponentid` = '$this->moduleComponentId'";
-					$result = mysql_query($query1);
-					$row = mysql_fetch_assoc($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+					$row = mysqli_fetch_assoc($result);
 	
 					$query = "DELETE FROM `news_data` WHERE `news_id`='".escape($_GET['newsid'])."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-					$result = mysql_query($query);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					displayinfo('News feed has been successfully deleted.');
 				}
 				elseif($_GET['subaction'] == 'editnews') {
 					$query = "SELECT * FROM `news_data` WHERE `news_id`='".escape($_GET['newsid'])."' AND `page_modulecomponentid` = '$this->moduleComponentId'";
-					$result = mysql_query($query);
-					$row = mysql_fetch_assoc($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					$row = mysqli_fetch_assoc($result);
 					$editForm = <<<EDITFORM
 						$validateScript
 					 	<fieldset><legend>{$ICONS['News Edit']['small']} Edit News<legend><form name="AddNews" action="./+edit" method="POST" onsubmit="return validate_empty();">
@@ -166,13 +166,13 @@ EDITFORM;
 			elseif($_GET['subaction'] == 'addnews') {
 				if(isset($_POST['btnAddNews'])) {
 					$query1 = "SELECT MAX(`news_id`) FROM `news_data` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-					$result = mysql_query($query1);
-					$resultArray = mysql_fetch_row($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+					$resultArray = mysqli_fetch_row($result);
 					$news_id = 1;
 					if(!is_null($resultArray[0]))
 						$news_id = $resultArray[0] +1;
 					$query2 = "INSERT INTO `news_data` (`page_modulecomponentid`, `news_id`, `news_title`, `news_feed`, `news_rank`,`news_link`) VALUES('$this->moduleComponentId','$news_id','".escape($_POST['title'])."','".escape($_POST['feed'])."','".escape($_POST['rank'])."','".escape($_POST['link'])."')";
-		 			$result = mysql_query($query2) or die(mysql_error() . '<br />' . $query2);
+		 			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query2) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '<br />' . $query2);
 				}
 				else {
 				
@@ -193,21 +193,21 @@ NEWS;
 		}
 		elseif(isset($_POST['btnSaveChanges']) && isset($_POST['newsid'])) {
 			$query = "UPDATE `news_data` SET `news_title`='".escape($_POST['title'])."',`news_feed`='".escape($_POST['feed'])."',`news_rank`='".escape($_POST['rank'])."',`news_link`='".escape($_POST['link'])."' WHERE `news_id`='".escape($_POST['newsid'])."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			$result = mysql_query($query);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			displayinfo("News feed has been successfully updated.");
 		}
 		if(isset($_POST['btnNewsPropSave'])) {
 			$query = "UPDATE `news_desc` SET `news_title` = '".escape($_POST['news_title'])."', `news_description`='".escape($_POST['news_desc'])."', `news_link`='".escape($_POST['news_link'])."', `news_copyright`='".escape($_POST['news_copyright'])."' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'";
-			if(mysql_query($query))
+			if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 				displayinfo("News Page Properties has been successfully updated.");
 			else
 				displayerror("There has been some error in updating Properties.");
 		}
 
 		$query="SELECT * FROM `news_data` WHERE `page_modulecomponentid`='$this->moduleComponentId' ORDER BY `news_rank`,`news_id`";
-		$result=mysql_query($query);
-		$descResult = mysql_fetch_assoc(mysql_query("SELECT * FROM `news_desc` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
-		$rowCount = mysql_num_rows($result);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$descResult = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `news_desc` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'"));
+		$rowCount = mysqli_num_rows($result);
 		global $ICONS;
 		$news = "<form method=POST action='./+edit'>";
 		$news .= "<table width=100%><tr><td>Title:</td><td><input name='news_title' type='text' value='{$descResult['news_title']}'></td></tr>";
@@ -238,7 +238,7 @@ CHECKDEL;
 		$news .= "<table frame=\"vsides\" border=\"1\" width=\"100%\">";
 		$news .="<tr><th>Sl. No.</th><th>Edit</th><th>Delete</th><th>News ID</th><th>Title</th><th>Feed</th><th>Rank</th><th>Date</th><th>Link</th></tr>";
 		$i = 1;
-		while($row=mysql_fetch_assoc($result)) {
+		while($row=mysqli_fetch_assoc($result)) {
 			$news .=
 					'<tr align="center"><td>'.$i.'</td><td><a href="./+edit&subaction=editnews&newsid='.$row['news_id'].'">' . $editImage . '</a></td>' .
 					'<td><a onclick="return checkDelete(this, \''.$row['news_id'].'\');" >' . $deleteImage . '</a></td>';
@@ -256,7 +256,7 @@ END;
 
 	public function createModule($moduleComponentId) {
 		$globalSettings = getGlobalSettings();
-		mysql_query("INSERT INTO `news_desc` (`page_modulecomponentid` ,`news_copyright`)VALUES ('$compId', '{$globalSettings['cms_footer']}')");
+		mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `news_desc` (`page_modulecomponentid` ,`news_copyright`)VALUES ('$compId', '{$globalSettings['cms_footer']}')");
 	}
 	public function deleteModule($moduleComponentId){
 		return true;
@@ -281,8 +281,8 @@ END;
 		if($newsId=='')
 		{
 			$query="SELECT * FROM `news_desc` WHERE `page_modulecomponentid`='$moduleCompId'";
-			$result=mysql_query($query) or die(mysql_error()."news.lib L247");
-			$temp=mysql_fetch_assoc($result);
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."news.lib L247");
+			$temp=mysqli_fetch_assoc($result);
 			$newsView.="<h1><a href='{$temp['news_link']}'>{$temp['news_title']}</a></h1><br>";
 			$cond="";
 
@@ -291,8 +291,8 @@ END;
 		else
 			$cond="AND `news_id`='$newsId'";
 		$query="SELECT * FROM `news_data` WHERE `page_modulecomponentid`='$moduleCompId' $cond ORDER BY `news_rank`, `news_id`";
-		$result=mysql_query($query);// or die (mysql_error()."news.lib 247");
-		while($newsResult=mysql_fetch_assoc($result))
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);// or die (mysql_error()."news.lib 247");
+		while($newsResult=mysqli_fetch_assoc($result))
 		{
 			$newsView.=<<<NEWS
 <div class='pragyan_newsbox'>

--- a/cms/modules/newsletter.lib.php
+++ b/cms/modules/newsletter.lib.php
@@ -62,22 +62,22 @@ class newsletter implements module {
 
 	private static function moveUserToInternal($userEmail, $userId) {
 		$query = "SELECT `page_modulecomponentid` FROM `newsletter_externalusers` WHERE `user_email` = '$userEmail'";
-		$result = mysql_query($query);
-		while ($row = mysql_fetch_row($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		while ($row = mysqli_fetch_row($result)) {
 			if (!isInternalUserRegistered($userId, $row[0], false)) {
 				$insertQuery = "INSERT INTO `newsletter_users`(`page_modulecomponentid`, `newsletter_subscriptiontype`, `user_id`, `user_joindatetime`) VALUES ({$row[0]}, 'user', $userId, NOW())";
-				if (!mysql_query($insertQuery)) {
+				if (!mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery)) {
 					displayerror('Could not add user to internal list.');
 				}
 				else {
 					$deleteQuery  = "DELETE FROM `newsletter_externalusers` WHERE `page_modulecomponentid` = {$row[0]} AND `user_email` = '$userEmail'";
-					if (!mysql_query($deleteQuery))
+					if (!mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery))
 						displayerror('Could not remove user from external list.');
 				}
 			}
 			else {
 				$deleteQuery = "DELETE FROM `newsletter_externalusers` WHERE `page_modulecomponentid` = {$row[0]} AND `user_email` = '$userEmail'";
-				if (!mysql_query($deleteQuery))
+				if (!mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery))
 					displayerror('Could not remove user from external list.');
 			}
 		}
@@ -85,8 +85,8 @@ class newsletter implements module {
 
 	private static function isInternalUserRegistered($userId, $moduleComponentId, $testGroups = true) {
 		$userExistsQuery = "SELECT COUNT(*) FROM `newsletter_users` WHERE `page_modulecomponentid` = $moduleComponentId AND `newsletter_subscriptiontype` = 'group'";
-		$userExistsResult = mysql_query($userExistsQuery);
-		if ($userExistsRow = mysql_fetch_row($userExistsResult))
+		$userExistsResult = mysqli_query($GLOBALS["___mysqli_ston"], $userExistsQuery);
+		if ($userExistsRow = mysqli_fetch_row($userExistsResult))
 			if ($userExistsRow[0] == 1)
 				return true;
 
@@ -95,8 +95,8 @@ class newsletter implements module {
 			$usergroupTable = MYSQL_DATABASE_PREFIX . 'usergroup';
 			$groupsQuery = "SELECT COUNT(*) FROM `newsletter_users`, `$usergroupTable` WHERE `newsletter_users`.`page_modulecomponentid` = $moduleComponentId AND `newsletter_users`.`newsletter_subscriptiontype` = 'group' " .
 					"AND `$usergroupTable`.`user_id` = $userId AND `newsletter_users`.`usergroup_id` = `$usergroupTable`.`group_id`";
-			$groupsResult = mysql_query($groupsQuery);
-			if ($groupsResultRow = mysql_fetch_row($groupsResult))
+			$groupsResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupsQuery);
+			if ($groupsResultRow = mysqli_fetch_row($groupsResult))
 				if ($groupsResultRow[0] > 0)
 					return true;
 		}
@@ -106,8 +106,8 @@ class newsletter implements module {
 
 	public static function isExternalUserRegistered($userEmail, $moduleComponentId) {
 		$userExistsQuery = "SELECT COUNT(*) FROM `newsletter_externalusers` WHERE `page_modulecomponentid` = $moduleComponentId AND `user_email` = '$userEmail'";
-		$userExistsResult = mysql_query($userExistsQuery);
-		if ($userExistsRow = mysql_fetch_row($userExistsResult))
+		$userExistsResult = mysqli_query($GLOBALS["___mysqli_ston"], $userExistsQuery);
+		if ($userExistsRow = mysqli_fetch_row($userExistsResult))
 			if ($userExistsRow[0] == 1)
 				return true;
 		return false;
@@ -115,8 +115,8 @@ class newsletter implements module {
 
 	private function getNewsletterName($listId) {
 		$listNameQuery = 'SELECT `newsletter_name` FROM `newsletter_desc` WHERE `page_modulecomponentid` = ' . $listId;
-		$listNameResult = mysql_query($listNameQuery);
-		if ($listNameRow = mysql_fetch_row($listNameQuery))
+		$listNameResult = mysqli_query($GLOBALS["___mysqli_ston"], $listNameQuery);
+		if ($listNameRow = mysqli_fetch_row($listNameQuery))
 			return $listNameRow[0];
 		return '';
 	}
@@ -128,10 +128,10 @@ class newsletter implements module {
 	// return an array containing name of list, path, boolean indicating if user is registered or not
 	public static function getSubscribableLists($userId) {
 		$newsletterListQuery = 'SELECT `page_id`, `page_modulecomponentid` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_module` = \'newsletter\' ORDER BY `page_modulecomponentid`';
-		$newsletterListResult = mysql_query($newsletterListQuery);
+		$newsletterListResult = mysqli_query($GLOBALS["___mysqli_ston"], $newsletterListQuery);
 
 		$subscribableLists = array();
-		while ($newsletterListRow = mysql_fetch_row($newsletterListQuery)) {
+		while ($newsletterListRow = mysqli_fetch_row($newsletterListQuery)) {
 			if (getPermissions($userId, $newsletterListRow[0], 'view', 'newsletter')) {
 				$listName = getNewsletterName($newsletterListRow[1]);
 				$listPath = getNewsletterPath($newsletterListRow[0]);
@@ -160,7 +160,7 @@ class newsletter implements module {
 
 	public function createModule($compId) {
 		$query = "INSERT INTO `newsletter_desc` (`page_modulecomponentid` ,`newsletter_name`)VALUES ('$compId', 'New Newsletter')";
-		$result = mysql_query($query) or die(mysql_error()."newsletter.lib L:188");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."newsletter.lib L:188");
 	}
 
 	public function deleteModule($moduleComponentId) {

--- a/cms/modules/newsletter/importContacts.php
+++ b/cms/modules/newsletter/importContacts.php
@@ -25,24 +25,24 @@ include_once("../../common.lib.php");
 connect();
 
 $query="SELECT `user_email` FROM `".MYSQL_DATABASE_PREFIX."users`";
-$result=mysql_query($query);
-while($temp=mysql_fetch_array($result,MYSQL_NUM))
+$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+while($temp=mysqli_fetch_array($result, MYSQLI_NUM))
 {
 foreach($temp as  $mail)
 {
 
 	$query1="SELECT * FROM `newsletter` WHERE `email`='$mail' ";
 //	echo $query1."<br>";
-	$result1=mysql_query($query1);
-	echo mysql_num_rows($result1).$query1."<br>";
+	$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+	echo mysqli_num_rows($result1).$query1."<br>";
 
-	if(!mysql_num_rows($result1))
+	if(!mysqli_num_rows($result1))
 	{
 		$query2="INSERT INTO `newsletter` (`email` ,`sent`)VALUES ('$mail','0')";
 		echo $query2."<br>";
-		$result2=mysql_query($query2) ;
-		if(mysql_affected_rows($result2)>0)echo "$mail inserted into newsletter<br>";
-		echo mysql_affected_rows($result2)."<=RES<br>";
+		$result2=mysqli_query($GLOBALS["___mysqli_ston"], $query2) ;
+		if(mysqli_affected_rows($result2)>0)echo "$mail inserted into newsletter<br>";
+		echo mysqli_affected_rows($result2)."<=RES<br>";
 
 //		echo $query2."<br>";
 	}

--- a/cms/modules/oc.lib.php
+++ b/cms/modules/oc.lib.php
@@ -91,8 +91,8 @@ public function actionOcteam() {
     //changed to use userid instead of rollno
     $fetchUserRollQuery = "SELECT * FROM `oc_form_reg` WHERE `page_moduleComponentId`={$mcId} AND 
                                       `user_id`='{$roll}'";
-    $fetchUserRollResult = mysql_query($fetchUserRollQuery);
-    $roll=mysql_fetch_assoc($fetchUserRollResult)['oc_roll_no'];
+    $fetchUserRollResult = mysqli_query($GLOBALS["___mysqli_ston"], $fetchUserRollQuery);
+    $roll=mysqli_fetch_assoc($fetchUserRollResult)['oc_roll_no'];
 
     checkExisting($mcId,$roll,0,$this->userId); 
     $form =<<<FORM
@@ -135,7 +135,7 @@ public function actionOchead() {
       $email = $excelData[$i][2].'@nitt.edu';
    	 $query="INSERT IGNORE INTO `oc_valid_emails` (`page_moduleComponentId`,`oc_name`,`oc_valid_email`) 
                                             VALUES ($mcId,'{$excelData[$i][1]}','{$email}')";
-      mysql_query($query) or displayerror($email);
+      mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror($email);
      
     }
     //echo $c." ".$d;

--- a/cms/modules/oc/oc_common.php
+++ b/cms/modules/oc/oc_common.php
@@ -18,8 +18,8 @@ if(!defined('__PRAGYAN_CMS')) {
 function getAuthMethod($userId) {
   if($userId <= 0) return "Anonymous";
   $query = "SELECT `user_loginmethod` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".$userId."'";
-  $result = mysql_query($query);
-  $row = mysql_fetch_row($result);
+  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+  $row = mysqli_fetch_row($result);
   return $row[0];
 
 }
@@ -35,8 +35,8 @@ function handleRegistrationFormSubmit($userId,$mcId) {
    global $authmethods;
    $rollNo=substr($email,0,strrpos($email,'@'.$authmethods['imap']['user_domain']));
    $checkIfUserRegisteredquery = "SELECT * from `oc_form_reg` WHERE `page_moduleComponentId`={$mcId} AND `user_id`={$userId}";
-   $checkIfUserRegisteredResult = mysql_query($checkIfUserRegisteredquery) or die(mysql_error());
-   if(mysql_num_rows($checkIfUserRegisteredResult)>0) {
+   $checkIfUserRegisteredResult = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserRegisteredquery) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+   if(mysqli_num_rows($checkIfUserRegisteredResult)>0) {
   if(!checkIfUserWhiteListed($mcId,getUserEmail($userId))) {
     displaywarning("<b>There are problems that persisting with your current mess account.</b><br/>Pragyan team will get back to you after identification of your problem.<br/><b>Your details have been noted</b>" );
    return false;
@@ -71,7 +71,7 @@ if(!isset($_POST['gender'])){
                                  VALUES ('$mcId','{$name}','{$amount}','{$userId}','{$tsize}','{$gender}',NOW(),$rollNo)";
      }*/
      else displaywarning("Good Try.But you won't get Food Coupon worth Rs.700");
-     if(mysql_query($query)) {
+     if(mysqli_query($GLOBALS["___mysqli_ston"], $query)) {
 	 displayinfo("Your registration is complete.");
        
        return false;
@@ -123,15 +123,15 @@ TABLE;
   $Yes = "green";
   $No = "red";
   $getRegisteredUserDetailQuery = "SELECT * FROM `oc_form_reg` WHERE `page_moduleComponentId`=1 ORDER BY oc_roll_no";
-  $getRegisteredUserOc = mysql_query($getRegisteredUserDetailQuery) or displayerror("Error on viewing registered user".mysql_error());
-  while($res = mysql_fetch_assoc($getRegisteredUserOc)) {
+  $getRegisteredUserOc = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailQuery) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($getRegisteredUserOc)) {
     //    $email = getUserEmail($res['user_id']);
     $rollNumber = $res['oc_roll_no'];
     $email = $res['oc_roll_no'].'@nitt.edu';
     //  if(!checkIfUserWhiteListed($mcId,$email)) continue;
   $getRegisteredUserDetailQuery1 = "SELECT * FROM `oc_valid_emails` WHERE `page_moduleComponentId`=1 AND oc_valid_email='{$email}'";
-  $getRegisteredUserOc1 = mysql_query($getRegisteredUserDetailQuery1) or displayerror("Error on viewing registered user".mysql_error());
-  $result12345 = mysql_fetch_assoc($getRegisteredUserOc1);
+  $getRegisteredUserOc1 = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailQuery1) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $result12345 = mysqli_fetch_assoc($getRegisteredUserOc1);
   
     
     $userDetails .=<<<TR
@@ -164,7 +164,7 @@ function view_whitelist_emails($mcId){
   if(isset($_POST['remove_email'])){
     $removing_user=escape($_POST['removing']);
     $query="DELETE FROM `oc_valid_emails` WHERE `oc_valid_email`='{$removing_user}' AND `page_moduleComponentId`={$mcId}";
-    mysql_query($query) or displayerror(mysql_error());
+    mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   }
   $userDetails =<<<TABLE
     $smarttablestuff
@@ -178,8 +178,8 @@ function view_whitelist_emails($mcId){
     </thead>
 TABLE;
   $getRegisteredUserDetailQuery = "SELECT oc_name,oc_valid_email FROM `oc_valid_emails` WHERE `page_moduleComponentId`={$mcId}";
-  $getRegisteredUserOc = mysql_query($getRegisteredUserDetailQuery) or displayerror("Error on viewing registered user".mysql_error());
-  while($res = mysql_fetch_assoc($getRegisteredUserOc)) {
+  $getRegisteredUserOc = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailQuery) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($getRegisteredUserOc)) {
     $name = $res['oc_name'];
     $email = $res['oc_valid_email'];
     $userDetails .=<<<TR
@@ -205,13 +205,13 @@ function add_whitelist_email($mcId){
   if(isset($_POST['add_email'])) {
     $name  = escape($_POST['roll']); 
     $email = escape($_POST['email']);
-    $query = mysql_query("INSERT IGNORE INTO `oc_valid_emails` (`page_modulecomponentid`,`oc_name`,`oc_valid_email`) 
+    $query = mysqli_query($GLOBALS["___mysqli_ston"], "INSERT IGNORE INTO `oc_valid_emails` (`page_modulecomponentid`,`oc_name`,`oc_valid_email`) 
                                                       VALUES ('$mcId','{$name}','{$email}')");
     if($query) {
       displayinfo("Successfully Added");
     }
     else {
-      displayinfo(mysql_error());
+      displayinfo(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     }
   }
   $addWhiteList=<<<FORM
@@ -229,15 +229,15 @@ function addToAvailability($mcId,$key,$pair) {
   escape($key);
   escape($pair);
   $checkIfKeyExistQuery = "SELECT * from `oc_config` WHERE `key`='{$key}' AND `page_moduleComponentId`={$mcId}";
-  $checkIfKeyExistResult = mysql_query($checkIfKeyExistQuery) or displayerror(mysql_error());
+  $checkIfKeyExistResult = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfKeyExistQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if((!$checkIfKeyExistResult)) {
     return;
   }
-  if(mysql_num_rows($checkIfKeyExistResult)) {
+  if(mysqli_num_rows($checkIfKeyExistResult)) {
     return;
   }
   $insertNewKeyQuery = "INSERT INTO `oc_config` VALUES ('{$mcId}','{$key}','{$pair}')";
-  $insertNewKeyResult = mysql_query($insertNewKeyQuery) or displayerror(mysql_error()); 
+  $insertNewKeyResult = mysqli_query($GLOBALS["___mysqli_ston"], $insertNewKeyQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 
   return;
 }
 
@@ -257,12 +257,12 @@ function availability($mcId){
     }
     else {
       $updateDetailsQuery = "UPDATE `oc_config` SET `value`='{$pair}' WHERE `key`='{$key}' AND `page_moduleComponentId`={$mcId}";
-      $updateDetailsResult = mysql_query($updateDetailsQuery) or displayerror(mysql_error());
+      $updateDetailsResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     }
   }  
 
   $getKeyQuery = "SELECT * from `oc_config` WHERE `page_moduleComponentId`={$mcId}";
-  $getKeyResult = mysql_query($getKeyQuery) or displayerror(mysql_error());
+  $getKeyResult = mysqli_query($GLOBALS["___mysqli_ston"], $getKeyQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if((!$getKeyResult)) {
     displayerror("Please contact System Administrator for ficing the error");
     return;
@@ -276,7 +276,7 @@ function availability($mcId){
       </tr>
 TABLE;
 
-  while($result = mysql_fetch_assoc($getKeyResult)) {
+  while($result = mysqli_fetch_assoc($getKeyResult)) {
     $tableDetails.=<<<TABLE
       <tr>
         <th>{$result['key']}</th>
@@ -308,15 +308,15 @@ function reg_status($mcId){
           <th>Total No. Of 700 Plan</th>
       </thead>
 TABLE;
-  $getRegStatus700 = mysql_query("SELECT * FROM `oc_form_reg` WHERE `amount`='700' AND `page_moduleComponentId`={$mcId}") 
-                             or displayerror(mysql_error());
-  $getRegStatus500 = mysql_query("SELECT * FROM `oc_form_reg` WHERE `amount`='500' AND `page_moduleComponentId`={$mcId}")
-                             or displayerror(mysql_error());
-  $totalReg = mysql_query("SELECT `user_id` FROM `oc_form_reg` WHERE `page_moduleComponentId`={$mcId}")
-                      or displayerror(mysql_error());
-  $countReg=mysql_num_rows($totalReg); 
-  $countReg500=mysql_num_rows($getRegStatus500); 
-  $countReg700=mysql_num_rows($getRegStatus700);
+  $getRegStatus700 = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `oc_form_reg` WHERE `amount`='700' AND `page_moduleComponentId`={$mcId}") 
+                             or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $getRegStatus500 = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `oc_form_reg` WHERE `amount`='500' AND `page_moduleComponentId`={$mcId}")
+                             or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $totalReg = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_id` FROM `oc_form_reg` WHERE `page_moduleComponentId`={$mcId}")
+                      or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $countReg=mysqli_num_rows($totalReg); 
+  $countReg500=mysqli_num_rows($getRegStatus500); 
+  $countReg700=mysqli_num_rows($getRegStatus700);
   $userDetails .=<<<TR
       <tr>
         <td>{$countReg}</td>
@@ -333,21 +333,21 @@ TABLEEND;
 function checkIfUserWhiteListed($mcId,$email) {
    $checkIfWhiteListQuery = "SELECT  `oc_name` FROM `oc_valid_emails` 
                         WHERE `page_moduleComponentId`={$mcId} AND `oc_valid_email`='{$email}'";
-   $checkIfWhiteListResult = mysql_query($checkIfWhiteListQuery);
-   if(mysql_num_rows($checkIfWhiteListResult)==1) return true;
+   $checkIfWhiteListResult = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfWhiteListQuery);
+   if(mysqli_num_rows($checkIfWhiteListResult)==1) return true;
    return false;
 }
 
 function isAvailable($mcId,$str) {
   $str=escape($str);
   $query = "SELECT `value` FROM `oc_config` WHERE `page_moduleComponentId` = '{$mcId}' AND `key` = '{$str}'";
-  $queryResult = mysql_query($query) or displayerror(mysql_error());
+  $queryResult = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if(!$queryResult) return false;
-  if(!mysql_num_rows($queryResult)) {
+  if(!mysqli_num_rows($queryResult)) {
     displaywarning("Invalid Key Given");
     return false;
   }
-  $value = mysql_fetch_assoc($queryResult);
+  $value = mysqli_fetch_assoc($queryResult);
   if($value['value'] == 'Yes')  return true;
   return false;
 }
@@ -376,7 +376,7 @@ function handleTShirtDistribution($mcId,$userId,$tShirtSize,$toDistribute = 0,$r
   } 
    $updateQuery = "UPDATE `oc_form_reg` SET `oc_tshirt_distributed`='Yes' , `updated_time`=NOW()
                            WHERE `oc_roll_no`={$userId} AND `page_moduleComponentId`={$mcId}";
-   if(mysql_query($updateQuery)) {
+   if(mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery)) {
     echo "Confirmed {$userId}:  ".$tShirtSize." to ".$userId.". $processIMG<br/><hr/>";
     $mailtype = "tshirt_registration";
     $messenger = new messenger(false);
@@ -417,7 +417,7 @@ function handleFoodCouponDistribution($mcId,$userId,$toDistribute = 0,$registere
   } 
    $updateQuery = "UPDATE `oc_form_reg` SET `oc_food_coupon_distributed`='Yes' , `updated_time`=NOW()
                            WHERE `oc_roll_no`={$userId} AND `page_moduleComponentId`={$mcId}";
-   if(mysql_query($updateQuery)) {
+   if(mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery)) {
     echo "Confirmed: Food Coupon to ".$userId.". $processIMG<br/><hr/>";
     $mailtype = "food_registration";
     $messenger = new messenger(false);
@@ -431,7 +431,7 @@ function handleFoodCouponDistribution($mcId,$userId,$toDistribute = 0,$registere
     $messenger->mailer($to,$mailtype,"",$from);
     }       
    else {
-    displayerror(mysql_error());
+    displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     echo "There is a error in Food Coupon Distribution.Contact System Administrator.Do not Distribute Food Coupon. $wrongIMG<br/><hr/>";
    }
    return;
@@ -460,7 +460,7 @@ function handleExtras($mcId,$userId,$toDistribute = 0) {
   } 
    $updateQuery = "UPDATE `oc_form_reg` SET `oc_extra_distributed`='Yes' , `updated_time` = NOW()
                            WHERE `oc_roll_no`={$userId} AND `page_moduleComponentId`={$mcId}";
-   if(mysql_query($updateQuery)) {
+   if(mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery)) {
     echo "Confirmed: Distribute Extra to ".$userId.". $processIMG<br/><hr/>";
    }       
    else {
@@ -488,13 +488,13 @@ function checkExisting($mcId,$barCode_roll,$submit = 0,$registeredBy){
   $userId = getUserIdFromEmail($email);
   $fetchUserDetailQuery = "SELECT * FROM `oc_form_reg` WHERE `page_moduleComponentId`={$mcId} AND 
                                       `oc_roll_no`='{$barCode_roll}'";
-  $fetchUserDetailResult = mysql_query($fetchUserDetailQuery);
+  $fetchUserDetailResult = mysqli_query($GLOBALS["___mysqli_ston"], $fetchUserDetailQuery);
   if(!$fetchUserDetailResult) {
     echo "There is an error is handling details.Contact CSG for more details. $wrongIMG<br/><hr/>";
     return;
   }
-  $userDetails = mysql_fetch_assoc($fetchUserDetailResult);
-  if(mysql_num_rows($fetchUserDetailResult)!=1) {
+  $userDetails = mysqli_fetch_assoc($fetchUserDetailResult);
+  if(mysqli_num_rows($fetchUserDetailResult)!=1) {
     echo "User ".$barCode_roll." has not registered for Coupons or T-Shirt. $wrongIMG<br/><hr/>";
     return;
   }
@@ -553,7 +553,7 @@ function upload_tshirt_list($mcId) {
       if($tsize == '') $tsize='N';
             $query="INSERT IGNORE INTO `oc_form_reg` (`page_modulecomponentid`,`name`,`amount`,`user_id`,`Tshirt_size`,`updated_time`,`oc_roll_no`) 
                                  VALUES ('$mcId','{$name}','700','0','{$tsize}',NOW(),'{$rollNumber}')";
-      mysql_query($query) or displayerror(mysql_error());
+      mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       
       //      $query = "UPDATE `oc_form_reg` SET Tshirt_size='{$tsize}' WHERE page_modulecomponentid='{$mcId}' AND oc_roll_no='{$rollNumber}'";  
       // mysql_query($query) or displayerror(mysql_error());
@@ -577,12 +577,12 @@ function download_black_list($mcId) {
       </tr>
 TABLE;
   $viewBlackListQuery="SELECT `name`,`oc_roll_no` FROM oc_form_reg WHERE `page_moduleComponentId`={$mcId} ORDER BY oc_roll_no";
-  $viewBlackListQueryRes = mysql_query($viewBlackListQuery) or displayerror(mysql_error());
-  while($res = mysql_fetch_assoc($viewBlackListQueryRes)) {
+  $viewBlackListQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $viewBlackListQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($viewBlackListQueryRes)) {
     $email = $res['oc_roll_no'].'@nitt.edu';
     $checkIfExist = "SELECT oc_valid_email FROM oc_valid_emails WHERE oc_valid_email='{$email}' AND `page_moduleComponentId`={$mcId}";
-    $checkIfExistRes = mysql_query($checkIfExist) or displayerror(mysql_error());
-    if(!mysql_num_rows($checkIfExistRes)) {
+    $checkIfExistRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfExist) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(!mysqli_num_rows($checkIfExistRes)) {
       $tableUpdate.=<<<TR
       <tr>
         <td>{$res['name']}</td>

--- a/cms/modules/pagelist.lib.php
+++ b/cms/modules/pagelist.lib.php
@@ -43,8 +43,8 @@ class pagelist implements module {
 		$pageid = getPageIdFromModuleComponentId("pagelist",$this->moduleComponentId);
 		$pageid=getParentPage($pageid);
 		$query = "SELECT `depth` FROM `list_prop` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-		$result = mysql_query($query) or die(mysql_error());
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$row = mysqli_fetch_assoc($result);
 		$reqdepth=$row['depth'];
 		$out=$this->generatePagelist($pageid, $this->userId, 0, 'view',$reqdepth+1);
 		return $out;
@@ -58,8 +58,8 @@ class pagelist implements module {
 		
 		else {
 			$permQuery = 'SELECT `page_module`, `perm_action` FROM `' . MYSQL_DATABASE_PREFIX . 'permissionlist` WHERE `perm_id` = \'' . $permId."'";
-			$permResult = mysql_query($permQuery);
-			$permRow = mysql_fetch_row($permResult);
+			$permResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
+			$permRow = mysqli_fetch_row($permResult);
 			$module = $permRow[0];
 			$action = $permRow[1];
 			$treeData .= $this->getNodeHtmlforPagelist($pageId, $userId, $module, $action, $urlRequestRoot . '/', $depth);
@@ -122,9 +122,9 @@ class pagelist implements module {
 			$htmlOut.="<span class='list'><img src='$thumbname' alt=' !sorry! '>" . getPageTitle($pageId) . "</span></a>\n</form>";
 
 			$childrenQuery = 'SELECT `page_id`, `page_displayinmenu` FROM `' . MYSQL_DATABASE_PREFIX  . 'pages` WHERE `page_parentid` <> `page_id` AND `page_parentid` = ' . $pageId;
-			$childrenResult = mysql_query($childrenQuery);
+			$childrenResult = mysqli_query($GLOBALS["___mysqli_ston"], $childrenQuery);
 			$childrenHtml = '';
-			while($childrenRow = mysql_fetch_row($childrenResult)) {
+			while($childrenRow = mysqli_fetch_row($childrenResult)) {
 				if($childrenRow[1] == 1&&$depth!=0) {
 					$childrenHtml .= $this->getNodeHtmlforPagelist($childrenRow[0], $userId, $module, $action, $pagePath, $depth-1);
 				
@@ -146,15 +146,15 @@ class pagelist implements module {
 		if(isset($_POST['depth'])) 
 		{ 		
 			$query = "UPDATE `list_prop` SET `depth`='".escape($_POST['depth'])."' WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-			$result = mysql_query($query);
-			if (mysql_affected_rows()) 	 
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if (mysqli_affected_rows($GLOBALS["___mysqli_ston"])) 	 
 				$ret.="<div class='cms-info'>Depth value updated.</div>";
 			else $ret.="<div class='cms-info'>ok. updated. (Its already set)</div>";	 
 		}	
 
 		$query = "SELECT `depth` FROM `list_prop` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-		$result = mysql_query($query) or die(mysql_error());
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+		$row = mysqli_fetch_assoc($result);
 		
 		$ret.="<form action='./+edit&subaction=submit' method=POST>
 <table>
@@ -176,7 +176,7 @@ class pagelist implements module {
 		
 		$defaultdepth=3;
 		$query = "INSERT INTO `list_prop` (`page_modulecomponentid`, `depth`) VALUES ('$compId', '$defaultdepth')";
-		$result = mysql_query($query) or die(mysql_error());
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}
 	
 	

--- a/cms/modules/poll.lib.php
+++ b/cms/modules/poll.lib.php
@@ -34,15 +34,15 @@ class poll implements module {
 			$display="<h2>Poll!</h2><br /><div align='center'>";
 			
 			$query="SELECT * FROM `poll_content` WHERE `visibility`='1' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			$r=mysql_query($query);
-			$n=mysql_num_rows($r);
-			while($row=mysql_fetch_array($r))
+			$r=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$n=mysqli_num_rows($r);
+			while($row=mysqli_fetch_array($r))
 			{
 				$m=$row['multiple_opt'];
 				$p=$row['pid'];	
 				$query2="SELECT * FROM `poll_users` WHERE `pid`='$p' AND `page_modulecomponentid`='$this->moduleComponentId' AND `userID`='$this->userId'";
-				$r2=mysql_query($query2);
-				$n2=mysql_num_rows($r2);
+				$r2=mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+				$n2=mysqli_num_rows($r2);
 				if($n2==0)   ///<the user has not yet voted for this poll
 				{       
 					    $display.="<form name='f".$p."' method='post' action='./+cast'><table width='50%'><tr><td align='center'><b><div align='center'>".$row['ques']."</div></b></td></tr>";
@@ -85,8 +85,8 @@ class poll implements module {
 				else
 				{
 						$query5="SELECT * FROM `poll_log` WHERE `pid`='".$p."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$res5=mysql_query($query5);
-						$row5=mysql_fetch_array($res5);
+						$res5=mysqli_query($GLOBALS["___mysqli_ston"], $query5);
+						$row5=mysqli_fetch_array($res5);
 						$total=$row5['o1']+$row5['o2']+$row5['o3']+$row5['o4']+$row5['o5']+$row5['o6'];
 						
 						if($row['o1']!=NULL)
@@ -132,11 +132,11 @@ class poll implements module {
 		$pid=escape($_POST['id']);
 
 		$query="INSERT INTO `poll_users`(`pid`,`userID`,`page_modulecomponentid`) VALUES('$pid','$user','$this->moduleComponentId')";
-		mysql_query($query);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		
 		$query2="SELECT * FROM `poll_content` WHERE `visibility`='1' AND `page_modulecomponentid`='$this->moduleComponentId' AND `pid`='".$pid."'";
-		$r1=mysql_query($query2);
-		$row=mysql_fetch_array($r1);
+		$r1=mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+		$row=mysqli_fetch_array($r1);
 		$m=$row['multiple_opt'];
 		
 		if($m==1)
@@ -150,7 +150,7 @@ class poll implements module {
 				else
 					$v=0;
 				$query1="UPDATE `poll_log` SET `$o`=`$o`+$v WHERE `pid` = $pid AND `page_modulecomponentid`=$this->moduleComponentId";
-				mysql_query($query1);
+				mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 			}
 		}
 		if($m==0)
@@ -158,13 +158,13 @@ class poll implements module {
 			$opt=escape($_POST['o']);
 			$o="o".$opt;
 			$query1="SELECT * FROM `poll_log` WHERE `pid`='".$pid."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			$res1=mysql_query($query1);
-			$n=mysql_num_rows($res1);
-			$val=mysql_fetch_array($res1);
+			$res1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			$n=mysqli_num_rows($res1);
+			$val=mysqli_fetch_array($res1);
 			$value=$val["$o"];
 			$value+=1;
 			$query2="UPDATE `poll_log` SET `$o` = '$value' WHERE `pid` = '$pid' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			mysql_query($query2);
+			mysqli_query($GLOBALS["___mysqli_ston"], $query2);
 		}
 		return $this->actionView();
 	}
@@ -197,7 +197,7 @@ class poll implements module {
 						$o6=htmlspecialchars(escape($_POST['o6']));
 						displayinfo('Poll Question Updated Succesfully');
 						$query="UPDATE `poll_content` SET `ques` = '$q',`o1` = '$o1',`o2` = '$o2',`o3` = '$o3',`o4` = '$o4',`o5` = '$o5',`o6` = '$o6',`multiple_opt` = '$multi' WHERE `pid` = $pid AND `page_modulecomponentid`='$this->moduleComponentId'";
-						mysql_query($query);
+						mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					}
 				return $this-> actionView();
 				}
@@ -216,20 +216,20 @@ class poll implements module {
 						displayinfo('Poll Question Added Succesfully');
 						$query="INSERT INTO `poll_content` (`page_modulecomponentid`,`ques` ,`o1` ,`o2` ,`o3` ,`o4` ,`o5` ,`o6` ,`visibility`)
 						VALUES ('$this->moduleComponentId','".htmlspecialchars(escape($_POST['q']))."','".htmlspecialchars(escape($_POST['o1']))."','".htmlspecialchars(escape($_POST['o2']))."','".htmlspecialchars(escape($_POST['o3']))."','".htmlspecialchars(escape($_POST['o4']))."','".htmlspecialchars(escape($_POST['o5']))."','".htmlspecialchars(escape($_POST['o6']))."','1')";
-						$result=mysql_query($query);
+						$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 						
 						if($_POST['multi']=='y')
 						{
 							$query5="UPDATE `poll_content` SET `multiple_opt`='1' WHERE `ques`='".htmlspecialchars(escape($_POST['q']))."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-							$result5=mysql_query($query5);
+							$result5=mysqli_query($GLOBALS["___mysqli_ston"], $query5);
 						}
 						
 						$query0="SELECT max(`pid`) from `poll_content` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-						$result0=mysql_query($query0);
-						$row0=mysql_fetch_array($result0);
+						$result0=mysqli_query($GLOBALS["___mysqli_ston"], $query0);
+						$row0=mysqli_fetch_array($result0);
 						
 						$query1="INSERT INTO `poll_log` (`pid`,`page_modulecomponentid`) VALUES ('".$row0[0]."','$this->moduleComponentId')";
-						$result1=mysql_query($query1);
+						$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 			
 					}
 				}
@@ -239,12 +239,12 @@ class poll implements module {
 					
 					$pollid=escape($_POST['ques1']);
 					$query3="SELECT * FROM `poll_content` WHERE `pid`= '$pollid' AND `page_modulecomponentid`='$this->moduleComponentId'";
-					$result3=mysql_query($query3);
-					$nop=mysql_num_rows($result3);
+					$result3=mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+					$nop=mysqli_num_rows($result3);
 					if($nop==1)
 					{
 						$query4="UPDATE `poll_content` SET `visibility`='0' WHERE `pid`= '$pollid' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$result4=mysql_query($query4);
+						$result4=mysqli_query($GLOBALS["___mysqli_ston"], $query4);
 					}
 					displayinfo("Poll Question Disabled");
 			
@@ -254,7 +254,7 @@ class poll implements module {
 				{
 					$pollid=escape($_POST['ques0']);
 					$query="SELECT * FROM `poll_content` WHERE `pid` = '$pollid' AND `page_modulecomponentid`='$this->moduleComponentId'";
-					$row=mysql_fetch_array(mysql_query($query));
+					$row=mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], $query));
 					$ques=$row['ques'];
 					$o1=$row['o1'];
 					$o2=$row['o2'];
@@ -297,12 +297,12 @@ class poll implements module {
 					
 					$pollid=escape($_POST['ques2']);
 					$query3="SELECT * FROM `poll_content` WHERE `pid`= '$pollid' AND `page_modulecomponentid`='$this->moduleComponentId'";
-					$result3=mysql_query($query3);
-					$nop=mysql_num_rows($result3);
+					$result3=mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+					$nop=mysqli_num_rows($result3);
 					if($nop==1)
 					{
 						$query4="UPDATE `poll_content` SET `visibility`='1' WHERE `pid`= '$pollid' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$result4=mysql_query($query4);
+						$result4=mysqli_query($GLOBALS["___mysqli_ston"], $query4);
 					}
 					displayinfo("Poll Question Enabled");
 				}
@@ -312,9 +312,9 @@ class poll implements module {
 					
 					$pollid=escape($_POST['ques3']);
 					$query4="DELETE FROM `poll_log` WHERE `pid`='$pollid'";
-					$result4=mysql_query($query4);
+					$result4=mysqli_query($GLOBALS["___mysqli_ston"], $query4);
 					$query5="DELETE FROM `poll_content` WHERE `pid`='$pollid'";
-					$result5=mysql_query($query5);
+					$result5=mysqli_query($GLOBALS["___mysqli_ston"], $query5);
 					displayinfo("Poll Question Deleted");
 			
 				}
@@ -340,18 +340,18 @@ class poll implements module {
 				
 				///Edit a poll question
 				$q0="SELECT * FROM `poll_content` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-				$r0=mysql_query($q0);
+				$r0=mysqli_query($GLOBALS["___mysqli_ston"], $q0);
 				$display.="<table width='100%'><tr><td><h3>&nbsp;&nbsp;Edit Poll Question</h3>";
 				$display.="<div align='center'><form name='f4' method='POST' action='./+manage'>";
-				if(mysql_num_rows($r0)==0)
+				if(mysqli_num_rows($r0)==0)
 					$display.="No poll questions exist currently.";
 				else
 				{
 					$display.="<select name='ques0'>";
-					$n0=mysql_num_rows($r0);
+					$n0=mysqli_num_rows($r0);
 					for($i=1;$i<=$n0;$i++)
 					{
-						$row0=mysql_fetch_array($r0);
+						$row0=mysqli_fetch_array($r0);
 						$display.="<option value='".$row0['pid']."'>".$row0['ques'];
 					}
 					$display.="</select><br /><br />";
@@ -361,18 +361,18 @@ class poll implements module {
 				
 				///Disable a poll question
 				$q1="SELECT * FROM `poll_content` WHERE `visibility`='1' AND `page_modulecomponentid`='$this->moduleComponentId'";
-				$r1=mysql_query($q1);
+				$r1=mysqli_query($GLOBALS["___mysqli_ston"], $q1);
 				$display.="<table width='100%'><tr><td><h3>&nbsp;&nbsp;Disable Poll Question</h3>";
 				$display.="<div align='center'><form name='f2' method='POST' action='./+manage'>";
-				if(mysql_num_rows($r1)==0)
+				if(mysqli_num_rows($r1)==0)
 					$display.="All Poll Questions are Currently Disabled!";
 				else
 				{
 					$display.="<select name='ques1'>";
-					$n1=mysql_num_rows($r1);
+					$n1=mysqli_num_rows($r1);
 					for($i=1;$i<=$n1;$i++)
 					{
-						$row1=mysql_fetch_array($r1);
+						$row1=mysqli_fetch_array($r1);
 						$display.="<option value='".$row1['pid']."'>".$row1['ques'];
 					}
 					$display.="</select><br /><br />";
@@ -382,15 +382,15 @@ class poll implements module {
 				
 				///Enable a poll question
 				$q2="SELECT * FROM `poll_content` WHERE `visibility`='0' AND `page_modulecomponentid`='$this->moduleComponentId'";
-				$r2=mysql_query($q2);	
+				$r2=mysqli_query($GLOBALS["___mysqli_ston"], $q2);	
 				$display.="<table width='100%'><tr><td><h3>&nbsp;&nbsp;Enable Poll Question</h3>";
 				$display.="<div align='center'><form name='f3' method='POST' action='./+manage'>";
-				if(mysql_num_rows($r2)==0)
+				if(mysqli_num_rows($r2)==0)
 					$display.="All Poll Questions are Currently Enabled!<br /><br />";
 				else
 				{
 					$display.="<select name='ques2'>";
-					while($row2=mysql_fetch_array($r2))
+					while($row2=mysqli_fetch_array($r2))
 						$display.="<option value='".$row2['pid']."'>".$row2['ques'];
 					$display.="</select><br /><br />";
 					$display.="<input type='submit' name='enable' value=' Enable ' /><br /><br />";
@@ -399,18 +399,18 @@ class poll implements module {
 				
 				///Delete a poll question
 				$q3="SELECT * FROM `poll_content` WHERE `page_modulecomponentid`='$this->moduleComponentId'";
-				$r3=mysql_query($q3);
+				$r3=mysqli_query($GLOBALS["___mysqli_ston"], $q3);
 				$display.="<table width='100%'><tr><td><h3>&nbsp;&nbsp;Delete Poll Question</h3>";
 				$display.="<div align='center'><form name='f3' method='POST' action='./+manage'>";
-				if(mysql_num_rows($r1)==0)
+				if(mysqli_num_rows($r1)==0)
 					$display.="No poll questions exist currently.";
 				else
 				{
 					$display.="<select name='ques3'>";
-					$n3=mysql_num_rows($r3);
+					$n3=mysqli_num_rows($r3);
 					for($i=1;$i<=$n3;$i++)
 					{
-						$row3=mysql_fetch_array($r3);
+						$row3=mysqli_fetch_array($r3);
 						$display.="<option value='".$row3['pid']."'>".$row3['ques'];
 					}
 					$display.="</select><br /><br />";
@@ -428,20 +428,20 @@ class poll implements module {
 			$display="<h2>Statistics</h2><br />";
 			
 			$query="SELECT * FROM `poll_content` WHERE `visibility`='1' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			$r=mysql_query($query);
-			$n=mysql_num_rows($r);
+			$r=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$n=mysqli_num_rows($r);
 			
 			$display.="<table width='100%'><tr><td>";
 			$display.="<h3>Currently Enabled Polls</h3>";
 			if($n==0)
 				$display.="There Exist no Enabled Poll Questions Currently.";
 			else
-			while($row=mysql_fetch_array($r))
+			while($row=mysqli_fetch_array($r))
 				{
 						$p=$row['pid'];
 						$query2="SELECT * FROM `poll_log` WHERE `pid`='".$p."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$res2=mysql_query($query2);
-						$row2=mysql_fetch_array($res2);
+						$res2=mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+						$row2=mysqli_fetch_array($res2);
 						$total=$row2['o1']+$row2['o2']+$row2['o3']+$row2['o4']+$row2['o5']+$row2['o6'];
 						
 						if($row['o1']!=NULL)
@@ -477,20 +477,20 @@ class poll implements module {
 			$display.="</td></tr></table>";
 			
 			$query="SELECT * FROM `poll_content` WHERE `visibility`='0' AND `page_modulecomponentid`='$this->moduleComponentId'";
-			$r=mysql_query($query);
-			$n=mysql_num_rows($r);
+			$r=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$n=mysqli_num_rows($r);
 			
 			$display.="<table width='100%'><tr><td>";
 			$display.="<h3>Currently Disabled Polls</h3>";
 			if($n==0)
 				$display.="There Exist no Disabled Poll Questions Currently.";
 			else
-			while($row=mysql_fetch_array($r))
+			while($row=mysqli_fetch_array($r))
 				{
 						$p=$row['pid'];
 						$query2="SELECT * FROM `poll_log` WHERE `pid`='".$p."' AND `page_modulecomponentid`='$this->moduleComponentId'";
-						$res2=mysql_query($query2);
-						$row2=mysql_fetch_array($res2);
+						$res2=mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+						$row2=mysqli_fetch_array($res2);
 						$total=$row2['o1']+$row2['o2']+$row2['o3']+$row2['o4']+$row2['o5']+$row2['o6'];
 						
 						if($row['o1']!=NULL)

--- a/cms/modules/pr.lib.php
+++ b/cms/modules/pr.lib.php
@@ -99,8 +99,8 @@ REGISTRATIONFORM;
 			}
 
 			$userIdQuery = 'SELECT MAX(`user_id`) FROM `'.MYSQL_DATABASE_PREFIX.'users`';
-			$userIdResult = mysql_query($userIdQuery);
-			$userIdRow = mysql_fetch_row($userIdResult);
+			$userIdResult = mysqli_query($GLOBALS["___mysqli_ston"], $userIdQuery);
+			$userIdRow = mysqli_fetch_row($userIdResult);
 
 			$newUserId = 1;
 			if(!is_null($userIdRow[0]))
@@ -112,7 +112,7 @@ REGISTRATIONFORM;
 			$userFullName=escape($_POST['txtUserFullName']);
 			$insertQuery = 'INSERT INTO `'.MYSQL_DATABASE_PREFIX.'users`(`user_id`, `user_name`, `user_email`, `user_fullname`, `user_password`, `user_regdate`, `user_lastlogin`, `user_activated`) ' .
 					"VALUES($newUserId, '$userFullName', '$userEmail', '$userFullName', MD5('$userPassword'), NOW(), NOW(), 1)";
-			$insertResult = mysql_query($insertQuery);
+			$insertResult = mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery);
 
 			if(!$insertResult) {
 				displayerror('Error. Could not add user to database.');
@@ -127,7 +127,7 @@ REGISTRATIONFORM;
 					"VALUES " .
 					"($newUserId, 0, $contactElementId, '$userContactNumber'), " .
 					"($newUserId, 0, $instituteElementId, '$userInstitute')";
-			$contactInsertResult = mysql_query($contactInsertQuery);
+			$contactInsertResult = mysqli_query($GLOBALS["___mysqli_ston"], $contactInsertQuery);
 			if(!$contactInsertResult) {
 				displayerror('Could not save the contact number of the user.');
 			}

--- a/cms/modules/prhospi.lib.php
+++ b/cms/modules/prhospi.lib.php
@@ -141,9 +141,9 @@ Ck1;
 
   private function getFormSuggestions($input) {
     $emailQuery ="SELECT * FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_name` LIKE '%$input%' AND `page_module`='form'";
-    $emailResult = mysql_query($emailQuery);
+    $emailResult = mysqli_query($GLOBALS["___mysqli_ston"], $emailQuery);
     $suggestions = array($input);
-    while($emailRow = mysql_fetch_row($emailResult)) {
+    while($emailRow = mysqli_fetch_row($emailResult)) {
       $suggestions[] = $emailRow[1]. ' - ' . $emailRow[7];
     }                                                                                                                                           
     return join($suggestions, ',');                                                                                                             
@@ -159,20 +159,20 @@ Ck1;
     if(isset($_GET['subaction'])&&$_GET['subaction'] == 'formDetailsrequired') {
       $cnt=0;
       while(isset($_POST['FormDetail-'.$cnt])&&isset($_POST['hiddenFormDetail-'.$cnt])) {
-	$_POST['hiddenFormDetail-'.$cnt]=mysql_real_escape_string($_POST['hiddenFormDetail-'.$cnt]);
-	$isRequired=(mysql_real_escape_string($_POST['FormDetail-'.$cnt])==='No')?0:1;
+	$_POST['hiddenFormDetail-'.$cnt]=((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $_POST['hiddenFormDetail-'.$cnt]) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
+	$isRequired=(((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $_POST['FormDetail-'.$cnt]) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""))==='No')?0:1;
 	$detailsGiven=explode("-",$_POST['hiddenFormDetail-'.$cnt]);
 	$checkForQuery="SELECT * FROM `prhospi_admin` WHERE `page_modulecomponentid`={$moduleComponentId} AND ";
 	$checkForQuery.="`page_getform_modulecomponentid`={$detailsGiven[1]} AND `details_to_display`='{$detailsGiven[2]}'";
-	if(mysql_num_rows(mysql_query($checkForQuery))) {
+	if(mysqli_num_rows(mysqli_query($GLOBALS["___mysqli_ston"], $checkForQuery))) {
 	  $updateRequiredDetailQuery="UPDATE `prhospi_admin` SET `detail_required`='{$isRequired}' WHERE `page_modulecomponentid`=";
 	  $updateRequiredDetailQuery.="{$moduleComponentId} AND `page_getform_modulecomponentid`={$detailsGiven[1]} AND `details_to_display`='";
 	  $updateRequiredDetailQuery.="{$detailsGiven[2]}'";
-	  $updateRequiredDetailRes=mysql_query($updateRequiredDetailQuery);
+	  $updateRequiredDetailRes=mysqli_query($GLOBALS["___mysqli_ston"], $updateRequiredDetailQuery);
 	}
 	else {
 	  $insertRequiredDetails="INSERT INTO `prhospi_admin` VALUES({$moduleComponentId},{$detailsGiven[1]},{$detailsGiven[2]},'{$isRequired}')";
-	  $insertRequiredResult=mysql_query($insertRequiredDetails);
+	  $insertRequiredResult=mysqli_query($GLOBALS["___mysqli_ston"], $insertRequiredDetails);
 	}
 	$cnt++;
       }
@@ -199,10 +199,10 @@ USER;
       if($findHypenPos !== false) {
 	$formModuleComponentId = substr($inputData,$findHypenPos+2); 
 	$getRequiredQuery = "SELECT * FROM `form_elementdesc` WHERE `page_modulecomponentid` IN (".$formModuleComponentId.",0)";
-	$getRequiredRes = mysql_query($getRequiredQuery);
+	$getRequiredRes = mysqli_query($GLOBALS["___mysqli_ston"], $getRequiredQuery);
 	$tableField="<form action='./+csg&subaction=formDetailsrequired' method='POST'><table border='1'>";
 	$cnt=0;
-	while($result=mysql_fetch_row($getRequiredRes)) {
+	while($result=mysqli_fetch_row($getRequiredRes)) {
 	  $tableField.=<<<REQUIRED
 	  <tr>
 	    <td>{$result[2]}</td>
@@ -385,18 +385,18 @@ checkOut;
     displayinfo(print_r(assignVars($this->userId,$moduleComponentId),true));
 
     if(isset($_POST['amountDetail'])) {
-      $amt=mysql_real_escape_string($_POST['amountDetail']);
+      $amt=((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $_POST['amountDetail']) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
       $insertQuery="UPDATE `prhospi_disclaimer` SET `team_cost`={$amt} WHERE `page_modulecomponentid`={$this->moduleComponentId} AND ";
       $insertQuery.="`disclaimer_team`='hospihead'";
-      $updateRes=mysql_query($insertQuery) or displayerror(mysql_error());
+      $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       if($updateRes!='') displayinfo("Amount Updated to Rs. $amt");
     }
 
     if(isset($_POST['amountDetail1'])) {
-      $amt=mysql_real_escape_string($_POST['amountDetail1']);
+      $amt=((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $_POST['amountDetail1']) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
       $insertQuery="UPDATE `prhospi_disclaimer` SET `team_cost`={$amt} WHERE `page_modulecomponentid`={$this->moduleComponentId} AND ";
       $insertQuery.="`disclaimer_team`='hospihead1'";
-      $updateRes=mysql_query($insertQuery) or displayerror(mysql_error());
+      $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       if($updateRes!='') displayinfo("Amount Updated to Rs. $amt");
     }
     
@@ -404,7 +404,7 @@ checkOut;
       $editorData=escape($_POST['CKEditor1']);
       $insertQuery="UPDATE `prhospi_disclaimer` SET `disclaimer_desc`='{$editorData}' WHERE `page_modulecomponentid`={$this->moduleComponentId} ";
       $insertQuery.="AND `disclaimer_team`='hospihead'";
-      $updateRes=mysql_query($insertQuery) or displayerror(mysql_error());
+      $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       if($updateRes!='') displayinfo("Details Successfully updated !!!");
     }
     if(isset($_POST['downloadSampleFormat'])) {
@@ -422,18 +422,18 @@ checkOut;
 	  $checkIfExistQuery = "SELECT * FROM `prhospi_hostel` 
                                 WHERE `hospi_hostel_name`='{$excelData[$i][1]}' AND 
                                       `hospi_room_no`={$j} AND `page_modulecomponentid`={$moduleComponentId}";
-	  $checkIfExistRes = mysql_query($checkIfExistQuery) or displayerror(mysql_error());
-	  if(mysql_num_rows($checkIfExistRes)) {
+	  $checkIfExistRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfExistQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	  if(mysqli_num_rows($checkIfExistRes)) {
 	    $updateFieldQuery = "UPDATE `prhospi_hostel` 
                                  SET `hospi_room_capacity`={$excelData[$i][4]} , `hospi_floor` =  {$excelData[$i][5]}
                                  WHERE `page_modulecomponentid`={$moduleComponentId} AND 
                                        `hospi_hostel_name`='{$excelData[$i][1]}' AND `hospi_room_no`={$j}";
-	    $updateResult = mysql_query($updateFieldQuery) or displayerror(mysql_error());
+	    $updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateFieldQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	    continue;
 	  }
 	  $insertIntoHospiQuery = "INSERT INTO `prhospi_hostel` (page_modulecomponentid,hospi_hostel_name,hospi_room_capacity,
                                                                       hospi_room_no,hospi_floor)                                                                                            VALUES ({$moduleComponentId},'{$excelData[$i][1]}',{$excelData[$i][4]},{$j},{$excelData[$i][5]})";
-	  $res = mysql_query($insertIntoHospiQuery) or displayerror(mysql_error());
+	  $res = mysqli_query($GLOBALS["___mysqli_ston"], $insertIntoHospiQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	  if($res == "") $success=0;
 	}
       }
@@ -598,10 +598,10 @@ checkOut;
       deletePrUser($detailsGiven[1],$moduleComponentId);
     }
     if(isset($_POST['amountDetail'])) {
-      $amt=mysql_real_escape_string($_POST['amountDetail']);
+      $amt=((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $_POST['amountDetail']) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
       $insertQuery="UPDATE `prhospi_disclaimer` SET `team_cost`={$amt} WHERE `page_modulecomponentid`={$this->moduleComponentId} AND ";
       $insertQuery.="`disclaimer_team`='prhead'";
-      $updateRes=mysql_query($insertQuery) or displayerror(mysql_error());
+      $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       if($updateRes!='') displayinfo("Amount Updated to Rs. $amt");
     }
     
@@ -609,7 +609,7 @@ checkOut;
       $editorData=escape($_POST['CKEditor1']);
       $insertQuery="UPDATE `prhospi_disclaimer` SET `disclaimer_desc`='{$editorData}' WHERE `page_modulecomponentid`={$this->moduleComponentId} ";
       $insertQuery.="AND `disclaimer_team`='prhead'";
-      $updateRes=mysql_query($insertQuery) or displayerror(mysql_error());
+      $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
       if($updateRes!='') displayinfo("Details Successfully updated !!!");
     }
 

--- a/cms/modules/prhospi/accommodation.php
+++ b/cms/modules/prhospi/accommodation.php
@@ -31,13 +31,13 @@ function isRoomAvailable($roomNo,$mcid) {
 
   $countRoomQuery="SELECT `hospi_room_capacity` FROM `prhospi_hostel` 
                    WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id` = {$roomNo} LIMIT 1"; 
-  $countRoomRes = mysql_query($countRoomQuery) or displayerror(mysql_error());
-  $res = mysql_fetch_array($countRoomRes);
+  $countRoomRes = mysqli_query($GLOBALS["___mysqli_ston"], $countRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $res = mysqli_fetch_array($countRoomRes);
   $availableQuery = "SELECT * FROM `prhospi_accomodation_status` 
                    WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id` = {$roomNo}
                    AND `hospi_actual_checkout` IS NULL"; 
-  $availableRes = mysql_query($availableQuery) or displayerror(mysql_error());                 
-  if(mysql_num_rows($availableRes)>=$res[0]) return false;
+  $availableRes = mysqli_query($GLOBALS["___mysqli_ston"], $availableQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));                 
+  if(mysqli_num_rows($availableRes)>=$res[0]) return false;
   return true;
 
 }
@@ -45,11 +45,11 @@ function isRoomAvailable($roomNo,$mcid) {
 // not yet done
 function displayUsersInRoom($roomId,$mcid) {
   $displayQuery = "SELECT * FROM `prhospi_accomodation_status` WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id` = {$roomId}";
-  $displayResult = mysql_query($displayQuery) or displayerror(mysql_error());
+  $displayResult = mysqli_query($GLOBALS["___mysqli_ston"], $displayQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $retForm =<<<DIV
     <div class="roomDetails" style="display:none" id="userInRoom$roomId">
 DIV;
-  while($res = mysql_fetch_assoc($displayResult)) {
+  while($res = mysqli_fetch_assoc($displayResult)) {
     $retForm.="PID: ".$res['user_id'].", Name: ".getUserName($res['user_id']).", Email: ".getUserEmail($res['user_id'])."<br/>";
   }
   $retForm .=<<<DIV
@@ -67,15 +67,15 @@ function addUserToRoom($userId,$roomId,$mcid,$checkedInBy,$registeredBy) {
   }
   
   $userExistQuery="SELECT `user_email` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".$userId."'";
-    $userExistRes = mysql_query($userExistQuery) or displayerror(mysql_error());
-    if(!mysql_num_rows($userExistRes)) {
+    $userExistRes = mysqli_query($GLOBALS["___mysqli_ston"], $userExistQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(!mysqli_num_rows($userExistRes)) {
       displayinfo("Invalid Pragyan Id:".$userId);
       return false;
     }
     $checkIfUserEnrolledQuery = "SELECT * FROM `prhospi_accomodation_status` 
                             WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid}";
-    $checkIfUserEnrolledRes = mysql_query($checkIfUserEnrolledQuery) or displayerror(mysql_error());
-    if(mysql_num_rows($checkIfUserEnrolledRes)) {
+    $checkIfUserEnrolledRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserEnrolledQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(mysqli_num_rows($checkIfUserEnrolledRes)) {
       displayinfo($userId." has already been alloted:");
       return false;
     }
@@ -84,7 +84,7 @@ function addUserToRoom($userId,$roomId,$mcid,$checkedInBy,$registeredBy) {
     $insertDetailsQuery = "INSERT INTO `prhospi_accomodation_status` 
                             (page_modulecomponentid,hospi_room_id,user_id,hospi_actual_checkin,hospi_checkedin_by,user_registered_by)
                             VALUES ($mcid,$roomId,$userId,'{$time}','{$checkedInBy}','{$registeredBy}')";
-    $insertDetailsRes = mysql_query($insertDetailsQuery) or displayerror(mysql_error());
+    $insertDetailsRes = mysqli_query($GLOBALS["___mysqli_ston"], $insertDetailsQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     return true;
 
 }
@@ -102,15 +102,15 @@ function checkOut($userId,$refund,$mcid) {
   
   $checkIfUserEnrolledQuery = "SELECT * FROM `prhospi_accomodation_status` 
                             WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid}";
-  $checkIfUserEnrolledRes = mysql_query($checkIfUserEnrolledQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($checkIfUserEnrolledRes)) {
+  $checkIfUserEnrolledRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserEnrolledQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($checkIfUserEnrolledRes)) {
     displaywarning("User ".getUserName($userId).", not registered for acco or for pragyan site ");
     return false;
     }
   $checkIfUserCheckedOutQuery = "SELECT * FROM `prhospi_accomodation_status` 
                             WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid} AND `hospi_actual_checkout`!='0000-00-00 00:00:00'";
-  $checkIfUserEnrolledRes = mysql_query($checkIfUserCheckedOutQuery) or displayerror(mysql_error());
-  if(mysql_num_rows($checkIfUserEnrolledRes)) {
+  $checkIfUserEnrolledRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserCheckedOutQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(mysqli_num_rows($checkIfUserEnrolledRes)) {
     displaywarning("User ".getUserName($userId).", has already Checkedout ");
     return false;
     }
@@ -119,8 +119,8 @@ function checkOut($userId,$refund,$mcid) {
                   SET `hospi_actual_checkout` = '{$time}',`hospi_cash_refunded`={$refund} 
                   WHERE `page_modulecomponentid`={$mcid} AND `user_id`={$userId}";
   
-   $updateRes = mysql_query($updateQuery) or displayerror(mysql_error());               
-   if(mysql_affected_rows()<=0) {
+   $updateRes = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));               
+   if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])<=0) {
      displaywarning("Pragyan Id: ".$userId.", not registered for acco or for pragyan site ");
      return;
    }
@@ -132,10 +132,10 @@ function checkOut($userId,$refund,$mcid) {
 
 function displayRooms ($mcid,$userId=0) {
   $query="SELECT DISTINCT `hospi_hostel_name` FROM `prhospi_hostel` WHERE `page_modulecomponentid`={$mcid}";
-  $result4=mysql_query($query)or displayerror(mysql_error());
+  $result4=mysqli_query($GLOBALS["___mysqli_ston"], $query)or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $statusall="";
   static $i;
-  while($temp4=mysql_fetch_array($result4,MYSQL_ASSOC)) {
+  while($temp4=mysqli_fetch_array($result4, MYSQLI_ASSOC)) {
     //    $statusall.=$temp4['hospi_hostel_name'];
     $statusall.='<table border="1">';
     $statusall.="<tr><td colspan='8'>{$temp4['hospi_hostel_name']}</td></tr>";
@@ -145,20 +145,20 @@ function displayRooms ($mcid,$userId=0) {
       $query="SELECT *  FROM `prhospi_hostel` 
                 WHERE `hospi_hostel_name`='$temp4[hospi_hostel_name]' AND `hospi_room_no`<>0  
                        AND `hospi_floor`=$i AND `page_modulecomponentid`={$mcid}";
-      $result=mysql_query($query)or displayerror(mysql_error());
-      $num=mysql_num_rows($result);
+      $result=mysqli_query($GLOBALS["___mysqli_ston"], $query)or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+      $num=mysqli_num_rows($result);
       $x=$num/8;
       $x++;
       
       $statusall.="<td rowspan=$x>$i</td>";
-      while($temp=mysql_fetch_array($result,MYSQL_ASSOC)) {
+      while($temp=mysqli_fetch_array($result, MYSQLI_ASSOC)) {
 	$status="<br>Vacant";
 	$query1="SELECT * FROM `prhospi_accomodation_status` 
                  WHERE `hospi_room_id`='$temp[hospi_room_id]' AND `page_modulecomponentid`={$mcid} AND `hospi_actual_checkout` IS NULL";
-	$result1=mysql_query($query1);
-	if(mysql_num_rows($result1)<$temp['hospi_room_capacity']);
+	$result1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+	if(mysqli_num_rows($result1)<$temp['hospi_room_capacity']);
 	else $status="Full";
-	if(mysql_num_rows($result1)>=$temp['hospi_room_capacity']||$temp['hospi_blocked']==1) {
+	if(mysqli_num_rows($result1)>=$temp['hospi_room_capacity']||$temp['hospi_blocked']==1) {
 	  $statusall.='<td id="asdf">';
 	}
 	else {
@@ -169,7 +169,7 @@ function displayRooms ($mcid,$userId=0) {
              <div class="details">
 	  Room No: {$temp['hospi_room_no']}{$usersInRoom}
 ADDUSER;
-	$statusall.="$status      (".mysql_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
+	$statusall.="$status      (".mysqli_num_rows($result1)."/".$temp['hospi_room_capacity'].")";
 	   $statusall.='</div></td>';
 	   $j++;
 	   if($j==8) {
@@ -216,14 +216,14 @@ function addUserToRoomAjax($userId,$roomId,$mcid,$checkedInBy,$stay,$registeredB
   }
   
   $userExistQuery="SELECT `user_email` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".$userId."'";
-    $userExistRes = mysql_query($userExistQuery) or displayerror(mysql_error());
-    if(!mysql_num_rows($userExistRes)) {
+    $userExistRes = mysqli_query($GLOBALS["___mysqli_ston"], $userExistQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(!mysqli_num_rows($userExistRes)) {
       return "Invalid Pragyan Id:".$userId;
     }
     $checkIfUserEnrolledQuery = "SELECT * FROM `prhospi_accomodation_status` 
                             WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid}";
-    $checkIfUserEnrolledRes = mysql_query($checkIfUserEnrolledQuery) or displayerror(mysql_error());
-    if(mysql_num_rows($checkIfUserEnrolledRes)) {
+    $checkIfUserEnrolledRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserEnrolledQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+    if(mysqli_num_rows($checkIfUserEnrolledRes)) {
       return getUserEmail($userId)." has already been alloted:";
     }
     $time = date("Y-m-d H:i:s");

--- a/cms/modules/prhospi/accommodation.php
+++ b/cms/modules/prhospi/accommodation.php
@@ -233,8 +233,8 @@ function addUserToRoomAjax($userId,$roomId,$mcid,$checkedInBy,$stay,$registeredB
     $insertDetailsQuery = "INSERT INTO `prhospi_accomodation_status` 
                             (page_modulecomponentid,hospi_room_id,user_id,hospi_actual_checkin,hospi_checkedin_by,hospi_cash_recieved,user_registered_by)
                             VALUES ($mcid,$roomId,$userId,'{$time}','{$checkedInBy}',{$amtRecieved},'{$registeredBy}')";
-                            (page_modulecomponentid,hospi_room_id,user_id,hospi_actual_checkin,hospi_checkedin_by,hospi_cash_recieved)
-                            VALUES ($mcid,$roomId,$userId,'{$time}','{$checkedInBy}',{$amtRecieved})";
+                            //(page_modulecomponentid,hospi_room_id,user_id,hospi_actual_checkin,hospi_checkedin_by,hospi_cash_recieved)
+                            //VALUES ($mcid,$roomId,$userId,'{$time}','{$checkedInBy}',{$amtRecieved})";
     $insertDetailsRes = mysql_query($insertDetailsQuery) or die(mysql_error());
     $availableRoomNo=getAvailableRooms($mcid);
     return "Success  {$availableRoomNo}";

--- a/cms/modules/prhospi/prhospi_common.php
+++ b/cms/modules/prhospi/prhospi_common.php
@@ -1016,25 +1016,25 @@ function blockRoomNo($roomId,$mcid) {
 }
 
 
-function blockRoomNo($roomId,$mcid) {
-  $roomId = escape($roomId);
-  $blockRoomQuery = "SELECT `hospi_blocked` FROM `prhospi_hostel` WHERE `hospi_blocked`=0 AND `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
-  if(!mysqli_num_rows($blockRoomQueryRes)) {
-    displayerror("Room Does Not exist");
-    return;
-  } 
-  $res = mysqli_fetch_assoc($blockRoomQueryRes);
-  if($res['hospi_blocked']!=0) {
-    displaywarning("Room Blocked Already");
-    return;
-  }
-  $blockRoomQuery = "UPDATE `prhospi_hostel` SET `hospi_blocked`=1 WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
-  if($blockRoomQueryRes) displayinfo("Room Blocked ");
-  else  displayinfo("There is a Error.Please contact System Administrator for Details");
-  return;
-}
+//function blockRoomNo($roomId,$mcid) {
+//  $roomId = escape($roomId);
+//  $blockRoomQuery = "SELECT `hospi_blocked` FROM `prhospi_hostel` WHERE `hospi_blocked`=0 AND `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
+//  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+//  if(!mysqli_num_rows($blockRoomQueryRes)) {
+//    displayerror("Room Does Not exist");
+//    return;
+//  } 
+//  $res = mysqli_fetch_assoc($blockRoomQueryRes);
+//  if($res['hospi_blocked']!=0) {
+//    displaywarning("Room Blocked Already");
+//    return;
+//  }
+//  $blockRoomQuery = "UPDATE `prhospi_hostel` SET `hospi_blocked`=1 WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
+//  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+//  if($blockRoomQueryRes) displayinfo("Room Blocked ");
+//  else  displayinfo("There is a Error.Please contact System Administrator for Details");
+//  return;
+//}
 
 function unBlockRoomNo($roomId,$mcid) {
   $roomId = escape($roomId);

--- a/cms/modules/prhospi/prhospi_common.php
+++ b/cms/modules/prhospi/prhospi_common.php
@@ -17,35 +17,35 @@ if(!defined('__PRAGYAN_CMS')) {
 
 function assignVars($userId,$mcId) {
   $query = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".$userId."'";
-  $result = mysql_query($query);
-  $row = mysql_fetch_assoc($result);
+  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+  $row = mysqli_fetch_assoc($result);
   $arr = array ('PRAGYAN_ID'=> $row['user_id'] , 'NAME' => $row['user_name'] , 'EMAIL' => $row['user_email']);
   $userDetail = "SELECT * FROM `prhospi_accomodation_status` WHERE `page_modulecomponentid`={$mcId} AND `user_id` = {$userId}";
-  $userResult = mysql_query($userDetail) or displayerror(mysql_error());
-  $row = mysql_fetch_array($userResult);
-  $columnDetail = mysql_query("SHOW COLUMNS FROM `prhospi_accomodation_status`") or displayerror(mysql_error());
+  $userResult = mysqli_query($GLOBALS["___mysqli_ston"], $userDetail) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $row = mysqli_fetch_array($userResult);
+  $columnDetail = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW COLUMNS FROM `prhospi_accomodation_status`") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $cnt = 0;
-  while($res = mysql_fetch_array($columnDetail)) {
+  while($res = mysqli_fetch_array($columnDetail)) {
     if($res[0] == 'hospi_room_id') {
-      $userDataHostel = mysql_query("SELECT `hospi_hostel_name` FROM prhospi_hostel WHERE hospi_room_id={$row[$cnt]}") or displayerror(mysql_error());
-      $rowHostelName=mysql_fetch_array($userDataHostel);
+      $userDataHostel = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `hospi_hostel_name` FROM prhospi_hostel WHERE hospi_room_id={$row[$cnt]}") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+      $rowHostelName=mysqli_fetch_array($userDataHostel);
       $ret[strtoupper($res[0])] = strtoupper($rowHostelName[0]); 
   
-      $userDataHostel = mysql_query("SELECT `hospi_room_no` FROM prhospi_hostel WHERE hospi_room_id={$row[$cnt]}") or displayerror(mysql_error());
-      $rowHostelName=mysql_fetch_array($userDataHostel);
+      $userDataHostel = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `hospi_room_no` FROM prhospi_hostel WHERE hospi_room_id={$row[$cnt]}") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+      $rowHostelName=mysqli_fetch_array($userDataHostel);
       $ret[strtoupper('hospi_room_no')] = strtoupper($rowHostelName[0]); 
       $cnt++;
   }
     else $ret[strtoupper($res[0])] = $row[$cnt++];
   }
-  $collegeName = mysql_query("SELECT form_elementdata FROM form_elementdata WHERE user_id={$userId} AND page_modulecomponentid=0 AND form_elementid=6" ) or displayerror(mysql_error()); 
-  if(mysql_num_rows($collegeName)) {
-      $sol=mysql_fetch_array($collegeName);
+  $collegeName = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT form_elementdata FROM form_elementdata WHERE user_id={$userId} AND page_modulecomponentid=0 AND form_elementid=6" ) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 
+  if(mysqli_num_rows($collegeName)) {
+      $sol=mysqli_fetch_array($collegeName);
       $ret['COLLEGE']=$sol[0];
   } 
-  $collegeName = mysql_query("SELECT form_elementdata FROM form_elementdata WHERE user_id={$userId} AND page_modulecomponentid=0 AND form_elementid=5" ) or displayerror(mysql_error()); 
-  if(mysql_num_rows($collegeName)) {
-      $sol=mysql_fetch_array($collegeName);
+  $collegeName = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT form_elementdata FROM form_elementdata WHERE user_id={$userId} AND page_modulecomponentid=0 AND form_elementid=5" ) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))); 
+  if(mysqli_num_rows($collegeName)) {
+      $sol=mysqli_fetch_array($collegeName);
       $ret['PHONE']=$sol[0];
   } 
   return array_merge($ret,$arr);
@@ -56,14 +56,14 @@ function getDisclaimer($team,$mcid) {
   $team = escape($team);
   $mcid = escape($mcid);
   $getQuery="SELECT * FROM `prhospi_disclaimer` WHERE `page_modulecomponentid`={$mcid} AND `disclaimer_team`='{$team}'"; 
-  $runQuery=mysql_query($getQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($runQuery)) {
+  $runQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($runQuery)) {
     
-    $insertQuery=mysql_query("INSERT INTO `prhospi_disclaimer` VALUES({$mcid},'{$team}','',0)") or displayerror(mysql_error());
+    $insertQuery=mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `prhospi_disclaimer` VALUES({$mcid},'{$team}','',0)") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if($insertQuery!="") displayinfo("Field {$team} Inserted TO Table");
     return "";
   }
-  $res=mysql_fetch_assoc($runQuery);
+  $res=mysqli_fetch_assoc($runQuery);
   
   return $res['disclaimer_desc'];
 }
@@ -73,7 +73,7 @@ function printDisclaimer($mcid,$data,$team){
                   SET `hospi_printed` = 1 
                   WHERE `page_modulecomponentid`={$mcid} AND `user_id`={$data}";
   
-   $updateRes = mysql_query($updateQuery) or displayerror(mysql_error());               
+   $updateRes = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));               
 
   global $sourceFolder,$moduleFolder;
   require_once($sourceFolder."/".$moduleFolder."/qaos1/excel.php");
@@ -95,32 +95,32 @@ function printDisclaimer($mcid,$data,$team){
 
 function getAmount($team,$mcid) {
   $getQuery="SELECT * FROM `prhospi_disclaimer` WHERE `page_modulecomponentid`={$mcid} AND `disclaimer_team`='{$team}'"; 
-  $runQuery=mysql_query($getQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($runQuery)) {
-    $insertQuery=mysql_query("INSERT INTO `prhospi_disclaimer` VALUES({$mcid},'{$team}','',0)") or displayerror(mysql_error());
+  $runQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($runQuery)) {
+    $insertQuery=mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `prhospi_disclaimer` VALUES({$mcid},'{$team}','',0)") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if($insertQuery!="") displayinfo("Field {$team} Inserted TO Table");
     return 0;
   }
-  $res=mysql_fetch_assoc($runQuery);
+  $res=mysqli_fetch_assoc($runQuery);
   return $res['team_cost'];
 }
 
 function getRoomNoFromRoomId($roomId,$mcid) {
   $roomQuery = "SELECT `hospi_room_no` FROM `prhospi_hostel` WHERE `hospi_room_id`={$roomId} AND `page_modulecomponentid`={$mcid}";
-  $result = mysql_query($roomQuery) or displayerror(mysql_error());
-  $res = mysql_fetch_array($result);
+  $result = mysqli_query($GLOBALS["___mysqli_ston"], $roomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  $res = mysqli_fetch_array($result);
   return $res[0];
 }
 function getDescription($team,$mcid) {
 
   $getQuery="SELECT * FROM `prhospi_disclaimer` WHERE `page_modulecomponentid`={$mcid} AND `disclaimer_team`='{$team}'"; 
-  $runQuery=mysql_query($getQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($runQuery)) {
-    $insertQuery=mysql_query("INSERT INTO `prhospi_disclaimer` VALUES({$mcid},'{$team}','',0)") or displayerror(mysql_error());
+  $runQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($runQuery)) {
+    $insertQuery=mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `prhospi_disclaimer` VALUES({$mcid},'{$team}','',0)") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if($insertQuery!="") displayinfo("Field {$team} Inserted TO Table");
     return "";
   }
-  $res=mysql_fetch_assoc($runQuery);
+  $res=mysqli_fetch_assoc($runQuery);
   
   return $res['disclaimer_desc'];
 }
@@ -128,9 +128,9 @@ function getDescription($team,$mcid) {
 function getSuggestionsForIdOrEmail($input) {
     $input=trim($input);
     $emailQuery ="SELECT * FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` LIKE '%$input%' OR `user_email` LIKE '%$input%'";
-    $emailResult = mysql_query($emailQuery);
+    $emailResult = mysqli_query($GLOBALS["___mysqli_ston"], $emailQuery);
     $suggestions = array($input);
-    while($emailRow = mysql_fetch_row($emailResult)) {
+    while($emailRow = mysqli_fetch_row($emailResult)) {
       $suggestions[] = $emailRow[2]. ' - ' . $emailRow[0];
     }                                                                                                                                           
     return join($suggestions, ',');                                                                                                             
@@ -138,9 +138,9 @@ function getSuggestionsForIdOrEmail($input) {
   
 function getHostelsName($mcid) {
    $hostelNameQuery="SELECT DISTINCT `hospi_hostel_name` FROM `prhospi_hostel` WHERE `page_modulecomponentid`={$mcid}";
-   $hostelNameRes=mysql_query($hostelNameQuery) or displayerror(mysql_error());
+   $hostelNameRes=mysqli_query($GLOBALS["___mysqli_ston"], $hostelNameQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
    $ret="<option value=''>SELECT HOSTEL</option>";
-   while($result = mysql_fetch_array($hostelNameRes)) {
+   while($result = mysqli_fetch_array($hostelNameRes)) {
      $temp=str_replace(" ","_",$result[0]);
     $ret.=<<<OPTIONS
       <option value="{$temp}">$result[0]</option>
@@ -153,14 +153,14 @@ function getAvailableRooms($mcid) {
      $roomQuery="SELECT `hospi_room_id`,`hospi_hostel_name`,`hospi_room_no`,`hospi_room_capacity` 
                 FROM `prhospi_hostel` 
                 WHERE `page_modulecomponentid`={$mcid} AND `hospi_blocked`=0 ORDER BY `hospi_hostel_name`,`hospi_room_no` ASC";
-    $roomRes=mysql_query($roomQuery) or displayerror(mysql_error());
+    $roomRes=mysqli_query($GLOBALS["___mysqli_ston"], $roomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     $ret="<option value=''>SELECT ROOM NO</option>";
-    while($res=mysql_fetch_array($roomRes)) {
+    while($res=mysqli_fetch_array($roomRes)) {
        $availableQuery = "SELECT * FROM `prhospi_accomodation_status` 
                           WHERE `hospi_room_id`={$res[0]} AND `page_modulecomponentid`={$mcid}
                           AND hospi_actual_checkout IS NULL";
-       $availableRes = mysql_query($availableQuery) or displayerror(mysql_error());
-       $availableNo=$res[3]-mysql_num_rows($availableRes);
+       $availableRes = mysqli_query($GLOBALS["___mysqli_ston"], $availableQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+       $availableNo=$res[3]-mysqli_num_rows($availableRes);
        
        if(!$availableNo) continue;
        $tempClass=str_replace(" ","_","roomNo_".$res[1]);
@@ -179,14 +179,14 @@ function getUserDetailsForHospi($userId,$mcid) {
     displayerror("Invalid format.<br/>Format should be 'userid'");
     return "";
   }
-  $checkUserExist=mysql_query("SELECT * FROM ".MYSQL_DATABASE_PREFIX."users WHERE `user_id`={$userId}") or displayerror(mysql_error());
-  if(!mysql_num_rows($checkUserExist)) {
+  $checkUserExist=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM ".MYSQL_DATABASE_PREFIX."users WHERE `user_id`={$userId}") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($checkUserExist)) {
     displayerror("Invalid User Id");
     return "";
   }
   $isRegisteredQuery = "SELECT * FROM prhospi_admin WHERE `page_modulecomponentid` = {$mcid}";
-  $isRegisteredRes = mysql_query($isRegisteredQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($isRegisteredRes)) {
+  $isRegisteredRes = mysqli_query($GLOBALS["___mysqli_ston"], $isRegisteredQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($isRegisteredRes)) {
     displayerror("Please Contact CSG for activating the accommodation form");
     return "";
   }  
@@ -199,7 +199,7 @@ function getUserDetailsForHospi($userId,$mcid) {
                   LEFT JOIN `form_elementdesc` AS formname 
                   ON formname.page_modulecomponentid=hospi.page_getform_modulecomponentid AND formname.form_elementid=hospi.details_to_display 
                   WHERE hospi.page_modulecomponentid = {$mcid} AND hospi.detail_required=1";
-  $displayResult=mysql_query($detailQuery) or displayerror(mysql_error());
+  $displayResult=mysqli_query($GLOBALS["___mysqli_ston"], $detailQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $checkRequired=0;
   $userDetails = <<<TABLE
     <table id="tableUserDetailsHospi" border="1">
@@ -211,7 +211,7 @@ function getUserDetailsForHospi($userId,$mcid) {
        </tr>
 
 TABLE;
-  while($result=mysql_fetch_array($displayResult)) {
+  while($result=mysqli_fetch_array($displayResult)) {
     $type=($result[0]==0)?"Profile":"Accomadation";
     if($result[2] == "") {
       if(!$result[3]) continue;
@@ -483,7 +483,7 @@ TROW;
 function deleteAccomodatedUser($userId,$mcid) {
   $deleteAccoUserQuery="DELETE FROM `prhospi_accomodation_status`
                   WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid}";
-  $deleteAccoUserRes=mysql_query($deleteAccoUserQuery) or displayerror(mysql_error());
+  $deleteAccoUserRes=mysqli_query($GLOBALS["___mysqli_ston"], $deleteAccoUserQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($deleteAccoUserRes) 
     displayinfo("Successfully deleted Pragyan User: ".$userId);
   
@@ -492,7 +492,7 @@ function deleteAccomodatedUser($userId,$mcid) {
 function deletePrUser($userId,$mcid) {
   $deleteAccoUserQuery="DELETE FROM `prhospi_pr_status`
                   WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid}";
-  $deleteAccoUserRes=mysql_query($deleteAccoUserQuery) or displayerror(mysql_error());
+  $deleteAccoUserRes=mysqli_query($GLOBALS["___mysqli_ston"], $deleteAccoUserQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($deleteAccoUserRes) 
     displayinfo("Successfully deleted Pragyan User: ".$userId);
   
@@ -523,8 +523,8 @@ function submitDetailsForPr($userId,$mcid,$registeredBy) {
     displayerror("Invalid format.<br/>Format should be 'userid'");
     return '';
   }
-  $checkUserExist=mysql_query("SELECT * FROM ".MYSQL_DATABASE_PREFIX."users WHERE `user_id`={$userId}") or displayerror(mysql_error());
-  if(!mysql_num_rows($checkUserExist)) {
+  $checkUserExist=mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM ".MYSQL_DATABASE_PREFIX."users WHERE `user_id`={$userId}") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($checkUserExist)) {
     displayerror("Invalid User Id");
     return '';
   }
@@ -538,7 +538,7 @@ function submitDetailsForPr($userId,$mcid,$registeredBy) {
                             data.user_id = $userId
                          WHERE descr.page_modulecomponentid = 0
                          ";
-  $profileDetailRes = mysql_query($profileDetailQuery) or displayerror(mysql_error());
+  $profileDetailRes = mysqli_query($GLOBALS["___mysqli_ston"], $profileDetailQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if(!$profileDetailRes) {
     displayerror("check the error in getProfileDetailsForPr function in prhospi_common.php");
     return '';
@@ -553,7 +553,7 @@ function submitDetailsForPr($userId,$mcid,$registeredBy) {
        </tr>
 
 TABLE;
-  while($result=mysql_fetch_assoc($profileDetailRes)) {
+  while($result=mysqli_fetch_assoc($profileDetailRes)) {
 	$dispText = $result['dispText'];
 	$dispData = $result['dispData'];
  
@@ -583,8 +583,8 @@ function isRegisteredToPr($userId,$mcId) {
   $userId = escape($userId);
   if(!is_numeric($userId)) return 0;
   $checkUserRegisteredToPr = "SELECT * FROM `prhospi_pr_status` WHERE `page_modulecomponentid` = {$mcId} AND `user_id` = {$userId}";
-  $checkUserRegisteredToPrQuery = mysql_query($checkUserRegisteredToPr) or displayerror(mysql_error());
-  if(mysql_num_rows($checkUserRegisteredToPrQuery)) return 1;
+  $checkUserRegisteredToPrQuery = mysqli_query($GLOBALS["___mysqli_ston"], $checkUserRegisteredToPr) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(mysqli_num_rows($checkUserRegisteredToPrQuery)) return 1;
   return 0;
 }
 
@@ -598,8 +598,8 @@ function checkInPrUser($userId,$mcId,$registeredBy) {
   $time = date("Y-m-d H:i:s");
   $amtToBeCollected = getAmount("prhead",$mcId); 
   $addUserToPrReg = "INSERT INTO `prhospi_pr_status` VALUES ({$mcId},{$userId},'{$time}','0000-00-00 00:00:00',{$amtToBeCollected},0,'{$registeredBy}')";
-  $addUserToPrRegQuery = mysql_query($addUserToPrReg) or displayerror(mysql_error());
-  if(mysql_affected_rows()>0) {
+  $addUserToPrRegQuery = mysqli_query($GLOBALS["___mysqli_ston"], $addUserToPrReg) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0) {
     displayinfo("Sucessfully Registered for Pragyan");
     return displayPrintOptionForPR($userId);
   }
@@ -619,15 +619,15 @@ function checkOutPr($userId,$refund,$mcid) {
   }
   $checkIfUserEnrolledQuery = "SELECT * FROM `prhospi_pr_status` 
                             WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid}";
-  $checkIfUserEnrolledRes = mysql_query($checkIfUserEnrolledQuery) or displayerror(mysql_error());
- if(!mysql_num_rows($checkIfUserEnrolledRes)) {
+  $checkIfUserEnrolledRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserEnrolledQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+ if(!mysqli_num_rows($checkIfUserEnrolledRes)) {
     displaywarning("User ".getUserName($userId).", not registered for pr or for pragyan site ");
     return false;
     }
   $checkIfUserCheckedOutQuery = "SELECT * FROM `prhospi_pr_status` 
                             WHERE `user_id`={$userId} AND `page_modulecomponentid`={$mcid} AND `hospi_checkpout_time`!='0000-00-00 00:00:00'";
-  $checkIfUserEnrolledRes = mysql_query($checkIfUserCheckedOutQuery) or displayerror(mysql_error());
-  if(mysql_num_rows($checkIfUserEnrolledRes)) {
+  $checkIfUserEnrolledRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfUserCheckedOutQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(mysqli_num_rows($checkIfUserEnrolledRes)) {
     displaywarning("User ".getUserName($userId).", has already Checkedout ");
     return false;
     }
@@ -636,7 +636,7 @@ function checkOutPr($userId,$refund,$mcid) {
                   SET `hospi_checkpout_time` = '{$time}',`amount_refunded`={$refund} 
                   WHERE `page_modulecomponentid`={$mcid} AND `user_id`={$userId}";
   
-  $updateRes = mysql_query($updateQuery) or displayerror(mysql_error());               
+  $updateRes = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));               
   displayinfo("User Successfully checked out");
 }
 
@@ -693,16 +693,16 @@ function displayUsersRegisteredToPr($mcId) {
     </thead>
 TABLE;
   $getRegisteredUserDetailPRQuery = "SELECT * FROM `prhospi_pr_status` WHERE `page_modulecomponentid`={$mcId}";
-  $getRegisteredUserPR = mysql_query($getRegisteredUserDetailPRQuery) or displayerror("Error on viewing registered user".mysql_error());
-  while($res = mysql_fetch_assoc($getRegisteredUserPR)) {
+  $getRegisteredUserPR = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailPRQuery) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($getRegisteredUserPR)) {
     $registeredByName = getUserName($res['user_registered_by']);
     $registeredByEmail = getUserEmail($res['user_registered_by']);
     $name = getUserName($res['user_id']);
     $id=$res['user_id'];
     $email = getUserEmail($res['user_id']);
     $getPhoneNumberQuery="SELECT * FROM `form_elementdata` WHERE `user_id`='{$id}' AND `page_modulecomponentid`=0 AND `form_elementid`=5";
-    $getPhoneNumberQuery=mysql_query($getPhoneNumberQuery);
-    $getPhoneNumberQueryResult=mysql_fetch_assoc($getPhoneNumberQuery);
+    $getPhoneNumberQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getPhoneNumberQuery);
+    $getPhoneNumberQueryResult=mysqli_fetch_assoc($getPhoneNumberQuery);
     $phoneNumber=$getPhoneNumberQueryResult['form_elementdata'];
     $userDetails .=<<<TR
       <tr>
@@ -755,8 +755,8 @@ function displayUsersRegisteredToPrDelete($mcId) {
     </thead>
 TABLE;
   $getRegisteredUserDetailPRQuery = "SELECT * FROM `prhospi_pr_status` WHERE `page_modulecomponentid`={$mcId}";
-  $getRegisteredUserPR = mysql_query($getRegisteredUserDetailPRQuery) or displayerror("Error on viewing registered user".mysql_error());
-  while($res = mysql_fetch_assoc($getRegisteredUserPR)) {
+  $getRegisteredUserPR = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailPRQuery) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($getRegisteredUserPR)) {
     $name = getUserName($res['user_id']);
     $email = getUserEmail($res['user_id']);
     $userDetails .=<<<TR
@@ -818,8 +818,8 @@ TABLE;
                                        LEFT JOIN `prhospi_hostel` AS hostel ON hostel.hospi_room_id = status.hospi_room_id AND
                                                                                hostel.page_modulecomponentid=status.page_modulecomponentid  
                                        WHERE status.page_modulecomponentid={$mcId}";
-  $getRegisteredUserPR = mysql_query($getRegisteredUserDetailAccoQuery) or displayerror("Error on viewing registered user".mysql_error());
-  while($res = mysql_fetch_assoc($getRegisteredUserPR)) {
+  $getRegisteredUserPR = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailAccoQuery) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($getRegisteredUserPR)) {
     $registeredByName = getUserName($res['user_registered_by']);
     $registeredByEmail = getUserEmail($res['user_registered_by']);
     $name = getUserName($res['user_id']);
@@ -891,8 +891,8 @@ TABLE;
                                        LEFT JOIN `prhospi_hostel` AS hostel ON hostel.hospi_room_id = status.hospi_room_id AND
                                                                                hostel.page_modulecomponentid=status.page_modulecomponentid  
                                        WHERE status.page_modulecomponentid={$mcId}";
-  $getRegisteredUserPR = mysql_query($getRegisteredUserDetailAccoQuery) or displayerror("Error on viewing registered user".mysql_error());
-  while($res = mysql_fetch_assoc($getRegisteredUserPR)) {
+  $getRegisteredUserPR = mysqli_query($GLOBALS["___mysqli_ston"], $getRegisteredUserDetailAccoQuery) or displayerror("Error on viewing registered user".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  while($res = mysqli_fetch_assoc($getRegisteredUserPR)) {
     
     $name = getUserName($res['user_id']);
     $email = getUserEmail($res['user_id']);
@@ -935,7 +935,7 @@ function blockRoom($mcid) {
     if($_POST['block']=='UNBLOCK') unBlockRoomNo(substr($_POST['roomId'],9),$mcid);
   }
   $getAvailableRoomQuery = "SELECT * FROM `prhospi_hostel` WHERE `hospi_blocked`=0 AND `page_modulecomponentid`={$mcid}";
-  $getAvailableRoomQueryRes = mysql_query($getAvailableRoomQuery) or displayerror(mysql_error());
+  $getAvailableRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $getAvailableRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   require_once("$sourceFolder/$moduleFolder/prhospi/accommodation.php");
   $roomDetails = displayRooms($mcid);
   $blockRoomForm=<<<FORM
@@ -947,7 +947,7 @@ $roomDetails
         <select id="blockRoomNo" name="roomAllotted">
         <option class="blockRoom" id="">Select Room</option>
 FORM;
-  while($details = mysql_fetch_assoc($getAvailableRoomQueryRes)) {
+  while($details = mysqli_fetch_assoc($getAvailableRoomQueryRes)) {
   $blockRoomForm.=<<<FORM
     <option class="blockRoom" id="blockRoom{$details['hospi_room_id']}">{$details['hospi_hostel_name']} RoomNo:{$details['hospi_room_no']}</option>
 FORM;
@@ -966,7 +966,7 @@ FORM;
 FORM;
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   $getAvailableRoomQuery = "SELECT * FROM `prhospi_hostel` WHERE `hospi_blocked`=1 AND `page_modulecomponentid`={$mcid}";
-  $getAvailableRoomQueryRes = mysql_query($getAvailableRoomQuery) or displayerror(mysql_error());
+  $getAvailableRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $getAvailableRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   $blockRoomForm.=<<<FORM
 <hr/>
 <h1> UnBlock Room</h1>
@@ -974,7 +974,7 @@ FORM;
         <select id="unblockRoomNo" name="roomAllotted">
         <option class="unblockRoom" id="">Select Room</option>
 FORM;
-  while($details = mysql_fetch_assoc($getAvailableRoomQueryRes)) {
+  while($details = mysqli_fetch_assoc($getAvailableRoomQueryRes)) {
   $blockRoomForm.=<<<FORM
     <option class="unblockRoom" id="blockRoom{$details['hospi_room_id']}">{$details['hospi_hostel_name']} RoomNo:{$details['hospi_room_no']}</option>
 FORM;
@@ -998,18 +998,18 @@ FORM;
 function blockRoomNo($roomId,$mcid) {
   $roomId = escape($roomId);
   $blockRoomQuery = "SELECT `hospi_blocked` FROM `prhospi_hostel` WHERE `hospi_blocked`=0 AND `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysql_query($blockRoomQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($blockRoomQueryRes)) {
+  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($blockRoomQueryRes)) {
     displayerror("Room Does Not exist");
     return;
   } 
-  $res = mysql_fetch_assoc($blockRoomQueryRes);
+  $res = mysqli_fetch_assoc($blockRoomQueryRes);
   if($res['hospi_blocked']!=0) {
     displaywarning("Room Blocked Already");
     return;
   }
   $blockRoomQuery = "UPDATE `prhospi_hostel` SET `hospi_blocked`=1 WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysql_query($blockRoomQuery) or displayerror(mysql_error());
+  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($blockRoomQueryRes) displayinfo("Room Blocked ");
   else  displayinfo("There is a Error.Please contact System Administrator for Details");
   return;
@@ -1019,18 +1019,18 @@ function blockRoomNo($roomId,$mcid) {
 function blockRoomNo($roomId,$mcid) {
   $roomId = escape($roomId);
   $blockRoomQuery = "SELECT `hospi_blocked` FROM `prhospi_hostel` WHERE `hospi_blocked`=0 AND `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysql_query($blockRoomQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($blockRoomQueryRes)) {
+  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($blockRoomQueryRes)) {
     displayerror("Room Does Not exist");
     return;
   } 
-  $res = mysql_fetch_assoc($blockRoomQueryRes);
+  $res = mysqli_fetch_assoc($blockRoomQueryRes);
   if($res['hospi_blocked']!=0) {
     displaywarning("Room Blocked Already");
     return;
   }
   $blockRoomQuery = "UPDATE `prhospi_hostel` SET `hospi_blocked`=1 WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysql_query($blockRoomQuery) or displayerror(mysql_error());
+  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($blockRoomQueryRes) displayinfo("Room Blocked ");
   else  displayinfo("There is a Error.Please contact System Administrator for Details");
   return;
@@ -1039,14 +1039,14 @@ function blockRoomNo($roomId,$mcid) {
 function unBlockRoomNo($roomId,$mcid) {
   $roomId = escape($roomId);
   $blockRoomQuery = "SELECT `hospi_blocked` FROM `prhospi_hostel` WHERE `hospi_blocked`=1 AND `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysql_query($blockRoomQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($blockRoomQueryRes)) {
+  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($blockRoomQueryRes)) {
     displayerror("Room Does Not exist");
     return;
   } 
-  $res = mysql_fetch_assoc($blockRoomQueryRes);
+  $res = mysqli_fetch_assoc($blockRoomQueryRes);
   $blockRoomQuery = "UPDATE `prhospi_hostel` SET `hospi_blocked`=0 WHERE `page_modulecomponentid`={$mcid} AND `hospi_room_id`={$roomId}";
-  $blockRoomQueryRes = mysql_query($blockRoomQuery) or displayerror(mysql_error());
+  $blockRoomQueryRes = mysqli_query($GLOBALS["___mysqli_ston"], $blockRoomQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($blockRoomQueryRes) displayinfo("Room Unblocked ");
   else  displayinfo("There is a Error.Please contact System Administrator for Details");
   

--- a/cms/modules/publication.lib.php
+++ b/cms/modules/publication.lib.php
@@ -65,11 +65,11 @@ TABLE_HEAD;
 			/*Get stuff from database based on moduleComponentId */
         $counter=0;
         $query="SELECT * FROM publication_details where module_component_id =".$this->moduleComponentId.";";
-        $details=mysql_query($query) or die("error ..".mysql_error());	
+        $details=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die("error ..".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));	
         
         $view2='';
 
-        while($arr_details=mysql_fetch_array($details))
+        while($arr_details=mysqli_fetch_array($details))
         {
             $counter1 = $counter+1;
             $view2.=<<<ROWS
@@ -157,11 +157,11 @@ FORM_AND_TABLE;
 
         $counter=0;
         $query="SELECT * FROM publication_details where module_component_id =".$this->moduleComponentId.";";
-        $details=mysql_query($query) or die("error ..".mysql_error());
-        $rows=mysql_num_rows($details) - 1;	
+        $details=mysqli_query($GLOBALS["___mysqli_ston"], $query) or die("error ..".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+        $rows=mysqli_num_rows($details) - 1;	
         $view2='';
 			 
-        while($arr_details=mysql_fetch_array($details))
+        while($arr_details=mysqli_fetch_array($details))
         {
             $counter1 = $counter+1;
 				

--- a/cms/modules/publication/edit.php
+++ b/cms/modules/publication/edit.php
@@ -21,17 +21,17 @@ function formSubmit($mcd , $pb_array)
 {
 
     $query ="SELECT `sl_no` FROM publication_details where module_component_id=".$mcd.";";
-    $result = mysql_query($query) or die("error1.");
+    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die("error1.");
  
     $counter=0;
 
 //All the <textarea> fields are updated in the database
 
-    while($array_nos = mysql_fetch_array($result))
+    while($array_nos = mysqli_fetch_array($result))
     {	
         $publication=$pb_array[$counter];
         $query_update = "UPDATE publication_details set publication='{$publication}' where sl_no=".$array_nos['sl_no'];
-        $result_update = mysql_query($query_update) or die("error.");
+        $result_update = mysqli_query($GLOBALS["___mysqli_ston"], $query_update) or die("error.");
         $counter++;
 	
     }
@@ -43,7 +43,7 @@ function add_new($mcd)
 {
 
     $query = "INSERT INTO publication_details(publication ,saved_time , created_time , module_component_id) values('', CURRENT_TIMESTAMP , CURRENT_TIMESTAMP , ".$mcd.");";
-    $result = mysql_query($query);
+    $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 
 }
 
@@ -52,16 +52,16 @@ function p_delete($mcd , $num)
 {
 
     $query1= "SELECT `sl_no` from publication_details where module_component_id=".$mcd;
-    $result1 = mysql_query($query1) or die("error. ".mysql_error());
+    $result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1) or die("error. ".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
     $counter=0;
 
-    while($arr = mysql_fetch_array($result1))
+    while($arr = mysqli_fetch_array($result1))
     {
         if($counter==$num)
         {
             $query = "DELETE FROM publication_details where sl_no=".$arr['sl_no'];
-            $result = mysql_query($query);
+            $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
             break;
         }	
     

--- a/cms/modules/qaos.lib.php
+++ b/cms/modules/qaos.lib.php
@@ -73,10 +73,10 @@ class qaos implements module {
 				$userId = getUserIdFromEmail($_GET['useremail']);
 				$htmlOut = "<br /><br />People who has been rated by this person:<br /><br />";
 				$query = "SELECT * FROM `qaos_scoring` WHERE user_id = $userId";
-				$result = mysql_query($query);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				$htmlOut .= "<table border=\"1\">";
 				$htmlOut .= "<tr><th>Target User Full Name</th><th>Target User Team</th><th>Target User Designation</th><th>Target User Score1</th><th>Target User Reason1</th><th>Target User Score2</th><th>Target User Reason2</th><th>Target User Score3</th><th>Target User Reason3</th><th>Target User Score4</th><th>Target User Reason4</th><th>Target User Score5</th><th>Target User Reason5</th>";
-				while($row = mysql_fetch_assoc($result)){
+				while($row = mysqli_fetch_assoc($result)){
 					$targetUserId = $row['targetuser_id'];
 					$targetUserFullName = getUserFullName($targetUserId);
 					$targetUserTeam = $this->getTeamNameFromTeamId($this->getTeamId($targetUserId));
@@ -105,16 +105,16 @@ class qaos implements module {
 USERDATA;
 				}
 				$query = "SELECT count(*) as count FROM `qaos_scoring` WHERE user_id = '$userId'";
-				$result = mysql_query($query);
-				$row = mysql_fetch_assoc($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$row = mysqli_fetch_assoc($result);
 				$htmlOut .= "</table> <br />Total No of persons this guy has rated : ".$row['count'];
 				 
 				$htmlOut .= "<br /><br /><br />People who has rated this person:<br /><br />";
 				$query = "SELECT * FROM `qaos_scoring` WHERE targetuser_id = '$userId'";
-				$result = mysql_query($query);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				$htmlOut .= "<table border=\"1\">";
 				$htmlOut .= "<tr><th>User Full Name</th><th>User Team</th><th>User Designation</th><th>User Score1</th><th>User Reason1</th><th>User Score2</th><th>User Reason2</th><th>User Score3</th><th>User Reason3</th><th>User Score4</th><th>User Reason4</th><th>User Score5</th><th>User Reason5</th>";
-				while($row2 = mysql_fetch_assoc($result)){
+				while($row2 = mysqli_fetch_assoc($result)){
 					$targetUserId = $row2['targetuser_id'];
 					$targetUserFullName = getUserFullName($userId);
 					$targetUserTeam = $this->getTeamNameFromTeamId($this->getTeamId($userId));
@@ -140,8 +140,8 @@ USERDATA;
 USERDATA;
 				}
 				$query = "SELECT count(*) as count FROM `qaos_scoring` WHERE targetuser_id = '$userId'";
-				$result = mysql_query($query);
-				$row = mysql_fetch_assoc($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$row = mysqli_fetch_assoc($result);
 				$htmlOut .= "</table><br />Total number of person who have rated this person : ".$row['count']; 
 				
 				return $htmlOut;
@@ -168,21 +168,21 @@ ADMIN;
 			if($_GET['subaction']=='addteam'){
 				if(isset($_POST['btnAddTeam'])){
 					$query = "SELECT MAX(`qaos_team_id`)  AS max FROM `qaos_teams`";
-					$result = mysql_query($query);
-					$resultArray = mysql_fetch_assoc($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					$resultArray = mysqli_fetch_assoc($result);
 					$max = $resultArray['max'];
 					for($i=1; $i<6;$i++){
 						if($teamName=$_POST["qaos_team".$i.""]){
 							$query = "SELECT * FROM `qaos_teams` WHERE `qaos_team_name` LIKE '$teamName%'";
-							$result = mysql_query($query);
-							if(mysql_num_rows($result)>1){
+							$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+							if(mysqli_num_rows($result)>1){
 								displayerror("The $teamName team already exists in the database.");
 								continue;
 							}
 							$teamId = $max + $i;
 							$teamDesc = $_POST["team_desc".$i.""];
 							$query = "INSERT INTO `qaos_teams` (`page_modulecomponentid`,`qaos_team_id`,`qaos_team_name`,`qaos_team_description`) VALUES ('$moduleComponentId','$teamId','$teamName','$teamDesc')";
-							$result = mysql_query($query);
+							$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 							if(!$result)
 								displayerror("The team '$teamName' could not be added. Please try again.");
 
@@ -194,8 +194,8 @@ ADMIN;
 			elseif($_GET['subaction']=='changeversion'){
 				if(isset($_POST['btnSubmitVersion'])){
 					$query = "UPDATE `qaos_version` SET `qaos_version` = '".escape($_POST[qaos_version])."' WHERE `page_modulecomponentid` = '$moduleComponentId'";
-					$result = mysql_query($query);
-					if(mysql_query($query))
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 						displayinfo("The version has been successfully updated.");
 					else
 						displayinfo("There was some error while updating the version. Please check your query once.");
@@ -224,8 +224,8 @@ ADMIN;
 
 
 		$queryVersion = "SELECT `qaos_version` FROM `qaos_version` WHERE `page_modulecomponentid` = '$moduleComponentId'";
-		$resultVersion = mysql_query($queryVersion);
-		$row = mysql_fetch_row($resultVersion);
+		$resultVersion = mysqli_query($GLOBALS["___mysqli_ston"], $queryVersion);
+		$row = mysqli_fetch_row($resultVersion);
 		$version = $row[0];
 		$html .= "<h2>$version</h2>	<br />";
 		if(getPermissions($this->userId,getPageIdFromModuleComponentId("qaos",$this->moduleComponentId),"create")){
@@ -252,9 +252,9 @@ EDITQAOS;
 		}
 		$html .= "<br /><h3>Teams in Pragyan 2008: </h3><br />";
 		$queryTeam = "SELECT * FROM `qaos_teams` WHERE `page_modulecomponentid`='$moduleComponentId' ORDER BY `qaos_team_name`";
-		$resultTeam = mysql_query($queryTeam);
+		$resultTeam = mysqli_query($GLOBALS["___mysqli_ston"], $queryTeam);
 		$html.= "<table border=\"1\"><tr><td><b>Team Name</b></td><td><b>Team Description</b></td><td><b>Team Representative</b></td></tr>";
-		while($row = mysql_fetch_row($resultTeam)){
+		while($row = mysqli_fetch_row($resultTeam)){
 			$team = $row[2];
 			$desc = $row[3];
 			$repr = $row[4];
@@ -580,18 +580,18 @@ DISABLEPARENTFIELD;
 		}
 		else if($patternType == 'designation'){
 			$suggestionsQuery = "SELECT `qaos_designation_name` FROM `qaos_designations` WHERE `qaos_designation_name` LIKE \"%$pattern%\"" ;
-			$suggestionsResult = mysql_query($suggestionsQuery) or die(mysql_error());
+			$suggestionsResult = mysqli_query($GLOBALS["___mysqli_ston"], $suggestionsQuery) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			$suggestions = array($pattern);
-			while($suggestionsRow = mysql_fetch_row($suggestionsResult)) {
+			while($suggestionsRow = mysqli_fetch_row($suggestionsResult)) {
 				$suggestions[] = $suggestionsRow[0];
 			}
 			return join($suggestions, ',');
 		}
 		else if($patternType == 'team'){
 			$suggestionsQuery = "SELECT `qaos_team_name` FROM `qaos_teams` WHERE `qaos_team_name` LIKE \"%$pattern%\"" ;
-			$suggestionsResult = mysql_query($suggestionsQuery) or die(mysql_error());
+			$suggestionsResult = mysqli_query($GLOBALS["___mysqli_ston"], $suggestionsQuery) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			$suggestions = array($pattern);
-			while($suggestionsRow = mysql_fetch_row($suggestionsResult)) {
+			while($suggestionsRow = mysqli_fetch_row($suggestionsResult)) {
 				$suggestions[] = $suggestionsRow[0];
 			}
 			return join($suggestions, ',');
@@ -600,65 +600,65 @@ DISABLEPARENTFIELD;
 	}
 	function getTeamId($userId){
 		$query = "SELECT `qaos_teams`.`qaos_team_id` FROM `qaos_teams`,`qaos_units`,`qaos_users` WHERE `qaos_users`.`user_id`='$userId' AND `qaos_users`.`qaos_unit_id` = `qaos_units`.`qaos_unit_id` AND `qaos_units`.`qaos_team_id`=`qaos_teams`.`qaos_team_id`";
-		$result = mysql_query($query);
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_assoc($result);
 		$teamId = $row['qaos_team_id'];
 		return $teamId;
 	}
 	function getDesignationId($userId){
 		$query = "SELECT `qaos_designations`.`qaos_designation_id` FROM `qaos_designations`,`qaos_units`,`qaos_users` WHERE `qaos_users`.`user_id`='$userId' AND `qaos_users`.`qaos_unit_id` = `qaos_units`.`qaos_unit_id` AND `qaos_units`.`qaos_designation_id`=`qaos_designations`.`qaos_designation_id`";
-		$result = mysql_query($query);
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_assoc($result);
 		$designationId = $row['qaos_designation_id'];
 		return $designationId;
 	}
 	function getDesignationPriority($designationId){
 		$query = "SELECT `qaos_designation_priority` FROM `qaos_designations` WHERE `qaos_designation_id`='$designationId'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_assoc($result);
 		$designationPriority = $row['qaos_designation_priority'];
 		return $designationPriority;
 	}
 	function getUnitId($teamId,$designationId){
 		$query = "SELECT `qaos_unit_id` FROM `qaos_units` WHERE `qaos_team_id`='$teamId' AND `qaos_designation_id`='$designationId'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_assoc($result);
 		$unitId = $row['qaos_unit_id'];
 		return $unitId;
 	}
 	function getUnitIdFromUserId($userId){
 		$query = "SELECT `qaos_unit_id` FROM `qaos_users` WHERE `user_id`='$userId'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_assoc($result);
 		$unitId = $row['qaos_unit_id'];
 		return $unitId;
 		
 	}
 	function getDesignationIdFromDesignationName($designation){
 		$query = "SELECT `qaos_designation_id` FROM `qaos_designations` WHERE `qaos_designation_name`='$designation'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 		$designationId = $row[0];
 		return $designationId;
 	}
 	function getDesignationNameFromDesignationId($designationId){
 		$query = "SELECT `qaos_designation_name` FROM `qaos_designations` WHERE `qaos_designation_id`='$designationId'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 		$designationName = $row[0];
 		return $designationName;
 	}
 	function getTeamIdFromTeamName($teamName){
 		$query = "SELECT `qaos_team_id` FROM `qaos_teams` WHERE `qaos_team_name`='$teamName'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 		$teamId = $row[0];
 		return $teamId;
 	}
 	function getTeamNameFromTeamId($teamId){
 		$query = "SELECT `qaos_team_name` FROM `qaos_teams` WHERE `qaos_team_id`='$teamId'";
-		$result = mysql_query($query);
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_row($result);
 		$teamName = $row[0];
 		return $teamName;
 	}
@@ -667,8 +667,8 @@ DISABLEPARENTFIELD;
 		if($qaosTeam1){
 			$memberadd = false;
 			$query = "SELECT `qaos_representative_user_id1` as user1,`qaos_representative_user_id2` as user2 FROM `qaos_teams` WHERE `qaos_team_name`='$qaosTeam1'";
-			$result = mysql_query($query);
-			$row = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$row = mysqli_fetch_assoc($result);
 			$userRep11 = $row['user1'];
 			$userRep12 = $row['user2'];
 			if($userRep11 && $userRep12){
@@ -676,7 +676,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep11 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id1` = '$userId' WHERE `qaos_team_name` = '$qaosTeam1'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam1");
 					$memberadd = true;
 				}
@@ -684,7 +684,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep12 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id2` = '$userId' WHERE `qaos_team_name` = '$qaosTeam1'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam1");
 					$memberadd = true;
 				}
@@ -695,8 +695,8 @@ DISABLEPARENTFIELD;
 			$userRep1 = NULL;
 			$userRep2 = NULL;
 			$query2 = "SELECT `qaos_representative_user_id1` as user1,`qaos_representative_user_id2` as user2 FROM `qaos_teams` WHERE `qaos_team_name`='$qaosTeam2'";
-			$result2 = mysql_query($query2);
-			$row2 = mysql_fetch_assoc($result2);
+			$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
+			$row2 = mysqli_fetch_assoc($result2);
 			$userRep1 = $row2['user1'];
 			$userRep2 = $row2['user2'];
 			if($userRep1 && $userRep2){
@@ -704,7 +704,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep1 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id1` = '$userId' WHERE `qaos_team_name` = '$qaosTeam2'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam2");
 					$memberadd = true;
 				}
@@ -712,7 +712,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep2 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id2` = '$userId' WHERE `qaos_team_name` = '$qaosTeam2'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam2");
 					$memberadd = true;
 				}
@@ -723,8 +723,8 @@ DISABLEPARENTFIELD;
 			$userRep1 = NULL;
 			$userRep2 = NULL;
 			$query3 = "SELECT `qaos_representative_user_id1` as user1,`qaos_representative_user_id2` as user2 FROM `qaos_teams` WHERE `qaos_team_name`='$qaosTeam3'";
-			$result3 = mysql_query($query3);
-			$row3 = mysql_fetch_assoc($result3);
+			$result3 = mysqli_query($GLOBALS["___mysqli_ston"], $query3);
+			$row3 = mysqli_fetch_assoc($result3);
 			$userRep1 = $row3['user1'];
 			$userRep2 = $row3['user2'];
 			if($userRep1 && $userRep2){
@@ -732,7 +732,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep1 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id1` = '$userId' WHERE `qaos_team_name` = '$qaosTeam3'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam3");
 					$memberadd = true;
 				}
@@ -740,7 +740,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep2 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id2` = '$userId' WHERE `qaos_team_name` = '$qaosTeam3'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam3");
 					$memberadd = true;
 				}
@@ -751,8 +751,8 @@ DISABLEPARENTFIELD;
 			$userRep1 = NULL;
 			$userRep2 = NULL;
 			$query4 = "SELECT `qaos_representative_user_id1` as user1,`qaos_representative_user_id2` as user2 FROM `qaos_teams` WHERE `qaos_team_name`='$qaosTeam4'";
-			$result4 = mysql_query($query4);
-			$row4 = mysql_fetch_assoc($result4);
+			$result4 = mysqli_query($GLOBALS["___mysqli_ston"], $query4);
+			$row4 = mysqli_fetch_assoc($result4);
 			$userRep1 = $row4['user1'];
 			$userRep2 = $row4['user2'];
 			if($userRep1 && $userRep2){
@@ -760,7 +760,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep1 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id1` = '$userId' WHERE `qaos_team_name` = '$qaosTeam4'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam4");
 					$memberadd = true;
 				}
@@ -768,7 +768,7 @@ DISABLEPARENTFIELD;
 			}
 			else if(!$userRep2 && !$memberadd){
 				$query = "UPDATE `qaos_teams` SET `qaos_representative_user_id2` = '$userId' WHERE `qaos_team_name` = '$qaosTeam4'";
-				if($result = mysql_query($query)){
+				if($result = mysqli_query($GLOBALS["___mysqli_ston"], $query)){
 					displayinfo("User Successfully added in $qaosTeam4");
 					$memberadd = true;
 				}
@@ -823,12 +823,12 @@ DISABLEPARENTFIELD;
 		}
 // now check if the user exists or not
 		$query = "SELECT `user_id`,`qaos_unit_id` FROM `qaos_users` WHERE `user_id`='$userId'";
-		$result = mysql_query($query);
-		if($row = mysql_fetch_assoc($result)){
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if($row = mysqli_fetch_assoc($result)){
 			$unitId = $row['qaos_unit_id'];
 			$queryTeam = "SELECT `qaos_teams`.`qaos_team_name` FROM `qaos_teams`, `qaos_units` WHERE `qaos_teams`.`qaos_team_id`=`qaos_units`.`qaos_team_id` AND `qaos_units`.`qaos_unit_id`='$unitId'";
-			$resultTeam = mysql_query($queryTeam);
-			$row = mysql_fetch_assoc($resultTeam);
+			$resultTeam = mysqli_query($GLOBALS["___mysqli_ston"], $queryTeam);
+			$row = mysqli_fetch_assoc($resultTeam);
 			var_dump($row);
 			$teamName = $row['qaos_team_name'];
 			displayerror("Sorry, the user can not be added. The person already exists in the ".$teamName." team.");
@@ -836,12 +836,12 @@ DISABLEPARENTFIELD;
 		else {
 // Check whether the unit already exists in the database or not. If not add a new unit, and then add the user otherwise directly add the user
 			$queryUnits = "SELECT `qaos_unit_id` FROM `qaos_units` WHERE `qaos_team_id`='$teamId' AND `qaos_designation_id`='$designationId'";
-			$resultUnits = mysql_query($queryUnits);
+			$resultUnits = mysqli_query($GLOBALS["___mysqli_ston"], $queryUnits);
 //if the unit exist, just add the user to the qaos_user table.
-			if($rowUnits = mysql_fetch_assoc($resultUnits)){
+			if($rowUnits = mysqli_fetch_assoc($resultUnits)){
 				$unitId = $rowUnits['qaos_unit_id'];
 				$queryUsers = "INSERT INTO `qaos_users` (`page_modulecomponentid`,`user_id`,`qaos_unit_id`) VALUES ('$this->moduleComponentId','$userId','$unitId')";
-				$resultUsers = mysql_query($queryUsers);
+				$resultUsers = mysqli_query($GLOBALS["___mysqli_ston"], $queryUsers);
 				if($resultUsers)
 					displayinfo("The User was successfully added to the team");
 				else
@@ -850,17 +850,17 @@ DISABLEPARENTFIELD;
 //if the unit does not exist, add a new unit, add the unit in the tree and add the new user.
 			else{
 				$queryMaxUnitid = "SELECT MAX(`qaos_unit_id`) AS MAX FROM `qaos_units`";
-				$resultMaxUnitid = mysql_query($queryMaxUnitid);
-				$rowMaxUnitid = mysql_fetch_assoc($resultMaxUnitid);
+				$resultMaxUnitid = mysqli_query($GLOBALS["___mysqli_ston"], $queryMaxUnitid);
+				$rowMaxUnitid = mysqli_fetch_assoc($resultMaxUnitid);
 				$unitId = 1 + $rowMaxUnitid['MAX'];
 				$queryInsertUnit = "INSERT INTO `qaos_units` (`page_modulecomponentid`,`qaos_unit_id`,`qaos_team_id`,`qaos_designation_id`) VALUES ('$this->moduleComponentId','$unitId','$teamId','$designationId')";
-				$resultInsertUnit = mysql_query($queryInsertUnit);
+				$resultInsertUnit = mysqli_query($GLOBALS["___mysqli_ston"], $queryInsertUnit);
 				//echo $parentUnitId."two";
 				$queryInsertTree = "INSERT INTO `qaos_tree` (`page_modulecomponentid`,`qaos_unit_id`,`qaos_parentunit_id`) VALUES ('$this->moduleComponentId','$unitId','$parentUnitId')";
-				$resultInsertTree = mysql_query($queryInsertTree);
+				$resultInsertTree = mysqli_query($GLOBALS["___mysqli_ston"], $queryInsertTree);
 
 				$queryInsertUser = "INSERT INTO `qaos_users` (`page_modulecomponentid`,`user_id`,`qaos_unit_id`) VALUES ('$this->moduleComponentId','$userId','$unitId')";
-				$resultInsertUser = mysql_query($queryInsertUser);
+				$resultInsertUser = mysqli_query($GLOBALS["___mysqli_ston"], $queryInsertUser);
 				displayinfo("The User was successfully added to the team.");
 			}
 		}
@@ -873,8 +873,8 @@ DISABLEPARENTFIELD;
 		$imagesFolder = "$urlRequestRoot/$cmsFolder/$templateFolder/common/images";
 		$scriptsFolder = "$urlRequestRoot/$cmsFolder/$templateFolder/common/scripts";
 		$queryVersion = "SELECT `qaos_version` FROM `qaos_version` WHERE `page_modulecomponentid` = '$moduleComponentId'";
-		$resultVersion = mysql_query($queryVersion);
-		$row = mysql_fetch_row($resultVersion);
+		$resultVersion = mysqli_query($GLOBALS["___mysqli_ston"], $queryVersion);
+		$row = mysqli_fetch_row($resultVersion);
 		$version = $row[0];
 		$treeData .= "<h2>$version</h2>	<br />";
 		$treeData .= '<div id="directorybrowser"><ul class="treeview" id="qaos">' .
@@ -906,13 +906,13 @@ TREEDATA;
 	function getNodeHtml($unitId,$score) {
 		$htmlOut = '';
 		$query = "SELECT `user_id`,us.`qaos_unit_id`,d.`qaos_designation_name`,tm.`qaos_team_name` FROM `qaos_users` us,`qaos_designations` d,`qaos_units` un,`qaos_tree` t,`qaos_teams` tm WHERE t.`qaos_parentunit_id`='$unitId' AND us.`qaos_unit_id` = t.`qaos_unit_id` AND un.`qaos_unit_id`=us.`qaos_unit_id` AND d.`qaos_designation_id` = un.`qaos_designation_id` AND tm.`qaos_team_id`=un.`qaos_team_id` ORDER BY d.`qaos_designation_name`,tm.`qaos_team_name`";
-		$queryResult = mysql_query($query);
+		$queryResult = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$arrayUsers = array();
 		$arrayUnits = array();
 		$arr = array();
 		$designation = array();
 		$team = array();
-		while($queryArray = mysql_fetch_assoc($queryResult))
+		while($queryArray = mysqli_fetch_assoc($queryResult))
 		{
 			//$arrayUsers[] = $queryArray['user_id'];
 			//$arrayUnits[] = $queryArray['qaos_unit_id'];
@@ -974,7 +974,7 @@ USERNAME;
 	/*createModule just creates an empty qaos module*/
 	public function createModule($newId){
 		$query = "INSERT INTO `qaos_version` (`page_modulecomponentid`) VALUES ('$newId')";
-		$result = mysql_query($query) or die(mysql_error()."qaos.lib L:76");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."qaos.lib L:76");
 	}
 	
 	public function actionScore($moduleComponentId){
@@ -993,7 +993,7 @@ USERNAME;
 					$targetUserId = getUserIdFromEmail($targetUserEmail);
 					$userId = getUserIdFromEmail($userEmail);
 					$query = "INSERT INTO `qaos_scoring`(`page_modulecomponentid`,`user_id`,`targetuser_id`,`qaos_score1`,`qaos_score2`,`qaos_score3`,`qaos_score4`,`qaos_score5`,`qaos_reason1`,`qaos_reason2`,`qaos_reason3`,`qaos_reason4`,`qaos_reason5`) VALUES($moduleComponentId,$userId,$targetUserId,'".escape($_POST['qaos_score1'])."','".escape($_POST['qaos_score2'])."','".escape($_POST['qaos_score3'])."','".escape($_POST['qaos_score4'])."','".escape($_POST['qaos_score5'])."','".escape($_POST['qaos_reason1'])."','".escape($_POST['qaos_reason2'])."','".escape($_POST['qaos_reason3'])."','".escape($_POST['qaos_reason4'])."','".escape($_POST['qaos_reason5'])."')";
-					if(mysql_query($query))
+					if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 						displayinfo("Your scores have been stored.");
 					else
 						displayerror("There was some error in storing your scores");
@@ -1011,8 +1011,8 @@ USERNAME;
 					}
 					
 					$query ="SELECT * FROM `qaos_scoring` WHERE user_id='$userId' AND targetuser_id='$targetUserId'";
-					$result = mysql_query($query);
-					if(mysql_affected_rows()>0){
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0){
 						displayerror("You have already scored this person.");
 						return $htmlOut;
 					}
@@ -1227,13 +1227,13 @@ SCOREUSER;
 			}
 		
 		$query = "SELECT `user_id`,un.`qaos_unit_id`,d.`qaos_designation_name`,t.`qaos_team_name` FROM `qaos_users` u,`qaos_designations` d,`qaos_teams` t,`qaos_units` un WHERE un.`qaos_unit_id` = u.`qaos_unit_id` AND un.`qaos_team_id`='$teamId' AND d.`qaos_designation_id` = un.`qaos_designation_id` AND t.`qaos_team_id`=un.`qaos_team_id`" ;
-		$queryResult = mysql_query($query);
+		$queryResult = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$arrayUsers = array();
 		$arrayUnits = array();
 		$arr = array();
 		$designation = array();
 		$team = array();
-		while($queryArray = mysql_fetch_assoc($queryResult))
+		while($queryArray = mysqli_fetch_assoc($queryResult))
 		{
 			$designation[$queryArray['qaos_unit_id']] = $queryArray['qaos_designation_name'];
 			$team[$queryArray['qaos_unit_id']] = $queryArray['qaos_team_name'];
@@ -1259,13 +1259,13 @@ SCOREUSER;
 		if($teamName=="Core"){
 			$unitId = $this->getUnitIdFromUserId($this->userId);
 			$query = "SELECT us.user_id,tr.qaos_unit_id,d.qaos_designation_name, tm.qaos_team_name FROM `qaos_tree` tr JOIN qaos_units un ON (tr.qaos_unit_id = un.qaos_unit_id) JOIN qaos_teams tm ON (un.qaos_team_id = tm.qaos_team_id) JOIN qaos_designations d ON (un.qaos_designation_id = d.qaos_designation_id) JOIN qaos_users us ON (un.qaos_unit_id = us.qaos_unit_id) WHERE tr.qaos_parentunit_id='$unitId'";
-			$queryResult = mysql_query($query);
+			$queryResult = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			$arrayUsers = array();
 			$arrayUnits = array();
 			$arr = array();
 			$designation = array();
 			$team = array();
-			while($queryArray = mysql_fetch_assoc($queryResult))
+			while($queryArray = mysqli_fetch_assoc($queryResult))
 			{
 				$designation[$queryArray['qaos_unit_id']] = $queryArray['qaos_designation_name'];
 				$team[$queryArray['qaos_unit_id']] = $queryArray['qaos_team_name'];
@@ -1290,13 +1290,13 @@ SCOREUSER;
 		if($teamName=="Qaos"){
 			$unitId = $this->getUnitIdFromUserId($this->userId);
 			$query = "SELECT us.`user_id`,u.`qaos_unit_id`,d.`qaos_designation_name`,t.`qaos_team_name` FROM `qaos_units` u,`qaos_designations` d,`qaos_users` us,`qaos_teams` t WHERE u.`qaos_unit_id`= us.`qaos_unit_id` AND u.`qaos_designation_id`= d.`qaos_designation_id` AND u.`qaos_team_id` = t.`qaos_team_id` AND u.`qaos_team_id` IN (SELECT t.`qaos_team_id` FROM `qaos_teams` t WHERE t.`qaos_representative_user_id1` = '$this->userId' OR t.`qaos_representative_user_id2` = '$this->userId')";
-			$result = mysql_query($query);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			$arrayUsers = array();
 			$arrayUnits = array();
 			$arr = array();
 			$designation = array();
 			$team = array();
-			while($queryArray = mysql_fetch_assoc($result))
+			while($queryArray = mysqli_fetch_assoc($result))
 			{
 				$designation[$queryArray['qaos_unit_id']] = $queryArray['qaos_designation_name'];
 				$team[$queryArray['qaos_unit_id']] = $queryArray['qaos_team_name'];

--- a/cms/modules/qaos1.lib.php
+++ b/cms/modules/qaos1.lib.php
@@ -37,9 +37,9 @@ class qaos1 implements module, fileuploadable {
   private function getFormSuggestions($input) {
     $mcid=$this->moduleComponentId;
     $emailQuery = "SELECT * FROM `qaos1_events` WHERE `events_name` LIKE '%{$input}%' and `page_modulecomponentid`={$mcid}";
-    $emailResult = mysql_query($emailQuery);
+    $emailResult = mysqli_query($GLOBALS["___mysqli_ston"], $emailQuery);
     $suggestions = array($input);
-    while($emailRow = mysql_fetch_row($emailResult)) {
+    while($emailRow = mysqli_fetch_row($emailResult)) {
       $suggestions[] = $emailRow[1];
     }
     return join($suggestions, ',');
@@ -143,12 +143,12 @@ AB;
                 WHERE `modulecomponentid`='{$this->moduleComponentId}' AND `evtproc_Request`='{$_POST["request"]}'";
 	 $query.=" AND `evtproc_Quantity`='{$_POST["qty"]}' AND `evtproc_name`='{$_POST["evtname"]}' AND `userid`='{$this->userId}' AND ";
 	 $query.=" `evtproc_date`='{$_POST["evtproc_time"]}' AND `evtproc_Status`=0 AND `evtproc_reason`='{$_POST["evtprocreason"]}'";
-	 $res=mysql_query($query) or displayerror(mysql_error());
-	 if(!mysql_num_rows($res)) { 
+	 $res=mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	 if(!mysqli_num_rows($res)) { 
 	  $submit="INSERT INTO `qaos1_evtproc` (evtproc_Request,evtproc_Quantity,evtproc_name,modulecomponentid,userid,evtproc_reason,evtproc_date)
                   values ('{$_POST["request"]}','{$_POST["qty"]}','{$_POST["evtname"]}',$this->moduleComponentId,$this->userId,
                           '{$_POST["evtprocreason"]}','{$_POST["evtproc_time"]}')";  
-	  mysql_query($submit) or displayerror(mysql_error());
+	  mysqli_query($GLOBALS["___mysqli_ston"], $submit) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	 }
 	}
       }    
@@ -170,13 +170,13 @@ AB;
                       `fundreq_Quantity`='{$_POST["qty1"]}' AND `fundreq_name`='{$_POST["fevtname"]}' AND `userid`='{$this->userId}' AND 
 	              `fundreq_date`='{$_POST["fundreq_time"]}' AND `fundreq_Status`=0 AND `fundreq_Amount`='{$_POST["amt1"]}' AND 
                       `fundreq_reason`='{$_POST["fundreqreason"]}'";
-	  $res=mysql_query($query) or displayerror(mysql_error());
-	  if(!mysql_num_rows($res)) { 
+	  $res=mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	  if(!mysqli_num_rows($res)) { 
 	    $submit="INSERT INTO `qaos1_fundreq` (fundreq_Request,fundreq_Quantity,fundreq_name,fundreq_Amount,
                                                  modulecomponentid,userid,fundreq_reason,fundreq_date) 
                    VALUES ('{$_POST["request1"]}','{$_POST["qty1"]}','{$_POST["fevtname"]}','{$_POST["amt1"]}',$this->moduleComponentId,
                            $this->userId,'{$_POST["fundreqreason"]}','{$_POST["fundreq_time"]}')";
-	    mysql_query($submit) or displayerror(mysql_error());
+	    mysqli_query($GLOBALS["___mysqli_ston"], $submit) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	  }
 	}		
     }
@@ -218,7 +218,7 @@ AB;
 
       $actionview=$actionview1.$actionview;
       $hist1="SELECT * FROM qaos1_evtproc where modulecomponentid=$this->moduleComponentId AND userid=$this->userId";
-      $res=mysql_query($hist1);
+      $res=mysqli_query($GLOBALS["___mysqli_ston"], $hist1);
       $actionview.=<<<AB
         $smarttablestuff
 	<div id="deventproc" class="forms">
@@ -226,7 +226,7 @@ AB;
 	<table class="display" border="1" id="table_eventproc" width="100%">
 	  <thead><tr><th>ITEM</th><th>QUANTITY</th><th>EVENT</th><th>REASON</th><th>STATUS</th><th>DEADLINE</th><th>DESCRIPTION</th></tr></thead>
 AB;
-      while($result=mysql_fetch_array($res)) {	
+      while($result=mysqli_fetch_array($res)) {	
 	if($result['evtproc_Status']==0)$status="Pending";
 	elseif($result['evtproc_Status']==1)$status="Accepted By QA";
 	elseif($result['evtproc_Status']==2) $status="Decline";
@@ -254,8 +254,8 @@ AB;
 	    <thead><tr><th>ITEM</th><th>QUANTITY</th><th>EVENT NAME</th><th>REASON</th><th>STATUS</th><th>DEADLINE</th><th>DESCRIPTION</th></tr></thead>
 AB;
       $hist2="SELECT * FROM qaos1_fundreq where modulecomponentid=$this->moduleComponentId AND userid=$this->userId";
-      $res1=mysql_query($hist2);
-      while($result1=mysql_fetch_array($res1)) {
+      $res1=mysqli_query($GLOBALS["___mysqli_ston"], $hist2);
+      while($result1=mysqli_fetch_array($res1)) {
 	if($result1['fundreq_Status']==0) $status1="Pending";
 	else if($result1['fundreq_Status']==1) $status1="Accepted by qaos";
 	else if($result1['fundreq_Status']==2) $status1="Decline";
@@ -418,11 +418,11 @@ FORMTOADD;
 	 if(($_POST["hid"]!=2)||($_POST["hid1"]!=""))  {
 	$query="update qaos1_evtproc set evtproc_Status = {$_POST["hid"]},evtproc_Desc ='{$_POST["hid1"]}' where evtproc_Id ='{$_POST["hid2"]}' AND modulecomponentid={$this->moduleComponentId} AND evtproc_Status=1";
         echo $query;        
-	$res=mysql_query($query);		 }
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);		 }
 		}		
 	}
         $query="SELECT * FROM qaos1_evtproc WHERE modulecomponentid={$this->moduleComponentId}";
-        $res=mysql_query($query);
+        $res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
        	$css1=$urlRequestRoot."/".$cmsFolder."/".$moduleFolder."/qaos1/styles/main.css";
 	$smarttablestuff = smarttable::render(array('table_evtprocrequest','table_eventproc_head'),null);
 	$STARTSCRIPTS .="initSmartTable();";
@@ -508,7 +508,7 @@ FORMTOADD;
 					<th>SUBMIT</th>
 				</tr></thead>
 AB;
-			while($result=mysql_fetch_array($res))
+			while($result=mysqli_fetch_array($res))
 			{
 				$event=$result['evtproc_Id'];
 				$userName=getUserName($result['userid']);
@@ -547,7 +547,7 @@ AB;
 AB;
 
 	$hist1="SELECT *FROM qaos1_evtproc WHERE modulecomponentid={$this->moduleComponentId}";
-        $res=mysql_query($hist1);
+        $res=mysqli_query($GLOBALS["___mysqli_ston"], $hist1);
 	 $orgCaction.=<<<AB
 	 	    <div id="formevt" class="forms">
 					<h2>Event Procurement Status</h2>	       	    	
@@ -564,7 +564,7 @@ AB;
                                                 <th>PRINT BILL</th>
 					 </tr></thead>
 AB;
-	while($result=mysql_fetch_array($res))
+	while($result=mysqli_fetch_array($res))
 		{	
 		  $userName=getUserName($result['userid']);
 			if($result['evtproc_Status']==0) $status="Pending";
@@ -629,10 +629,10 @@ return $orgCaction;
       for($i=2;$i<=count($excelData);$i++) {
 	if($excelData[$i][1] == NULL) continue;
 	$checkIfExistQuery = "SELECT * FROM `qaos1_events` WHERE `events_name`='{$excelData[$i][1]}' AND `page_modulecomponentid`={$mcid}";
-	$checkIfExistRes = mysql_query($checkIfExistQuery) or displayerror(mysql_error());
-	if(mysql_num_rows($checkIfExistRes)) continue;
+	$checkIfExistRes = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfExistQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+	if(mysqli_num_rows($checkIfExistRes)) continue;
 	$insertIntoEventTableQuery = "INSERT IGNORE INTO `qaos1_events` (events_name,page_modulecomponentid) VALUES ('{$excelData[$i][1]}',{$mcid})";  
-	$res = mysql_query($insertIntoEventTableQuery) or displayerror(mysql_error());
+	$res = mysqli_query($GLOBALS["___mysqli_ston"], $insertIntoEventTableQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	if($res == "") $success=0; 
       }
       if(!$success) displayerror("Datas are not inserted");
@@ -649,7 +649,7 @@ return $orgCaction;
 				{ 
 				if(($_POST["hid"]!=2)||($_POST["hid1"]!=""))  {
 			$query="update qaos1_evtproc set evtproc_Status = '{$_POST["hid"]}',evtproc_Desc ='{$_POST["hid1"]}' where evtproc_Id ='{$_POST["hid2"]}' AND modulecomponentid={$this->moduleComponentId}";
-			$res=mysql_query($query);		 }
+			$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);		 }
 				}		
 		}
 		if(isset($_GET['subaction'])&&($_GET['subaction']=="apFundReq")&&(isset($_POST['qhid'])))
@@ -662,13 +662,13 @@ return $orgCaction;
 				if(($_POST["qhid"]!=2)||($_POST["qhid1"]!=""))  {
 
 			$query="update qaos1_fundreq set fundreq_Status = '{$_POST["qhid"]}',fundreq_Desc ='{$_POST["qhid1"]}' where fundreq_Id ='{$_POST["qhid2"]}' AND modulecomponentid={$this->moduleComponentId}";
-	       		$res=mysql_query($query);}
+	       		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);}
 					}
 		}
                 $query="SELECT * FROM qaos1_evtproc WHERE modulecomponentid={$this->moduleComponentId}";
-		$res=mysql_query($query);
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
        	  	$query1="SELECT * FROM qaos1_fundreq WHERE modulecomponentid={$this->moduleComponentId}";
-        	$res1=mysql_query($query1);
+        	$res1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
         $css1=$urlRequestRoot."/".$cmsFolder."/".$moduleFolder."/qaos1/styles/main.css";
 
 	$smarttablestuff = smarttable::render(array('table_evtprocrequest','table_fundreqform','table_eventproc_head','table_funreq_head'),null);
@@ -796,7 +796,7 @@ return $orgCaction;
 					<th>SUBMIT</th>
 				</tr></thead>
 AB;
-			while($result=mysql_fetch_array($res))
+			while($result=mysqli_fetch_array($res))
 			{
 				$event=$result['evtproc_Id'];
 				$userName=getUserName($result['userid']);
@@ -847,7 +847,7 @@ AB;
 		                                <th>SUBMIT</th>
 					    </tr></thead>
 AB;
-		     while($result1=mysql_fetch_array($res1))
+		     while($result1=mysqli_fetch_array($res1))
 				{
 					$event1=$result1['fundreq_Id'];
 					$userName=getUserName($result1['userid']);
@@ -886,7 +886,7 @@ AB;
 AB;
 
 	$hist1="SELECT *FROM qaos1_evtproc WHERE modulecomponentid={$this->moduleComponentId}";
-        $res=mysql_query($hist1);
+        $res=mysqli_query($GLOBALS["___mysqli_ston"], $hist1);
 	 $headaction.=<<<AB
 	 	    <div id="dheadeventproc" class="forms">
 					<h2>Event Procurement Status</h2>	       	    	
@@ -902,7 +902,7 @@ AB;
 				  		<th>DESCRIPTION</th>
 					 </tr></thead>
 AB;
-	while($result=mysql_fetch_array($res))
+	while($result=mysqli_fetch_array($res))
 		{	
 		  $userName=getUserName($result['userid']);
 			if($result['evtproc_Status']==0) $status="Pending";
@@ -945,9 +945,9 @@ AB;
 AB;
 	
 	$hist2="SELECT *  FROM qaos1_fundreq WHERE modulecomponentid={$this->moduleComponentId}";
-       	$res1=mysql_query($hist2);
+       	$res1=mysqli_query($GLOBALS["___mysqli_ston"], $hist2);
 
-     		 while($result1=mysql_fetch_array($res1))
+     		 while($result1=mysqli_fetch_array($res1))
 		 {
 		   $userName=getUserName($result1['userid']);
 			if($result1['fundreq_Status']==0) $status1="Pending";
@@ -1022,10 +1022,10 @@ return $headaction;
 				{ 
 				if(($_POST["qhid"]!=2)||($_POST["qhid1"]!=""))  {
 			$query="update qaos1_fundreq set fundreq_Status = '{$_POST["qhid"]}',fundreq_Desc ='{$_POST["qhid1"]}' where fundreq_Id ='{$_POST["qhid2"]}' AND modulecomponentid={$this->moduleComponentId}";
-			$res=mysql_query($query);}}
+			$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);}}
 			}
         	$query1="SELECT * FROM qaos1_fundreq WHERE modulecomponentid={$this->moduleComponentId}";
-         	$res1=mysql_query($query1);
+         	$res1=mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 		$css1=$urlRequestRoot."/".$cmsFolder."/".$moduleFolder."/qaos1/styles/main.css";
 		$smarttablestuff = smarttable::render(array('table_formstatus','table_funreq_treasurer','filestable'),null);
 		$STARTSCRIPTS .="initSmartTable();";
@@ -1121,7 +1121,7 @@ return $headaction;
 
 						</tr></thead>
 AB;
-		while($result1=mysql_fetch_array($res1))
+		while($result1=mysqli_fetch_array($res1))
 		     			{
 					  $userName=getUserName($result1['userid']);
 						$event1=$result1['fundreq_Id'];
@@ -1174,8 +1174,8 @@ AB;
  			     			</tr></thead>
 AB;
 				$hist2="SELECT *  FROM qaos1_fundreq WHERE modulecomponentid={$this->moduleComponentId}";
-       				$res1=mysql_query($hist2);
-				while($result1=mysql_fetch_array($res1))
+       				$res1=mysqli_query($GLOBALS["___mysqli_ston"], $hist2);
+				while($result1=mysqli_fetch_array($res1))
 		 		{
 				  $userName = getUserName($result1['userid']);
 				  if($result1['fundreq_Status']==0) $status1="Pending";

--- a/cms/modules/qaos1/excel/excel_reader2.php
+++ b/cms/modules/qaos1/excel/excel_reader2.php
@@ -913,7 +913,7 @@ class Spreadsheet_Excel_Reader {
 	 * Some basic initialisation
 	 */
 	function Spreadsheet_Excel_Reader($file='',$store_extended_info=true,$outputEncoding='') {
-		$this->_ole =& new OLERead();
+		$this->_ole = new OLERead();
 		$this->setUTFEncoder('iconv');
 		if ($outputEncoding != '') { 
 			$this->setOutputEncoding($outputEncoding);

--- a/cms/modules/qaos1/qaos_common.php
+++ b/cms/modules/qaos1/qaos_common.php
@@ -21,19 +21,19 @@ if(!defined('__PRAGYAN_CMS'))
 
 function assignVars($userId) {
   $query = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".$userId."'";
-  $result = mysql_query($query);
-  $row = mysql_fetch_assoc($result);
+  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+  $row = mysqli_fetch_assoc($result);
   return $arr = array ('PRAGYAN_ID'=> $row['user_id'] , 'NAME' => $row['user_name'] , 'EMAIL' => $row['user_email']);
 }
 
 function getEvtProc($evtProcId,$mcId) {
  $query = "SELECT * FROM `qaos1_evtproc` WHERE `modulecomponentid` = {$mcId} AND `evtproc_Id` = {$evtProcId}";		
- $result = mysql_query($query);
- $row = mysql_fetch_array($result);
- $columnDetail = mysql_query("SHOW COLUMNS FROM `qaos1_evtproc`");	
+ $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+ $row = mysqli_fetch_array($result);
+ $columnDetail = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW COLUMNS FROM `qaos1_evtproc`");	
  $ret = array();
  $cnt = 0;
- while($res = mysql_fetch_array($columnDetail)){
+ while($res = mysqli_fetch_array($columnDetail)){
   $ret[strtoupper($res[0])] = $row[$cnt++];
 
  } 
@@ -42,12 +42,12 @@ function getEvtProc($evtProcId,$mcId) {
 
 function getFundReq($fundReqId,$mcId) {
  $query = "SELECT * FROM `qaos1_fundreq` WHERE `modulecomponentid` = {$mcId} AND `fundreq_Id` = {$fundReqId}";		
- $result = mysql_query($query);
- $row = mysql_fetch_array($result);
- $columnDetail = mysql_query("SHOW COLUMNS FROM `qaos1_fundreq`");	
+ $result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+ $row = mysqli_fetch_array($result);
+ $columnDetail = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW COLUMNS FROM `qaos1_fundreq`");	
  $ret = array();
  $cnt = 0;
- while($res = mysql_fetch_array($columnDetail)){
+ while($res = mysqli_fetch_array($columnDetail)){
   $ret[strtoupper($res[0])] = $row[$cnt++];
 
  } 
@@ -129,17 +129,17 @@ TABLE;
 
 function getEventNameFromId($evtId,$mcid) {
   $query = "SELECT `events_name` FROM `qaos1_events` WHERE `page_modulecomponentid`=$mcid AND `events_id` = {$evtId}"; 
-  $result = mysql_query($query) or displayerror(mysql_error());
-  if(!mysql_num_rows($result)) return 0;
-  $res = mysql_fetch_array($result);
+  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($result)) return 0;
+  $res = mysqli_fetch_array($result);
   return $res[0];
 }
 
 function getEventIdFromName($evtName,$mcid) {
   $query = "SELECT `events_id` FROM `qaos1_events` WHERE `page_modulecomponentid`=$mcid AND `events_name` = '{$evtName}'"; 
-  $result = mysql_query($query) or displayerror(mysql_error());
-  if(!mysql_num_rows($result)) return 0;
-  $res = mysql_fetch_array($result);
+  $result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($result)) return 0;
+  $res = mysqli_fetch_array($result);
   return $res[0];
 }
 
@@ -153,25 +153,25 @@ function _date_is_valid($str) {
 }
 function addToBills($imgName,$evtId,$mcid,$userId,$cluster,$corp,$bill,$billdate,$billamt,$tin) {
   $checkImageExist = "SELECT * FROM  `qaos1_bills` WHERE `qaos1_eventid` = {$evtId} AND `page_modulecomponentid` = {$mcid} AND `qaos1_imgname` = '{$imgName}'";
-  $checkImageExistResult=mysql_query($checkImageExist) or displayerror(mysql_error());
-  if(mysql_num_rows($checkImageExistResult)) {
+  $checkImageExistResult=mysqli_query($GLOBALS["___mysqli_ston"], $checkImageExist) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(mysqli_num_rows($checkImageExistResult)) {
     displayerror("Image Already Exist");
     return 0;
   }
     $insertNewBillQuery = "INSERT INTO `qaos1_bills` (`qaos1_eventid`,`page_modulecomponentid`,`qaos1_imgname`,`userid`,`qaos1_cluster`,`qaos1_corp`,`qaos1_bill`,`qaos1_bill_date`,`qaos1_amt`,`qaos1_tin`) ";
   $insertNewBillQuery.= "VALUES ({$evtId},{$mcid},'{$imgName}',{$userId},'{$cluster}','{$corp}','{$bill}','{$billdate}','{$billamt}','{$tin}') ";
-  $insertNewBillResult = mysql_query($insertNewBillQuery) or displayerror(mysql_error());
+  $insertNewBillResult = mysqli_query($GLOBALS["___mysqli_ston"], $insertNewBillQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   return 1;
 }
 
 function displayBills($mcid,$active = false) {
   global $urlRequestRoot,$cmsFolder,$STARTSCRIPTS,$sourceFolder,$smarttablestuff;
   $billQuery = "SELECT * FROM `qaos1_bills` WHERE `page_modulecomponentid`={$mcid}";
-  $billResult = mysql_query($billQuery) or displayerror(mysql_error());
+  $billResult = mysqli_query($GLOBALS["___mysqli_ston"], $billQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($billQuery == "") return "";
   require_once($sourceFolder."/upload.lib.php");
   $uploadedFilesString = "";
-  while($result = mysql_fetch_assoc($billResult)) {
+  while($result = mysqli_fetch_assoc($billResult)) {
     $evtName=getEventNameFromId($result['qaos1_eventid'],$mcid);
     $billAddedBy = getUserName($result['userid']);
     $uploadedFilesString.=<<<TABLEROW
@@ -247,10 +247,10 @@ function downloadAsZipFile($mcid,$evtId = 0) {
   $getFileData.=($evtId != 0)?"AND events.qaos1_eventid= {$evtId}":"";
   $getFileData .= "      ORDER BY events.qaos1_eventid ";
   //  displayinfo($getFileData);
-  $getFileDataRes = mysql_query($getFileData) or displayerror(mysql_error());
+  $getFileDataRes = mysqli_query($GLOBALS["___mysqli_ston"], $getFileData) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
   if($getFileDataRes == "") return false;
   $billNo = array();
-  while($result = mysql_fetch_assoc($getFileDataRes)) {
+  while($result = mysqli_fetch_assoc($getFileDataRes)) {
     $upload_fileid = $result['upload_fileid'];
     $fileName = $result['qaos1_imgname'];
     $filename = str_repeat("0", (10 - strlen((string) $upload_fileid))) . $upload_fileid . "_" . $fileName;
@@ -303,21 +303,21 @@ FIELD;
 
 
 function disclaimerUpdate($mcid,$disclaimerTeam,$editorData) {
-    $mcid = mysql_real_escape_string($mcid);
+    $mcid = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $mcid) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
     $disclaimerTeam = escape($disclaimerTeam);	
 
     $checkIfBillDisclaimerExist = "SELECT * FROM `qaos1_disclaimer`                                                                  
                                    WHERE `page_modulecomponentid`={$mcid} AND  `disclaimer_team`='{$disclaimerTeam}'";
-    $checkQuery = mysql_query($checkIfBillDisclaimerExist) or displayerror(mysql_error());
+    $checkQuery = mysqli_query($GLOBALS["___mysqli_ston"], $checkIfBillDisclaimerExist) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if(!$checkQuery) return;
-    if(!mysql_num_rows($checkQuery)) {
+    if(!mysqli_num_rows($checkQuery)) {
 	$insertDisclaimer = "INSERT INTO `qaos1_disclaimer` VALUES($mcid,'{$disclaimerTeam}','')"; 	
-        $insertDIsclaimerQuery = mysql_query($insertDisclaimer) or displayerror(mysql_error());	
+        $insertDIsclaimerQuery = mysqli_query($GLOBALS["___mysqli_ston"], $insertDisclaimer) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));	
 	if(!$insertDIsclaimerQuery) return ;
 	}
     $insertQuery="UPDATE `qaos1_disclaimer` SET `disclaimer_desc`='{$editorData}' WHERE `page_modulecomponentid`={$mcid} ";
     $insertQuery.="AND `disclaimer_team`='{$disclaimerTeam}'";
-    $updateRes=mysql_query($insertQuery) or displayerror(mysql_error());
+    $updateRes=mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if($updateRes!='') displayinfo("Details Successfully updated !!!");
 }
 
@@ -326,14 +326,14 @@ function getDisclaimer($team,$mcid) {
   $mcid = escape($mcid);
 
   $getQuery="SELECT * FROM `qaos1_disclaimer` WHERE `page_modulecomponentid`={$mcid} AND `disclaimer_team`='{$team}'"; 
-  $runQuery=mysql_query($getQuery) or displayerror(mysql_error());
-  if(!mysql_num_rows($runQuery)) {
+  $runQuery=mysqli_query($GLOBALS["___mysqli_ston"], $getQuery) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+  if(!mysqli_num_rows($runQuery)) {
     
-    $insertQuery=mysql_query("INSERT INTO `qaos1_disclaimer` VALUES({$mcid},'{$team}','')") or displayerror(mysql_error());
+    $insertQuery=mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `qaos1_disclaimer` VALUES({$mcid},'{$team}','')") or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     if($insertQuery!="") displayinfo("Field {$team} Inserted TO Table");
     return "";
   }
-  $res=mysql_fetch_assoc($runQuery);
+  $res=mysqli_fetch_assoc($runQuery);
   
   return $res['disclaimer_desc'];
 }

--- a/cms/modules/quiz.lib.php
+++ b/cms/modules/quiz.lib.php
@@ -292,13 +292,13 @@ class quiz implements module {
 			$userid = escape($_POST['userid']);
 			$mark = escape($_POST['mark']);
 			$condition = "`page_modulecomponentid` = '$quizid' AND `quiz_sectionid` = '$sectionid' AND `quiz_questionid` = '$questionid' AND `user_id` = '$userid'";
-			$result = mysql_query("SELECT `quiz_submittedanswer` FROM `quiz_answersubmissions` WHERE $condition");
-			if($row = mysql_fetch_array($result)) {
-				$result = mysql_fetch_array(mysql_query("SELECT `question_positivemarks`, `question_negativemarks` FROM `quiz_weightmarks` WHERE `page_modulecomponentid` = '$quizid' AND `question_weight` = (SELECT `quiz_questionweight` FROM `quiz_questions` WHERE `page_modulecomponentid` = '$quizid' AND `quiz_sectionid` = '$sectionid' AND `quiz_questionid` = '$questionid')"));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_submittedanswer` FROM `quiz_answersubmissions` WHERE $condition");
+			if($row = mysqli_fetch_array($result)) {
+				$result = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `question_positivemarks`, `question_negativemarks` FROM `quiz_weightmarks` WHERE `page_modulecomponentid` = '$quizid' AND `question_weight` = (SELECT `quiz_questionweight` FROM `quiz_questions` WHERE `page_modulecomponentid` = '$quizid' AND `quiz_sectionid` = '$sectionid' AND `quiz_questionid` = '$questionid')"));
 				if($_POST['mark'] > $result['question_positivemarks'] || $_POST['mark'] < -1 * $result['question_negativemarks'])
 					displaywarning('Mark out of range for this question, so mark not set');
 				else {
-					mysql_query("UPDATE `quiz_answersubmissions` SET `quiz_marksallotted` = $mark WHERE $condition");
+					mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `quiz_answersubmissions` SET `quiz_marksallotted` = $mark WHERE $condition");
 					updateSectionMarks($quizid);
 					displayinfo('Mark set');
 				}
@@ -330,8 +330,8 @@ class quiz implements module {
 	 */
 	public function createModule($moduleComponentId) {
 		$insertQuery = "INSERT INTO `quiz_descriptions`(`page_modulecomponentid`,`quiz_title`, `quiz_headertext`, `quiz_submittext`, `quiz_quiztype`, `quiz_testduration`, `quiz_questionspertest`, `quiz_questionsperpage`, `quiz_timeperpage`, `quiz_allowsectionrandomaccess`, `quiz_mixsections`, `quiz_showquiztimer`, `quiz_showpagetimer`) VALUES" . "('{$moduleComponentId}','New Quiz', 'Quiz under construction', 'Quiz under construction', 'simple', '00:30', '20', '10', 0, 1, 0, 1, 0)"; 
-		if (!mysql_query($insertQuery)) {
-			displayerror('Database Error. Could not create quiz. ' . $insertQuery . ' ' . mysql_error());
+		if (!mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery)) {
+			displayerror('Database Error. Could not create quiz. ' . $insertQuery . ' ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		}
 	}
 

--- a/cms/modules/quiz/quizcorrect.php
+++ b/cms/modules/quiz/quizcorrect.php
@@ -12,8 +12,8 @@ if(!defined('__PRAGYAN_CMS'))
 
 function isQuizEvaluated($quizId) {
 	$countQuery = "SELECT COUNT(*) FROM `quiz_userattempts` WHERE `quiz_marksallotted` IS NULL AND `page_modulecomponentid` = '$quizId'";
-	$countResult = mysql_query($countQuery);
-	$countRow = mysql_fetch_row($countResult);
+	$countResult = mysqli_query($GLOBALS["___mysqli_ston"], $countQuery);
+	$countRow = mysqli_fetch_row($countResult);
 	return $countRow[0] == 0;
 }
 
@@ -47,7 +47,7 @@ function evaluateQuiz($quizId) {
 UPDATEQUERY;
 //	echo $updateQuery;
 
-	$updateResult = mysql_query($updateQuery);
+	$updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 	if (!$updateResult) {
 		displayerror('Database Error. Could not correct questions.');
 		return false;
@@ -66,10 +66,10 @@ function updateSectionMarks($quizId) {
 			"`quiz_answersubmissions`.`quiz_sectionid` = `quiz_userattempts`.`quiz_sectionid` AND " .
 			"`quiz_answersubmissions`.`page_modulecomponentid` = '$quizId'" .
 			") WHERE `page_modulecomponentid` = '$quizId'";
-	$updateResult = mysql_query($updateQuery);
+	$updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 
 	if (!$updateResult) {
-		displayerror('Database Error. Could not update section marks. ' . $updateQuery . ' ' . mysql_error());
+		displayerror('Database Error. Could not update section marks. ' . $updateQuery . ' ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		return false;
 	}
 
@@ -82,8 +82,8 @@ function updateSectionMarks($quizId) {
  */
 function getWeights($quizId) {
 	$weighs = array();
-	$result = mysql_query("SELECT `quiz_questionweight` FROM `quiz_questions` WHERE `page_modulecomponentid` = '$quizId' AND `quiz_questionweight` NOT IN (SELECT `question_weight` FROM `quiz_weightmarks` WHERE `page_modulecomponentid` = '$quizId')");
-	while($row = mysql_fetch_assoc($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_questionweight` FROM `quiz_questions` WHERE `page_modulecomponentid` = '$quizId' AND `quiz_questionweight` NOT IN (SELECT `question_weight` FROM `quiz_weightmarks` WHERE `page_modulecomponentid` = '$quizId')");
+	while($row = mysqli_fetch_assoc($result))
 		$weighs[] = $row['quiz_questionweight'];
 	return $weighs;
 }
@@ -119,19 +119,19 @@ function getQuizUserListHtml($quizId) {
 			"GROUP BY `quiz_userattempts`.`user_id` ORDER BY `total` DESC, `timetaken`, `starttime`, `finishtime`, `email`";
 	
 	$profileQuery = 'SELECT `form_elementname` FROM `form_elementdesc` WHERE `page_modulecomponentid` = 0 ORDER BY `form_elementrank`';
-	$profileResult = mysql_query($profileQuery);
+	$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
 	$profilecolumns=array();
-	while($profileRow = mysql_fetch_row($profileResult)) {
+	while($profileRow = mysqli_fetch_row($profileResult)) {
 		$profilecolumns['form0_' . $profileRow[0]] = $profileRow[0];
 	}
 
 	
-	$markResult = mysql_query($markQuery);
+	$markResult = mysqli_query($GLOBALS["___mysqli_ston"], $markQuery);
 	if (!$markResult) {
-		displayerror($markQuery . '  ' . mysql_error());
+		displayerror($markQuery . '  ' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}
-	$query = mysql_fetch_array(mysql_query("SELECT `quiz_title` FROM `quiz_descriptions` WHERE `page_modulecomponentid` = '$quizId'"));
-	$result = mysql_query("SELECT `quiz_sectiontitle` FROM `quiz_sections` WHERE `page_modulecomponentid` = '$quizId' ORDER BY `quiz_sectionid`");
+	$query = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_title` FROM `quiz_descriptions` WHERE `page_modulecomponentid` = '$quizId'"));
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_sectiontitle` FROM `quiz_sections` WHERE `page_modulecomponentid` = '$quizId' ORDER BY `quiz_sectionid`");
 	$sectionHead = "";
 	$secCols="";
 	$toggleColumns="<tr><td><input type='checkbox' onclick='fnShowHide(0);' checked />User Full Name<br/></td>";
@@ -142,7 +142,7 @@ function getQuizUserListHtml($quizId) {
 	$toggleColumns.="<td><input type='checkbox' onclick='fnShowHide(5);' />Finished<br/></td>";
 	
 	$c=6;
-	while($row = mysql_fetch_array($result))
+	while($row = mysqli_fetch_array($result))
 	{
 		$sectionHead .= "<th>Section : {$row['quiz_sectiontitle']}</th>";
 		$tableJqueryStuff.="null,";
@@ -219,12 +219,12 @@ HEAD;
 		"<thead><tr><th>User Full Name</th><th>User Email</th><th>Total Marks</th><th>Time Taken</th><th>Started</th><th>Finished</th>$sectionHead<th>Action</th></tr></thead><tbody>";
 		
 		
-	while ($markRow = mysql_fetch_assoc($markResult)) {
+	while ($markRow = mysqli_fetch_assoc($markResult)) {
 		$userMarks = "";
-		$marksResult = mysql_query("SELECT `quiz_marksallotted`,`quiz_sectionid` FROM `quiz_userattempts` WHERE `user_id` = '{$markRow['user_id']}' AND `page_modulecomponentid` = '$quizId' ORDER BY `quiz_sectionid`");
+		$marksResult = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_marksallotted`,`quiz_sectionid` FROM `quiz_userattempts` WHERE `user_id` = '{$markRow['user_id']}' AND `page_modulecomponentid` = '$quizId' ORDER BY `quiz_sectionid`");
 		$cc=1;
 		
-		while($row = mysql_fetch_array($marksResult))
+		while($row = mysqli_fetch_array($marksResult))
 		{
 			
 			if($row['quiz_sectionid']!=$cc) // To check if some sections are missing, if yes then add NA value
@@ -248,9 +248,9 @@ HEAD;
 						"`form_elementdata`.`page_modulecomponentid` = 0 AND `user_id` = '{$markRow['user_id']}' AND " .
 						"`form_elementdata`.`page_modulecomponentid` = `form_elementdesc`.`page_modulecomponentid` AND " .
 						"`form_elementdata`.`form_elementid` = `form_elementdesc`.`form_elementid` ORDER BY `form_elementrank`";
-			$elementDataResult = mysql_query($elementDataQuery) or die($elementDataQuery . '<br />' . mysql_error());
+			$elementDataResult = mysqli_query($GLOBALS["___mysqli_ston"], $elementDataQuery) or die($elementDataQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			$elementRow=array();
-			while($elementDataRow = mysql_fetch_assoc($elementDataResult)) {
+			while($elementDataRow = mysqli_fetch_assoc($elementDataResult)) {
 				$elementRow['form0_' . $elementDataRow['form_elementname']] = $elementDataRow['form_elementdata'];
 				if($elementDataRow['form_elementtype'] == 'file') {
 					$elementRow['form0_' . $elementDataRow['form_elementname']] = '<a href="./'.$elementDataRow['form_elementdata'].'">' . $elementDataRow['form_elementdata'] . '</a>';
@@ -309,15 +309,15 @@ HEAD;
  * returns form where user answers submissions will be displayed, marks can be alloted for subjective answers
  */
 function getQuizCorrectForm($quizId, $userId) {
-	$marks = mysql_fetch_array(mysql_query("SELECT SUM(`quiz_marksallotted`) AS `total`, MIN(`quiz_attemptstarttime`) AS `starttime`, MAX(`quiz_submissiontime`) AS `finishtime`, TIMEDIFF(MAX(`quiz_submissiontime`), MIN(`quiz_attemptstarttime`)) AS `timetaken` FROM `quiz_userattempts` WHERE `user_id` = '{$userId}' AND `page_modulecomponentid` = '$quizId'"));
-	$title = mysql_fetch_array(mysql_query("SELECT `quiz_title` FROM `quiz_descriptions` WHERE `page_modulecomponentid` = '$quizId'"));
+	$marks = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT SUM(`quiz_marksallotted`) AS `total`, MIN(`quiz_attemptstarttime`) AS `starttime`, MAX(`quiz_submissiontime`) AS `finishtime`, TIMEDIFF(MAX(`quiz_submissiontime`), MIN(`quiz_attemptstarttime`)) AS `timetaken` FROM `quiz_userattempts` WHERE `user_id` = '{$userId}' AND `page_modulecomponentid` = '$quizId'"));
+	$title = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_title` FROM `quiz_descriptions` WHERE `page_modulecomponentid` = '$quizId'"));
 
 	$correctFormHtml = "";
 	$sectionHead="";
 
-	$sections = mysql_query("SELECT `quiz_sections`.`quiz_sectiontitle` AS `quiz_sectiontitle`, `quiz_sections`.`quiz_sectionid` AS `quiz_sectionid`, `quiz_marksallotted` FROM `quiz_userattempts` JOIN `quiz_sections` ON `quiz_userattempts`.`quiz_sectionid` = `quiz_sections`.`quiz_sectionid` WHERE `user_id` = '$userId' AND `quiz_userattempts`.`page_modulecomponentid` = '$quizId' AND `quiz_sections`.`page_modulecomponentid` = '$quizId'");
+	$sections = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `quiz_sections`.`quiz_sectiontitle` AS `quiz_sectiontitle`, `quiz_sections`.`quiz_sectionid` AS `quiz_sectionid`, `quiz_marksallotted` FROM `quiz_userattempts` JOIN `quiz_sections` ON `quiz_userattempts`.`quiz_sectionid` = `quiz_sections`.`quiz_sectionid` WHERE `user_id` = '$userId' AND `quiz_userattempts`.`page_modulecomponentid` = '$quizId' AND `quiz_sections`.`page_modulecomponentid` = '$quizId'");
 	
-	while($sectionsRow = mysql_fetch_array($sections)) {
+	while($sectionsRow = mysqli_fetch_array($sections)) {
 	$correctFormHtml .= "<h4>{$sectionsRow['quiz_sectiontitle']}(Marks: {$sectionsRow['quiz_marksallotted']})</h4>";
 	$sectionHead .="<td><b>{$sectionsRow['quiz_sectiontitle']}</b> section marks: {$sectionsRow['quiz_marksallotted']}</td>";
 	
@@ -334,12 +334,12 @@ function getQuizCorrectForm($quizId, $userId) {
 			"`user_id` = '$userId' ORDER BY `quiz_answersubmissions`.`quiz_questionrank`";
 
 
-	$questionResult = mysql_query($questionQuery);
+	$questionResult = mysqli_query($GLOBALS["___mysqli_ston"], $questionQuery);
 
 	if (!$questionResult)
-		displayerror($questionQuery . '<br />' . mysql_error());
+		displayerror($questionQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	
-	while ($questionRow = mysql_fetch_assoc($questionResult)) {
+	while ($questionRow = mysqli_fetch_assoc($questionResult)) {
 		$correctFormHtml .= '<table class="quiz_' . (is_null($questionRow['quiz_marksallotted']) || floatval($questionRow['quiz_marksallotted']) <= 0 ? 'wrong' : 'right') . "answer\"><tr><td colspan=\"2\">{$questionRow['quiz_question']}</td></tr>\n";
 		if ($questionRow['quiz_questiontype'] == 'subjective') {
 			$submittedAnswers = array();

--- a/cms/modules/quiz/quizview.php
+++ b/cms/modules/quiz/quizview.php
@@ -18,9 +18,9 @@ if(!defined('__PRAGYAN_CMS'))
  */
 function getQuestionTypeCounts($quizId, $sectionId) {
 	$countQuery = "SELECT `quiz_questiontype`, COUNT(*) FROM `quiz_questions` WHERE `page_modulecomponentid` = '$quizId' AND `quiz_sectionid` = '$sectionId' GROUP BY `quiz_questiontype`";
-	$countResult = mysql_query($countQuery);
+	$countResult = mysqli_query($GLOBALS["___mysqli_ston"], $countQuery);
 	$result = array();
-	while ($countRow = mysql_fetch_row($countResult))
+	while ($countRow = mysqli_fetch_row($countResult))
 		$result[$countRow[0]] = $countRow[1];
 	$questionTypes = array_keys(getQuestionTypes());
 	for ($i = 0; $i < count($questionTypes); ++$i)
@@ -55,8 +55,8 @@ function checkQuizSetup($quizId) {
  */
 function checkQuizOpen($quizId) {
 	$quizQuery = "SELECT IF(NOW() < `quiz_startdatetime`, -1, IF(NOW() > `quiz_enddatetime`, 1, 0)) FROM `quiz_descriptions` WHERE `page_modulecomponentid` = '$quizId'";
-	$quizResult = mysql_query($quizQuery);
-	$quizRow = mysql_fetch_row($quizResult);
+	$quizResult = mysqli_query($GLOBALS["___mysqli_ston"], $quizQuery);
+	$quizRow = mysqli_fetch_row($quizResult);
 	if (!$quizRow) {
 		displayerror('Error. Could not find information about the given quiz.');
 		return 1;
@@ -70,8 +70,8 @@ function checkQuizOpen($quizId) {
  */
 function checkUserFirstAttempt($quizId, $userId) {
 	$attemptQuery = "SELECT COUNT(*) FROM `quiz_userattempts` WHERE `page_modulecomponentid` = '$quizId' AND `user_id` = '$userId'";
-	$attemptResult = mysql_query($attemptQuery);
-	$attemptRow = mysql_fetch_row($attemptResult);
+	$attemptResult = mysqli_query($GLOBALS["___mysqli_ston"], $attemptQuery);
+	$attemptRow = mysqli_fetch_row($attemptResult);
 	return $attemptRow[0] == 0;
 }
 
@@ -81,8 +81,8 @@ function checkUserFirstAttempt($quizId, $userId) {
  */
 function sectionBelongsToQuiz($quizId, $sectionId) {
 	$sectionQuery = "SELECT COUNT(*) FROM `quiz_sections` WHERE `page_modulecomponentid` = '$quizId' AND `quiz_sectionid` = '$sectionId'";
-	$sectionResult = mysql_query($sectionQuery);
-	$sectionRow = mysql_fetch_row($sectionResult);
+	$sectionResult = mysqli_query($GLOBALS["___mysqli_ston"], $sectionQuery);
+	$sectionRow = mysqli_fetch_row($sectionResult);
 	return $sectionRow[0] == 1;
 }
 
@@ -93,7 +93,7 @@ function sectionBelongsToQuiz($quizId, $sectionId) {
 function startSection($quizId, $sectionId, $userId) {
 	$attemptQuery = "INSERT INTO `quiz_userattempts`(`page_modulecomponentid`, `quiz_sectionid`, `user_id`, `quiz_attemptstarttime`) VALUES " .
 			"('$quizId', '$sectionId', '$userId', NOW())";
-	if (!mysql_query($attemptQuery)) {
+	if (!mysqli_query($GLOBALS["___mysqli_ston"], $attemptQuery)) {
 		displayerror('Database Error. Could not mark section as started.');
 		return false;
 	}
@@ -106,10 +106,10 @@ function startSection($quizId, $sectionId, $userId) {
  */
 function getFirstSectionId($quizId) {
 	$sectionQuery = "SELECT MIN(`quiz_sectionid`) FROM `quiz_sections` WHERE `page_modulecomponentid` = '$quizId'";
-	$sectionResult = mysql_query($sectionQuery);
+	$sectionResult = mysqli_query($GLOBALS["___mysqli_ston"], $sectionQuery);
 	if (!$sectionResult)
 		return -1;
-	$sectionRow = mysql_fetch_row($sectionResult);
+	$sectionRow = mysqli_fetch_row($sectionResult);
 	return $sectionRow[0];
 }
 
@@ -119,6 +119,6 @@ function getFirstSectionId($quizId) {
  */
 function getAttemptRow($quizId, $sectionId, $userId) {
 	$attemptQuery = "SELECT * FROM `quiz_userattempts` WHERE `page_modulecomponentid` = '$quizId' AND `quiz_sectionid` = '$sectionId' AND `user_id` = '$userId'";
-	$attemptResult = mysql_query($attemptQuery);
-	return mysql_fetch_assoc($attemptResult);
+	$attemptResult = mysqli_query($GLOBALS["___mysqli_ston"], $attemptQuery);
+	return mysqli_fetch_assoc($attemptResult);
 }

--- a/cms/modules/safedit.lib.php
+++ b/cms/modules/safedit.lib.php
@@ -59,10 +59,10 @@ class safedit implements module, fileuploadable {
 	 */
 	public function actionView() {
 		$ret = "";
-		$val = mysql_fetch_assoc(mysql_query("SELECT `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_module` = 'safedit' AND `page_modulecomponentid` = '{$this->moduleComponentId}'"));
+		$val = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_module` = 'safedit' AND `page_modulecomponentid` = '{$this->moduleComponentId}'"));
 		$ret .= "<h1>".$val['page_title']."</h1>";
-		$result = mysql_query("SELECT `section_id`,`section_heading`,`section_type`,`section_content` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_show` = 1 ORDER BY `section_priority`");
-		while($row = mysql_fetch_assoc($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `section_id`,`section_heading`,`section_type`,`section_content` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_show` = 1 ORDER BY `section_priority`");
+		while($row = mysqli_fetch_assoc($result)) {
 			if($row['section_heading']!="")
 				$ret .= "<h2>".$row['section_heading']."</h2>";
 			$ret .= "<div class='safedit_section'>";
@@ -120,29 +120,29 @@ RET;
 		require_once($sourceFolder."/upload.lib.php");
 		submitFileUploadForm($this->moduleComponentId,"safedit",$this->userId,UPLOAD_SIZE_LIMIT);
 		$end = "<fieldset id='uploadFile'><legend>{$ICONS['Uploaded Files']['small']}File Upload</legend>Upload files : <br />".getFileUploadForm($this->moduleComponentId,"safedit",'./+edit',UPLOAD_SIZE_LIMIT,5).getUploadedFilePreviewDeleteForm($this->moduleComponentId,"safedit",'./+edit').'</fieldset>';
-		$val = mysql_fetch_assoc(mysql_query("SELECT `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_module` = 'safedit' AND `page_modulecomponentid` = '{$this->moduleComponentId}'"));
+		$val = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_module` = 'safedit' AND `page_modulecomponentid` = '{$this->moduleComponentId}'"));
 		$ret .= "<h1>Editing '".$val['page_title']."' page</h1>";
 		if(isset($_GET['subaction'])) {
 			if($_GET['subaction']=="addSection") {
 				$show = isset($_POST['sectionShow']);
 				$heading = escape($_POST['heading']);
-				$result = mysql_query("SELECT MAX(`section_id`)+1 as `section_id` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'") or die(mysql_error());
-				$row = mysql_fetch_row($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT MAX(`section_id`)+1 as `section_id` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'") or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				$row = mysqli_fetch_row($result);
 				$sectionId = $row[0];
-				$result = mysql_query("SELECT MAX(`section_priority`)+1 as `section_priority` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'");
-				$row = mysql_fetch_row($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT MAX(`section_priority`)+1 as `section_priority` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'");
+				$row = mysqli_fetch_row($result);
 				$priority = $row[0];
 				$query = "INSERT INTO `safedit_sections`(`page_modulecomponentid`,`section_id`,`section_heading`,`section_type`,`section_show`,`section_priority`) VALUES ('{$this->moduleComponentId}','{$sectionId}','{$heading}','" . escape($_POST['type']) . "','{$show}','{$priority}')";
-				mysql_query($query) or die($query . "<br>" . mysql_error());
-				if(mysql_affected_rows()>0)
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die($query . "<br>" . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 					displayinfo("Section: {$heading}, created");
 				else
 					displayerror("Couldn't create section");
 			} else if($_GET['subaction']=='deleteSection') {
 				$sectionId = escape($_GET['sectionId']);
 				$query = "DELETE FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'";
-				mysql_query($query) or die($query . "<br>" . mysql_error());
-				if(mysql_affected_rows()>0)
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die($query . "<br>" . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 					displayinfo("Section deleted succesfully");
 				else
 					displayerror("Couldn't delete section");
@@ -151,32 +151,32 @@ RET;
 				$heading = escape($_POST['heading']);
 				$typeUpdate = isset($_POST['type'])?", `section_type` = '{$_POST['type']}'":'';
 				$show = ", `section_show` = '" . isset($_POST['sectionShow']) . "'";
-				$result = mysql_query("SELECT `section_type` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'");
-				$row = mysql_fetch_row($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `section_type` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'");
+				$row = mysqli_fetch_row($result);
 				$type = $row[0];
 				if($type=="para"||$type=="ulist"||$type=="olist")
 					$sectionContent = escape($this->processSave($_POST['content']));
 				else if($type=="picture")
 					$sectionContent = escape($_POST['selectFile']);
 				$query = "UPDATE `safedit_sections` SET `section_heading` = '{$heading}', `section_content` = '{$sectionContent}'{$typeUpdate}{$show} WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'";
-				mysql_query($query) or die($query . "<br>" . mysql_error());
-				if(mysql_affected_rows()>0)
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die($query . "<br>" . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 					displayinfo("Section saved successfully");
 			} else if($_GET['subaction']=='moveUp'||$_GET['subaction']=='moveDown') {
 				$compare = $_GET['subaction']=='moveUp'?'<=':'>=';
 				$arrange = $_GET['subaction']=='moveUp'?'DESC':'ASC';
 				$sectionId = escape($_GET['sectionId']);
 				$query = "SELECT `section_id`,`section_priority` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_priority` '{$compare}' (SELECT `section_priority` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}') ORDER BY `section_priority` '{$arrange}' LIMIT 2";
-				$result = mysql_query($query);
-				$row = mysql_fetch_row($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$row = mysqli_fetch_row($result);
 				$sid = $row[0]; $spr = $row[1];
-				if($row = mysql_fetch_row($result)) {
-					mysql_query("UPDATE `safedit_sections` SET `section_priority` = '{$spr}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$row[0]}'");
-					mysql_query("UPDATE `safedit_sections` SET `section_priority` = '{$row[1]}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sid}'");
+				if($row = mysqli_fetch_row($result)) {
+					mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `safedit_sections` SET `section_priority` = '{$spr}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$row[0]}'");
+					mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `safedit_sections` SET `section_priority` = '{$row[1]}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sid}'");
 				}
 			} else if($_GET['subaction']=='moveTop'||$_GET['subaction']=='moveBottom') {
 				$sectionId = escape($_GET['sectionId']);
-				$cpri = mysql_fetch_row(mysql_query("SELECT `section_priority` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'")) or die(mysql_error());
+				$cpri = mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `section_priority` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'")) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				if($_GET['subaction']=='moveTop') {
 					$sign = '+';
 					$cmpr = '<';
@@ -184,18 +184,18 @@ RET;
 				} else {
 					$sign = '-';
 					$cmpr = '>';
-					$set = mysql_fetch_row(mysql_query("SELECT MAX(`section_priority`) FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'")) or die(mysql_error());
+					$set = mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT MAX(`section_priority`) FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'")) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 					$set = isset($set[0])?$set[0]:'';
 				}
 				$cmpr = $_GET['subaction']=='moveTop'?'<':'>';
 				$query = "UPDATE `safedit_sections` SET `section_priority` = `section_priority`{$sign}1 WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_priority` {$cmpr} '{$cpri[0]}'";
-				mysql_query($query) or die(mysql_error());
-				mysql_query("UPDATE `safedit_sections` SET `section_priority` = '{$set}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'") or die(mysql_error());
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `safedit_sections` SET `section_priority` = '{$set}' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' AND `section_id` = '{$sectionId}'") or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			}
 		}
 		
-		$result = mysql_query("SELECT `section_id`,`section_heading`,`section_type`,`section_content`,`section_show` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' ORDER BY `section_priority`");
-		while($row = mysql_fetch_assoc($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `section_id`,`section_heading`,`section_type`,`section_content`,`section_show` FROM `safedit_sections` WHERE `page_modulecomponentid` = '{$this->moduleComponentId}' ORDER BY `section_priority`");
+		while($row = mysqli_fetch_assoc($result)) {
 			$show = $row['section_show']?'checked ':'';
 			$type = $row['section_type'];
 			$help = $type!="picture"?" <a href='#help' title='Only Plain text allowed, Click to know more'>{$ICONS['Help']['small']}</a>":'';

--- a/cms/modules/scrolltext.lib.php
+++ b/cms/modules/scrolltext.lib.php
@@ -35,12 +35,12 @@ class scrolltext implements module{
 	public function actionScrollview($text="") {
 			if($text=="") {
 				$query = "SELECT article_modulecomponentid FROM scrolltext WHERE page_modulecomponentid=". $this->moduleComponentId;
-				$result = mysql_query($query);
-				$row = mysql_fetch_assoc($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$row = mysqli_fetch_assoc($result);
 				$articleid=$row['article_modulecomponentid'];
 				$query = "SELECT article_content,article_lastupdated FROM article_content WHERE page_modulecomponentid=" . $articleid;
-				$result = mysql_query($query);
-				if($row = mysql_fetch_assoc($result)) {
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				if($row = mysqli_fetch_assoc($result)) {
 					$text = $row['article_content'];
 					global $PAGELASTUPDATED;
 					$PAGELASTUPDATED = $row['article_lastupdated'];
@@ -62,16 +62,16 @@ class scrolltext implements module{
 public function actionEdit(){
 
 			$query = "SELECT article_modulecomponentid FROM scrolltext WHERE page_modulecomponentid=". $this->moduleComponentId;
-			$result = mysql_query($query);
-			$row = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$row = mysqli_fetch_assoc($result);
 			$articleId=$row['article_modulecomponentid'];
 			return $this->scrollarticle->getHtml($this->userId,$articleId,"edit");
 }
 public function actionView(){
 
 			$query = "SELECT article_modulecomponentid FROM scrolltext WHERE page_modulecomponentid=". $this->moduleComponentId;
-			$result = mysql_query($query);
-			$row = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$row = mysqli_fetch_assoc($result);
 			$articleId=$row['article_modulecomponentid'];
 			return $this->scrollarticle->getHtml($this->userId,$articleId,"view");
 }
@@ -82,19 +82,19 @@ public function createModule($scrollId) {
 		$articleId = createInstance('article');
 		$article->createModule($articleId);
 		$query=  "INSERT INTO `scrolltext` (`page_modulecomponentid` ,`article_modulecomponentid`)VALUES ('$scrollId','$articleId')";
-		$result = mysql_query($query) or die(mysql_error());
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		return true;
 	}
 
 public function deleteModule($moduleComponentId) {
 		$query = "SELECT article_modulecomponentid FROM scrolltext WHERE page_modulecomponentid=". $moduleComponentId;
-		$result = mysql_query($query);
-		$row = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$row = mysqli_fetch_assoc($result);
 		$articleId=$row['article_modulecomponentid'];
 
 		$query = "DELETE FROM `article_content` WHERE `page_modulecomponentid`=$articleId";
-		$result = mysql_query($query);
-		if ((mysql_affected_rows()) >= 1)
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if ((mysqli_affected_rows($GLOBALS["___mysqli_ston"])) >= 1)
 			return true;
 		else
 			return false;
@@ -106,24 +106,24 @@ public function deleteModule($moduleComponentId) {
 		$articleId = createInstance('article');
 		$article->createModule($articleId);
 		$query=  "INSERT INTO `scrolltext` (`page_modulecomponentid` ,`article_modulecomponentid`)VALUES ('$newId','$articleId')";
-		$result = mysql_query($query) or die(mysql_error());
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		
 		$query = "SELECT article_modulecomponentid FROM scrolltext WHERE page_modulecomponentid='{$moduleComponentId}'";
-		$result = mysql_query($query);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		if(!$result)
 			return false;
-		$row = mysql_fetch_assoc($result);
+		$row = mysqli_fetch_assoc($result);
 		$fromId=$row['article_modulecomponentid'];
 
 		$query = "SELECT * FROM `article_content` WHERE `page_modulecomponentid`='$fromId'";
-		$result = mysql_query($query);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		if(!$result)
 			return false;
 		
-		$content = mysql_fetch_assoc($result);
+		$content = mysqli_fetch_assoc($result);
 		
-		$query = "INSERT INTO `article_content` (`page_modulecomponentid` ,`article_content`)VALUES ('$articleId', '".mysql_escape_string($content['article_content'])."')";
-		mysql_query($query) or displayerror(mysql_error()."scrolltext.lib L:104");
+		$query = "INSERT INTO `article_content` (`page_modulecomponentid` ,`article_content`)VALUES ('$articleId', '".((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $content['article_content']) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""))."')";
+		mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."scrolltext.lib L:104");
 		return true;
 	}
 	public function moduleAdmin(){

--- a/cms/modules/search/admin/admin.php
+++ b/cms/modules/search/admin/admin.php
@@ -127,11 +127,11 @@ $database_funcs = Array ("database" => "default");
 			$space .= "&nbsp;&nbsp;&nbsp;&nbsp;";
 
 		$query = "SELECT * FROM ".$mysql_table_prefix."categories WHERE parent_num=$parent ORDER BY category";
-		$result = mysql_query($query);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		
-		if (mysql_num_rows($result) <> '')
-			while ($row = mysql_fetch_array($result)) {
+		if (mysqli_num_rows($result) <> '')
+			while ($row = mysqli_fetch_array($result)) {
 				if ($color =="white") 
 					$color = "grey";
 				else 
@@ -156,18 +156,18 @@ $database_funcs = Array ("database" => "default");
 			$space .= "&nbsp;&nbsp;&nbsp;&nbsp;";
 
 		$query = "SELECT * FROM ".$mysql_table_prefix."categories WHERE parent_num=$parent ORDER BY category";
-		$result = mysql_query($query);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		
-		if (mysql_num_rows($result) <> '')
-			while ($row = mysql_fetch_array($result)) {
+		if (mysqli_num_rows($result) <> '')
+			while ($row = mysqli_fetch_array($result)) {
 				$id = $row['category_id'];
 				$cat = $row['category'];
 				$state = '';
 				if ($site_id <> '') {
-					$result2 = mysql_query("select * from ".$mysql_table_prefix."site_category where site_id=$site_id and category_id=$id");
-					echo mysql_error();
-					$rows = mysql_num_rows($result2);
+					$result2 = mysqli_query($GLOBALS["___mysqli_ston"], "select * from ".$mysql_table_prefix."site_category where site_id=$site_id and category_id=$id");
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+					$rows = mysqli_num_rows($result2);
 
 					if ($rows > 0)
 						$state = "checked";
@@ -196,15 +196,15 @@ function addcatform($parent) {
 		$par='(Top level)';
 	else {
 		$query = "SELECT category, parent_num FROM ".$mysql_table_prefix."categories WHERE category_id='$parent'";
-		$result = mysql_query($query);
-		if (!mysql_error())	{
-			if ($row = mysql_fetch_row($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if (!((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)))	{
+			if ($row = mysqli_fetch_row($result)) {
 				$par=$row[0];
 				$query = "SELECT Category_ID, Category FROM ".$mysql_table_prefix."categories WHERE Category_ID='$row[1]'";
-				$result = mysql_query($query);
-				echo mysql_error();
-				if (mysql_num_rows($result)<>'') {
-					$row = mysql_fetch_row($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				if (mysqli_num_rows($result)<>'') {
+					$row = mysqli_fetch_row($result);
 					$par2num = $row[0];
 					$par2 = $row[1];
 				}
@@ -214,7 +214,7 @@ function addcatform($parent) {
 				}
 			}
 		else
-			echo mysql_error();
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		print "</td></tr></table>";
 	}
 
@@ -229,12 +229,12 @@ function addcatform($parent) {
 <?php 
 	print "<tr><td colspan=2>";
 	$query = "SELECT category_ID, Category FROM ".$mysql_table_prefix."categories WHERE parent_num='$parent'";
-	$result = mysql_query($query);
-	echo mysql_error();
-	if (mysql_num_rows($result)>0) {
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+	if (mysqli_num_rows($result)>0) {
 		print "<br/><b>Create subcategory under</b><br/><br/>";
 	}
-	while ($row = mysql_fetch_row($result)) {
+	while ($row = mysqli_fetch_row($result)) {
 		print "<a href=\"admin.php?f=add_cat&parent=$row[0]\">".stripslashes($row[1])."</a><br/>";
 	}
 	print "</td></tr></table></center>";
@@ -250,11 +250,11 @@ function addcatform($parent) {
 		}
 		$query = "INSERT INTO ".$mysql_table_prefix."categories (category, parent_num)
 				 VALUES ('$category', ".$parent.")";
-		mysql_query($query);
-		If (!mysql_error()) {
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		If (!((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))) {
 			return "<center><b>Category $category added.</b></center>" ;
 		} else {
-			return mysql_error();
+			return ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 	}
 
@@ -279,9 +279,9 @@ function addcatform($parent) {
 
 	function editsiteform($site_id) {
 		global $mysql_table_prefix;
-		$result = mysql_query("SELECT site_id, url, title, short_desc, spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites where site_id=$site_id");
-		echo mysql_error();
-		$row = mysql_fetch_array($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT site_id, url, title, short_desc, spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row = mysqli_fetch_array($result);
 		$depth = $row['spider_depth'];
 		$fullchecked = "";
 		$depthchecked = "";		
@@ -325,35 +325,35 @@ function addcatform($parent) {
 			global $mysql_table_prefix;
 			$short_desc = addslashes($short_desc);
 			$title = addslashes($title);
-			mysql_query("delete from ".$mysql_table_prefix."site_category where site_id=$site_id");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."site_category where site_id=$site_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			$compurl=parse_url($url);
 			if ($compurl['path']=='')
 				$url=$url."/";
-			mysql_query("UPDATE ".$mysql_table_prefix."sites SET url='$url', title='$title', short_desc='$short_desc', spider_depth =$depth, required='$required', disallowed='$disallowed', can_leave_domain=$domaincb WHERE site_id=$site_id");
-			echo mysql_error();
-			$result=mysql_query("select category_id from ".$mysql_table_prefix."categories");
-			echo mysql_error();
-			print mysql_error();
-			while ($row=mysql_fetch_row($result)) {
+			mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE ".$mysql_table_prefix."sites SET url='$url', title='$title', short_desc='$short_desc', spider_depth =$depth, required='$required', disallowed='$disallowed', can_leave_domain=$domaincb WHERE site_id=$site_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], "select category_id from ".$mysql_table_prefix."categories");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			while ($row=mysqli_fetch_row($result)) {
 				$cat_id=$row[0];
 				if ($cat[$cat_id]=='on') {
-					mysql_query("INSERT INTO ".$mysql_table_prefix."site_category (site_id, category_id) values ('$site_id', '$cat_id')");
-					echo mysql_error();
+					mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO ".$mysql_table_prefix."site_category (site_id, category_id) values ('$site_id', '$cat_id')");
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 				}
 			}
-			If (!mysql_error()) {
+			If (!((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))) {
 				return "<br/><center><b>Site updated.</b></center>" ;
 			} else {
-				return mysql_error();
+				return ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			}
 		}
 
 	function editcatform($cat_id) {
 		global $mysql_table_prefix;
-		$result = mysql_query("SELECT category FROM ".$mysql_table_prefix."categories where category_id='$cat_id'");
-		echo mysql_error();
-		$row=mysql_fetch_array($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT category FROM ".$mysql_table_prefix."categories where category_id='$cat_id'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row=mysqli_fetch_array($result);
 		$category=$row[0];
 		?>
 				<div id="submenu">
@@ -373,11 +373,11 @@ function addcatform($parent) {
 	function editcat ($cat_id, $category) {
 		global $mysql_table_prefix;
 		$qry = "UPDATE ".$mysql_table_prefix."categories SET category='".addslashes($category)."' WHERE category_id='$cat_id'";
-		mysql_query($qry);
-		if (!mysql_error())	{
+		mysqli_query($GLOBALS["___mysqli_ston"], $qry);
+		if (!((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)))	{
 			return "<br/><center><b>Category updated</b></center>";
 		} else {
-			return mysql_error();
+			return ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 	}
 
@@ -385,14 +385,14 @@ function addcatform($parent) {
 
 	function showsites($message) {
 		global $mysql_table_prefix;
-		$result = mysql_query("SELECT site_id, url, title, indexdate from ".$mysql_table_prefix."sites ORDER By indexdate, title");
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT site_id, url, title, indexdate from ".$mysql_table_prefix."sites ORDER By indexdate, title");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		?>
 		<div id='submenu'>
 		 <ul>
 		  <li><a href='admin.php?f=add_site'>Add site</a> </li>
 		  <?php 
-			if (mysql_num_rows($result) > 0) {
+			if (mysqli_num_rows($result) > 0) {
 				?>
 				<li><a href='spider.php?all=1'> Reindex all</a></li>
 				<?php 
@@ -404,22 +404,22 @@ function addcatform($parent) {
 		<?php 
 		print $message;
 		print "<br/>";
-		if (mysql_num_rows($result) > 0) {
+		if (mysqli_num_rows($result) > 0) {
 			print "<div align=\"center\"><table cellspacing =\"0\" cellpadding=\"0\" class=\"darkgrey\"><tr><td><table cellpadding=\"3\" cellspacing=\"1\">
 			<tr class=\"grey\"><td align=\"center\"><b>Site name</b></td><td align=\"center\"><b>Site url</b></td><td align=\"center\"><b>Last indexed</b></td><td colspan=4></td></tr>\n";
 		} else {
 			?><center><p><b>Welcom to Sphider. <br><br>Choose "Add site" from the submenu to add a new site, or "Index" to directly go to the indexing section.</b></p></center><?php 
 		}
 		$class = "grey";
-		while ($row=mysql_fetch_array($result))	{
+		while ($row=mysqli_fetch_array($result))	{
 			if ($row['indexdate']=='') {
 				$indexstatus="<font color=\"red\">Not indexed</font>";
 				$indexoption="<a href=\"admin.php?f=index&url=$row[url]\">Index</a>";
 			} else {
 				$site_id = $row['site_id'];
-				$result2 = mysql_query("SELECT site_id from ".$mysql_table_prefix."pending where site_id =$site_id");
-				echo mysql_error();			
-				$row2=mysql_fetch_array($result2);
+				$result2 = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT site_id from ".$mysql_table_prefix."pending where site_id =$site_id");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));			
+				$row2=mysqli_fetch_array($result2);
 				if ($row2['site_id'] == $row['site_id']) {
 					$indexstatus = "Unfinished";
 					$indexoption="<a href=\"admin.php?f=index&url=$row[url]\">Continue</a>";
@@ -437,7 +437,7 @@ function addcatform($parent) {
 			print "<td><a href=admin.php?f=20&site_id=$row[site_id] id=\"small_button\">Options</a></td></tr>\n";
 
 		}
-		if (mysql_num_rows($result) > 0) {
+		if (mysqli_num_rows($result) > 0) {
 			print "</table></td></tr></table></div>";
 		}
 	}
@@ -445,23 +445,23 @@ function addcatform($parent) {
 	function deletecat($cat_id) {
 		global $mysql_table_prefix;
 		$list = implode(",", get_cats($cat_id));
-		mysql_query("delete from ".$mysql_table_prefix."categories where category_id in ($list)");
-		echo mysql_error();
-		mysql_query("delete from ".$mysql_table_prefix."site_category where category_id=$cat_id");
-		echo mysql_error();
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."categories where category_id in ($list)");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."site_category where category_id=$cat_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		return "<center><b>Category deleted.</b></center>";
 	}
 	function deletesite($site_id) {
 		global $mysql_table_prefix;
-		mysql_query("delete from ".$mysql_table_prefix."sites where site_id=$site_id");
-		echo mysql_error();
-		mysql_query("delete from ".$mysql_table_prefix."site_category where site_id=$site_id");
-		echo mysql_error();
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."sites where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."site_category where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$query = "select link_id from ".$mysql_table_prefix."links where site_id=$site_id";
-		$result = mysql_query($query);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$todelete = array();
-		while ($row=mysql_fetch_array($result)) {
+		while ($row=mysqli_fetch_array($result)) {
 			$todelete[]=$row['link_id'];
 		}
 
@@ -470,36 +470,36 @@ function addcatform($parent) {
 			for ($i=0;$i<=15; $i++) {
 				$char = dechex($i);
 				$query = "delete from ".$mysql_table_prefix."link_keyword$char where link_id in($todelete)";
-				mysql_query($query);
-				echo mysql_error();
+				mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			}
 		}
 
-		mysql_query("delete from ".$mysql_table_prefix."links where site_id=$site_id");
-		echo mysql_error();
-		mysql_query("delete from ".$mysql_table_prefix."pending where site_id=$site_id");
-		echo mysql_error();
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."links where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."pending where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		return "<br/><center><b>Site deleted</b></center>";
 	}
 
 	function deletePage($link_id) {
 		global $mysql_table_prefix;
-		mysql_query("delete from ".$mysql_table_prefix."links where link_id=$link_id");
-		echo mysql_error();
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."links where link_id=$link_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		for ($i=0;$i<=15; $i++) {
 			$char = dechex($i);
-			mysql_query("delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
+			mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
 		}
-		echo mysql_error();
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		return "<br/><center><b>Page deleted</b></center>";
 	}
 
 	
 	function cleanTemp() {
 		global $mysql_table_prefix;
-		$result = mysql_query("delete from ".$mysql_table_prefix."temp where level >= 0");
-		echo mysql_error();
-		$del = mysql_affected_rows();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."temp where level >= 0");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$del = mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
 				?>
 		<div id="submenu">
 		</div><?php 
@@ -508,9 +508,9 @@ function addcatform($parent) {
 
 	function clearLog() {
 		global $mysql_table_prefix;
-		$result = mysql_query("delete from ".$mysql_table_prefix."query_log where time >= 0");
-		echo mysql_error();
-		$del = mysql_affected_rows();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."query_log where time >= 0");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$del = mysqli_affected_rows($GLOBALS["___mysqli_ston"]);
 		?>
 		<div id="submenu">
 		</div><?php 
@@ -521,43 +521,43 @@ function addcatform($parent) {
 	function cleanLinks() {
 		global $mysql_table_prefix;
 		$query = "select site_id from ".$mysql_table_prefix."sites";
-		$result = mysql_query($query);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$todelete = array();
-		if (mysql_num_rows($result)>0) {
-			while ($row=mysql_fetch_array($result)) {
+		if (mysqli_num_rows($result)>0) {
+			while ($row=mysqli_fetch_array($result)) {
 				$todelete[]=$row['site_id'];
 			}
 			$todelete = implode(",", $todelete);
 			$sql_end = " not in ($todelete)";
 		}
 		
-		$result = mysql_query("select link_id from ".$mysql_table_prefix."links where site_id".$sql_end);
-		echo mysql_error();
-		$del = mysql_num_rows($result);
-		while ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link_id from ".$mysql_table_prefix."links where site_id".$sql_end);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$del = mysqli_num_rows($result);
+		while ($row=mysqli_fetch_array($result)) {
 			$link_id=$row[link_id];
 			for ($i=0;$i<=15; $i++) {
 				$char = dechex($i);
-				mysql_query("delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
-				echo mysql_error();
+				mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			}
-			mysql_query("delete from ".$mysql_table_prefix."links where link_id=$link_id");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."links where link_id=$link_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 
-		$result = mysql_query("select link_id from ".$mysql_table_prefix."links where site_id is NULL");
-		echo mysql_error();
-		$del += mysql_num_rows($result);
-		while ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link_id from ".$mysql_table_prefix."links where site_id is NULL");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$del += mysqli_num_rows($result);
+		while ($row=mysqli_fetch_array($result)) {
 			$link_id=$row[link_id];
 			for ($i=0;$i<=15; $i++) {
 				$char = dechex($i);
-				mysql_query("delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
-				echo mysql_error();
+				mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			}
-			mysql_query("delete from ".$mysql_table_prefix."links where link_id=$link_id");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."links where link_id=$link_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 		?>
 		<div id="submenu">
@@ -568,19 +568,19 @@ function addcatform($parent) {
 	function cleanKeywords() {
 		global $mysql_table_prefix;
 		$query = "select keyword_id, keyword from ".$mysql_table_prefix."keywords";
-		$result = mysql_query($query);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$del = 0;
-		while ($row=mysql_fetch_array($result)) {
+		while ($row=mysqli_fetch_array($result)) {
 			$keyId=$row['keyword_id'];
 			$keyword=$row['keyword'];
 			$wordmd5 = substr(md5($keyword), 0, 1);
 			$query = "select keyword_id from ".$mysql_table_prefix."link_keyword$wordmd5 where keyword_id = $keyId";
-			$result2 = mysql_query($query);
-			echo mysql_error();
-			if (mysql_num_rows($result2) < 1) {
-				mysql_query("delete from ".$mysql_table_prefix."keywords where keyword_id=$keyId");
-				echo mysql_error();
+			$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if (mysqli_num_rows($result2) < 1) {
+				mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."keywords where keyword_id=$keyId");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 				$del++;
 			}
 		}?>
@@ -597,32 +597,32 @@ function addcatform($parent) {
 		$siteQuery = "select count(site_id) from ".$mysql_table_prefix."sites";
 		$categoriesQuery = "select count(category_id) from ".$mysql_table_prefix."categories";
 
-		$result = mysql_query($keywordQuery);
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $keywordQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$stats['keywords']=$row[0];
 		}
-		$result = mysql_query($linksQuery);
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $linksQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$stats['links']=$row[0];
 		}
 		for ($i=0;$i<=15; $i++) {
 			$char = dechex($i);
-			$result = mysql_query("select count(link_id) from ".$mysql_table_prefix."link_keyword$char");
-			echo mysql_error();
-			if ($row=mysql_fetch_array($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select count(link_id) from ".$mysql_table_prefix."link_keyword$char");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if ($row=mysqli_fetch_array($result)) {
 				$stats['index']+=$row[0];
 			}
 		}
-		$result = mysql_query($siteQuery);
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $siteQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$stats['sites']=$row[0];
 		}
-		$result = mysql_query($categoriesQuery);
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $categoriesQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$stats['categories']=$row[0];
 		}
 		return $stats;
@@ -637,30 +637,30 @@ function addcatform($parent) {
 		$compurl=parse_url("".$url);
 		if ($compurl['path']=='')
 			$url=$url."/";
-		$result = mysql_query("select site_ID from ".$mysql_table_prefix."sites where url='$url'");
-		echo mysql_error();
-		$rows = mysql_numrows($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select site_ID from ".$mysql_table_prefix."sites where url='$url'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$rows = mysqli_num_rows($result);
 		if ($rows==0 ) {
-			mysql_query("INSERT INTO ".$mysql_table_prefix."sites (url, title, short_desc) VALUES ('$url', '$title', '$short_desc')");
-			echo mysql_error();
-			$result = mysql_query("select site_ID from ".$mysql_table_prefix."sites where url='$url'");
-			echo mysql_error();
-			$row = mysql_fetch_row($result);
+			mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO ".$mysql_table_prefix."sites (url, title, short_desc) VALUES ('$url', '$title', '$short_desc')");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select site_ID from ".$mysql_table_prefix."sites where url='$url'");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$row = mysqli_fetch_row($result);
 			$site_id = $row[0];
-			$result=mysql_query("select category_id from ".$mysql_table_prefix."categories");
-			echo mysql_error();
-			while ($row=mysql_fetch_row($result)) {
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], "select category_id from ".$mysql_table_prefix."categories");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			while ($row=mysqli_fetch_row($result)) {
 				$cat_id=$row[0];
 				if ($cat[$cat_id]=='on') {
-					mysql_query("INSERT INTO ".$mysql_table_prefix."site_category (site_id, category_id) values ('$site_id', '$cat_id')");
-					echo mysql_error();
+					mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO ".$mysql_table_prefix."site_category (site_id, category_id) values ('$site_id', '$cat_id')");
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 				}
 	 		}
 		
-			If (!mysql_error())	{
+			If (!((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)))	{
 				$message =  "<br/><center><b>Site added</b></center>" ;
 			} else {
-				$message = mysql_error();
+				$message = ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			}
 
 		} else {
@@ -680,11 +680,11 @@ function addcatform($parent) {
 			$advurl = "";
 		} else {
 			$advurl = $url;
-			$result = mysql_query("select spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites " .
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites " .
 					"where url='$url'");
-			echo mysql_error();
-			if (mysql_num_rows($result) > 0) {
-				$row = mysql_fetch_row($result);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if (mysqli_num_rows($result) > 0) {
+				$row = mysqli_fetch_row($result);
 				$spider_depth = $row[0];
 				if ($spider_depth == -1 ) {
 					$fullchecked = "checked";
@@ -743,18 +743,18 @@ function addcatform($parent) {
 
 	function siteScreen($site_id, $message)  {
 		global $mysql_table_prefix;
-		$result = mysql_query("SELECT site_id, url, title, short_desc, indexdate from ".$mysql_table_prefix."sites where site_id=$site_id");
-		echo mysql_error();
-		$row=mysql_fetch_array($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT site_id, url, title, short_desc, indexdate from ".$mysql_table_prefix."sites where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row=mysqli_fetch_array($result);
 		$url = replace_ampersand($row[url]);
 		if ($row['indexdate']=='') {
 			$indexstatus="<font color=\"red\">Not indexed</font>";
 			$indexoption="<a href=\"admin.php?f=index&url=$url\">Index</a>";
 		} else {
 			$site_id = $row['site_id'];
-			$result2 = mysql_query("SELECT site_id from ".$mysql_table_prefix."pending where site_id =$site_id");
-			echo mysql_error();			
-			$row2=mysql_fetch_array($result2);
+			$result2 = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT site_id from ".$mysql_table_prefix."pending where site_id =$site_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));			
+			$row2=mysqli_fetch_array($result2);
 			if ($row2['site_id'] == $row['site_id']) {
 				$indexstatus = "Unfinished";
 				$indexoption="<a href=\"admin.php?f=index&url=$url\">Continue indexing</a>";
@@ -817,9 +817,9 @@ function addcatform($parent) {
 
 	function siteStats($site_id) {
 		global $mysql_table_prefix;
-		$result = mysql_query("select url from ".$mysql_table_prefix."sites where site_id=$site_id");
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select url from ".$mysql_table_prefix."sites where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$url=$row[0];
 
 			$lastIndexQuery = "SELECT indexdate from ".$mysql_table_prefix."sites where site_id = $site_id";
@@ -827,44 +827,44 @@ function addcatform($parent) {
 			$siteSizeQuery = "select sum(size) from ".$mysql_table_prefix."links where site_id = $site_id";
 			$linksQuery = "select count(*) from ".$mysql_table_prefix."links where site_id = $site_id";
 
-			$result = mysql_query($lastIndexQuery);
-			echo mysql_error();
-			if ($row=mysql_fetch_array($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $lastIndexQuery);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if ($row=mysqli_fetch_array($result)) {
 				$stats['lastIndex']=$row[0];
 			}
 
-			$result = mysql_query($sumSizeQuery);
-			echo mysql_error();
-			if ($row=mysql_fetch_array($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $sumSizeQuery);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if ($row=mysqli_fetch_array($result)) {
 				$stats['sumSize']=$row[0];
 			}
-			$result = mysql_query($linksQuery);
-			echo mysql_error();
-			if ($row=mysql_fetch_array($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $linksQuery);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if ($row=mysqli_fetch_array($result)) {
 				$stats['links']=$row[0];
 			}
 
 			for ($i=0;$i<=15; $i++) {
 				$char = dechex($i);
-				$result = mysql_query("select count(*) from ".$mysql_table_prefix."links, ".$mysql_table_prefix."link_keyword$char where ".$mysql_table_prefix."links.link_id=".$mysql_table_prefix."link_keyword$char.link_id and ".$mysql_table_prefix."links.site_id = $site_id");
-				echo mysql_error();
-				if ($row=mysql_fetch_array($result)) {
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], "select count(*) from ".$mysql_table_prefix."links, ".$mysql_table_prefix."link_keyword$char where ".$mysql_table_prefix."links.link_id=".$mysql_table_prefix."link_keyword$char.link_id and ".$mysql_table_prefix."links.site_id = $site_id");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				if ($row=mysqli_fetch_array($result)) {
 					$stats['index']+=$row[0];
 				}
 			}
 			for ($i=0;$i<=15; $i++) {
 				$char = dechex($i);
 				$wordQuery = "select count(distinct keyword) from ".$mysql_table_prefix."keywords, ".$mysql_table_prefix."links, ".$mysql_table_prefix."link_keyword$char where ".$mysql_table_prefix."links.link_id=".$mysql_table_prefix."link_keyword$char.link_id and ".$mysql_table_prefix."links.site_id = $site_id and ".$mysql_table_prefix."keywords.keyword_id = ".$mysql_table_prefix."link_keyword$char.keyword_id";
-				$result = mysql_query($wordQuery);
-				echo mysql_error();
-				if ($row=mysql_fetch_array($result)) {
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $wordQuery);
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				if ($row=mysqli_fetch_array($result)) {
 					$stats['words']+=$row[0];
 				}
 			}
 			
-			$result = mysql_query($siteSizeQuery);
-			echo mysql_error();
-			if ($row=mysql_fetch_array($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $siteSizeQuery);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if ($row=mysqli_fetch_array($result)) {
 				$stats['siteSize']=$row[0];
 			}
 			if ($stats['siteSize']=="")
@@ -886,9 +886,9 @@ function addcatform($parent) {
 
 	function browsePages($site_id, $start, $filter, $per_page) {
 		global $mysql_table_prefix;
-		$result = mysql_query("select url from ".$mysql_table_prefix."sites where site_id=$site_id");
-		echo mysql_error();
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select url from ".$mysql_table_prefix."sites where site_id=$site_id");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row = mysqli_fetch_row($result);
 		$url = $row[0];
 		
 		$query_add = "";
@@ -896,20 +896,20 @@ function addcatform($parent) {
 			$query_add = "and url like '%$filter%'";
 		}
 		$linksQuery = "select count(*) from ".$mysql_table_prefix."links where site_id = $site_id $query_add";
-		$result = mysql_query($linksQuery);
-		echo mysql_error();
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $linksQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row = mysqli_fetch_row($result);
 		$numOfPages = $row[0]; 
 
-		$result = mysql_query($linksQuery);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $linksQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$from = ($start-1) * 10;
 		$to = min(($start)*10, $numOfPages);
 
 		
 		$linksQuery = "select link_id, url from ".$mysql_table_prefix."links where site_id = $site_id and url like '%$filter%' order by url limit $from, $per_page";
-		$result = mysql_query($linksQuery);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $linksQuery);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		?>
 		<div id="submenu"></div>
 		<br/>
@@ -931,7 +931,7 @@ function addcatform($parent) {
 
 		<?php 
 		$class = "white";
-		while ($row = mysql_fetch_array($result)) {
+		while ($row = mysqli_fetch_array($result)) {
 			if ($class =="white") 
 				$class = "grey";
 			else 
@@ -966,14 +966,14 @@ function addcatform($parent) {
 
 	function cleanForm () {
 		global $mysql_table_prefix;
-		$result = mysql_query("select count(*) from ".$mysql_table_prefix."query_log");
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select count(*) from ".$mysql_table_prefix."query_log");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$log=$row[0];
 		}
-		$result = mysql_query("select count(*) from ".$mysql_table_prefix."temp");
-		echo mysql_error();
-		if ($row=mysql_fetch_array($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select count(*) from ".$mysql_table_prefix."temp");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		if ($row=mysqli_fetch_array($result)) {
 			$temp=$row[0];
 		}
 
@@ -1010,17 +1010,17 @@ function addcatform($parent) {
 		<?php 
 			if ($type == "") {
 				$cachedSumQuery = "select sum(length(fulltxt)) from ".$mysql_table_prefix."links";
-				$result=mysql_query("select sum(length(fulltxt)) from ".$mysql_table_prefix."links");
-				echo mysql_error();
-				if ($row=mysql_fetch_array($result)) {
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], "select sum(length(fulltxt)) from ".$mysql_table_prefix."links");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				if ($row=mysqli_fetch_array($result)) {
 					$cachedSumSize = $row[0];
 				}
 				$cachedSumSize = number_format($cachedSumSize / 1024, 2);
 
 				$sitesSizeQuery = "select sum(size) from ".$mysql_table_prefix."links";
-				$result=mysql_query("$sitesSizeQuery");
-				echo mysql_error();
-				if ($row=mysql_fetch_array($result)) {
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], "$sitesSizeQuery");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				if ($row=mysqli_fetch_array($result)) {
 					$sitesSize = $row[0];
 				}
 				$sitesSize = number_format($sitesSize, 2);
@@ -1041,9 +1041,9 @@ function addcatform($parent) {
 				print "<br/><div align=\"center\"><table cellspacing =\"0\" cellpadding=\"0\" class=\"darkgrey\"><tr><td><table cellpadding=\"3\" cellspacing = \"1\"><tr  class=\"grey\"><td><b>Keyword</b></td><td><b>Occurrences</b></td></tr>";
 				for ($i=0;$i<=15; $i++) {
 					$char = dechex($i);
-					$result=mysql_query("select keyword, count(".$mysql_table_prefix."link_keyword$char.keyword_id) as x from ".$mysql_table_prefix."keywords, ".$mysql_table_prefix."link_keyword$char where ".$mysql_table_prefix."keywords.keyword_id = ".$mysql_table_prefix."link_keyword$char.keyword_id group by keyword order by x desc limit 30");
-					echo mysql_error();
-					while (($row=mysql_fetch_row($result))) {
+					$result=mysqli_query($GLOBALS["___mysqli_ston"], "select keyword, count(".$mysql_table_prefix."link_keyword$char.keyword_id) as x from ".$mysql_table_prefix."keywords, ".$mysql_table_prefix."link_keyword$char where ".$mysql_table_prefix."keywords.keyword_id = ".$mysql_table_prefix."link_keyword$char.keyword_id group by keyword order by x desc limit 30");
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+					while (($row=mysqli_fetch_row($result))) {
 						$topwords[$row[0]] = $row[1];
 					}
 				}
@@ -1071,9 +1071,9 @@ function addcatform($parent) {
 				   <b>Page</b></td>
 				   <td><b>Text size</b></td></tr>
 				<?php 
-				$result=mysql_query("select ".$mysql_table_prefix."links.link_id, url, length(fulltxt)  as x from ".$mysql_table_prefix."links order by x desc limit 20");
-				echo mysql_error();
-				while ($row=mysql_fetch_row($result)) {
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], "select ".$mysql_table_prefix."links.link_id, url, length(fulltxt)  as x from ".$mysql_table_prefix."links order by x desc limit 20");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				while ($row=mysqli_fetch_row($result)) {
 					if ($class =="white") 
 						$class = "grey";
 					else 
@@ -1088,9 +1088,9 @@ function addcatform($parent) {
 			if ($type=='top_searches') {
 				$class = "grey";
 				print "<br/><div align=\"center\"><table cellspacing =\"0\" cellpadding=\"0\" class=\"darkgrey\"><tr><td><table cellpadding=\"3\" cellspacing = \"1\"><tr  class=\"grey\"><td><b>Query</b></td><td><b>Count</b></td><td><b> Average results</b></td><td><b>Last queried</b></td></tr>";
-				$result=mysql_query("select query, count(*) as c, date_format(max(time), '%Y-%m-%d %H:%i:%s'), avg(results)  from ".$mysql_table_prefix."query_log group by query order by c desc");
-				echo mysql_error();
-				while ($row=mysql_fetch_row($result)) {
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], "select query, count(*) as c, date_format(max(time), '%Y-%m-%d %H:%i:%s'), avg(results)  from ".$mysql_table_prefix."query_log group by query order by c desc");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				while ($row=mysqli_fetch_row($result)) {
 					if ($class =="white") 
 						$class = "grey";
 					else 
@@ -1107,9 +1107,9 @@ function addcatform($parent) {
 			if ($type=='log') {
 				$class = "grey";
 				print "<br/><div align=\"center\"><table cellspacing =\"0\" cellpadding=\"0\" class=\"darkgrey\"><tr><td><table cellpadding=\"3\" cellspacing = \"1\"><tr  class=\"grey\"><td align=\"center\"><b>Query</b></td><td align=\"center\"><b>Results</b></td><td align=\"center\"><b>Queried at</b></td><td align=\"center\"><b>Time taken</b></td></tr>";
-				$result=mysql_query("select query,  date_format(time, '%Y-%m-%d %H:%i:%s'), elapsed, results from ".$mysql_table_prefix."query_log order by time desc");
-				echo mysql_error();
-				while ($row=mysql_fetch_row($result)) {
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], "select query,  date_format(time, '%Y-%m-%d %H:%i:%s'), elapsed, results from ".$mysql_table_prefix."query_log order by time desc");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				while ($row=mysqli_fetch_row($result)) {
 					if ($class =="white") 
 						$class = "grey";
 					else 
@@ -1162,9 +1162,9 @@ function addcatform($parent) {
 			if ($compurl['path']=='')
 				$url=$url."/";
 		 
-			$result = mysql_query("select site_id from ".$mysql_table_prefix."sites where url='$url'");
-			echo mysql_error();
-			$row = mysql_fetch_row($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select site_id from ".$mysql_table_prefix."sites where url='$url'");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$row = mysqli_fetch_row($result);
 			if ($site_id != "")
 				siteScreen($site_id, $message);
 			else

--- a/cms/modules/search/admin/db_main.php
+++ b/cms/modules/search/admin/db_main.php
@@ -70,15 +70,15 @@ function checkAll(theForm, cName, allNo_stat) {
  <?php
 
 
-		$stats  = mysql_query ("SHOW TABLE STATUS FROM $dbname LIKE '$dbprefix%'");
-		$num_tables = mysql_num_rows($stats);
+		$stats  = mysqli_query($GLOBALS["___mysqli_ston"], "SHOW TABLE STATUS FROM $dbname LIKE '$dbprefix%'");
+		$num_tables = mysqli_num_rows($stats);
 		if ($num_tables==0) {
 			echo("ERROR: Database contains no tables");
 		}	
 
 		$bgcolor='grey';
 		$i=0;
-		while ($rows=mysql_fetch_array($stats) ) {
+		while ($rows=mysqli_fetch_array($stats) ) {
 			print "<tr><td class=".$bgcolor."><input type='checkbox' id='tables$i' class='check' name='tables[$i]' value='".$rows["Name"]."' ></td>";
 			print "<td class=".$bgcolor.">".$rows["Name"]."</td>";
 			print '<td align="center" class='.$bgcolor.'>'.$rows['Rows'].'</td>';
@@ -153,7 +153,7 @@ if (isset($file) && $del==0) {
 	$file_temp=fread(fopen($backup_path.$file, "r"), filesize($backup_path.$file));
 	$query=explode(";#%%\n",$file_temp);
 	for ($i=0;$i < count($query)-1;$i++) {
-		mysql_db_query($dbname,$query[$i]) or die(mysql_error());
+		((mysqli_query($GLOBALS["___mysqli_ston"], "USE $dbname")) ? mysqli_query($GLOBALS["___mysqli_ston"], $query[$i]) : false) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	}
 	unlink($backup_path.$file);
 	echo "<table width=\"94%\"><tr><td><b>Your restore 

--- a/cms/modules/search/admin/install.php
+++ b/cms/modules/search/admin/install.php
@@ -13,7 +13,7 @@ $settings_dir = "../settings";
 include "$settings_dir/database.php";
 
 $error = 0;
-mysql_query("create table `".$mysql_table_prefix."sites`(
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."sites`(
 	site_id int auto_increment not null primary key,
 	url varchar(255),
 	title varchar(255),
@@ -23,13 +23,13 @@ mysql_query("create table `".$mysql_table_prefix."sites`(
 	required text,
 	disallowed text,
 	can_leave_domain bool)");
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
-mysql_query("create table `".$mysql_table_prefix."links` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."links` (
 	link_id int auto_increment primary key not null,
 	site_id int,
 	url varchar(255) not null,
@@ -44,28 +44,28 @@ mysql_query("create table `".$mysql_table_prefix."links` (
 	visible int default 0, 
 	level int)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
-mysql_query("create table `".$mysql_table_prefix."keywords`	(
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."keywords`	(
 	keyword_id int primary key not null auto_increment,
 	keyword varchar(30) not null,
 	unique kw (keyword),
 	key keyword (keyword(10)))");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
 for ($i=0;$i<=15; $i++) {
 	$char = dechex($i);
-	mysql_query("create table `".$mysql_table_prefix."link_keyword$char` (
+	mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."link_keyword$char` (
 		link_id int not null,
 		keyword_id int not null,
 		weight int(3),
@@ -73,53 +73,53 @@ for ($i=0;$i<=15; $i++) {
 		key linkid(link_id),
 		key keyid(keyword_id))");
 
-	if (mysql_errno() > 0) {
+	if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 		print "Error: ";
-		print mysql_error();
+		print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		print "<br>\n";
-		$error += mysql_errno();
+		$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 	}
 }
 
-mysql_query("create table `".$mysql_table_prefix."categories` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."categories` (
 	category_id integer not null auto_increment primary key, 
 	category text,
 	parent_num integer
 	)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("create table `".$mysql_table_prefix."site_category` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."site_category` (
 	site_id integer,
 	category_id integer
 	)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("create table `".$mysql_table_prefix."temp` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."temp` (
 	link varchar(255),
 	level integer,
 	id varchar (32)
 	)");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("create table `".$mysql_table_prefix."pending` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."pending` (
 	site_id integer,
 	temp_id varchar(32),
 	level integer,
@@ -127,36 +127,36 @@ mysql_query("create table `".$mysql_table_prefix."pending` (
 	num integer
 )");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("create table `".$mysql_table_prefix."query_log` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."query_log` (
 	query varchar(255),
 	time timestamp(14),
 	elapsed float(2),
 	results int, 
 	key query_key(query))");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
-mysql_query("create table `".$mysql_table_prefix."domains` (
+mysqli_query($GLOBALS["___mysqli_ston"], "create table `".$mysql_table_prefix."domains` (
 	domain_id int auto_increment primary key not null,	
 	domain varchar(255))");
 
-if (mysql_errno() > 0) {
+if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) > 0) {
 	print "Error: ";
-	print mysql_error();
+	print ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 	print "<br>\n";
-	$error += mysql_errno();
+	$error += ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false));
 }
 
 

--- a/cms/modules/search/admin/spider.php
+++ b/cms/modules/search/admin/spider.php
@@ -111,9 +111,9 @@ if(!defined('__PRAGYAN_CMS'))
 	} else {
 
 		if ($reindex == 1 && $command_line == 1) {
-			$result=mysql_query("select url, spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites where url='$url'");
-			echo mysql_error();
-			if($row=mysql_fetch_row($result)) {
+			$result=mysqli_query($GLOBALS["___mysqli_ston"], "select url, spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites where url='$url'");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			if($row=mysqli_fetch_row($result)) {
 				$url = $row[0];
 				$maxlevel = $row[1];
 				$in= $row[2];
@@ -166,12 +166,12 @@ if(!defined('__PRAGYAN_CMS'))
 			$url = preg_replace("/ /", "", url_purify($url_status['path'], $url, $can_leave_domain));
 
 			if ($url <> '') {
-				$result = mysql_query("select link from ".$mysql_table_prefix."temp where link='$url' && id = '$sessid'");
-				echo mysql_error();
-				$rows = mysql_numrows($result);
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link from ".$mysql_table_prefix."temp where link='$url' && id = '$sessid'");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+				$rows = mysqli_num_rows($result);
 				if ($rows == 0) {
-					mysql_query ("insert into ".$mysql_table_prefix."temp (link, level, id) values ('$url', '$level', '$sessid')");
-					echo mysql_error();
+					mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."temp (link, level, id) values ('$url', '$level', '$sessid')");
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 				}
 			}
 
@@ -280,7 +280,7 @@ if(!defined('__PRAGYAN_CMS'))
 							if ($tmp_urls[$thislink[1]] != 1) {
 								$tmp_urls[$thislink[1]] = 1;
 								$numoflinks++;
-								mysql_query ("insert into ".$mysql_table_prefix."temp (link, level, id) values ('$thislink[1]', '$level', '$sessid')") or die (mysql_error()."-spider.php L:276");
+								mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."temp (link, level, id) values ('$thislink[1]', '$level', '$sessid')") or die (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."-spider.php L:276");
 							}
 						}
 					}
@@ -301,8 +301,8 @@ if(!defined('__PRAGYAN_CMS'))
 					if (isset($domain_arr[$domain_for_db])) {
 						$dom_id = $domain_arr[$domain_for_db];
 					} else {
-						mysql_query("insert into ".$mysql_table_prefix."domains (domain) values ('$domain_for_db')");
-						$dom_id = mysql_insert_id();
+						mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."domains (domain) values ('$domain_for_db')");
+						$dom_id = ((is_null($___mysqli_res = mysqli_insert_id($GLOBALS["___mysqli_ston"]))) ? false : $___mysqli_res);
 						$domain_arr[$domain_for_db] = $dom_id;
 					}
 
@@ -311,9 +311,9 @@ if(!defined('__PRAGYAN_CMS'))
 					//if there are words to index, add the link to the database, get its id, and add the word + their relation
 					if (is_array($wordarray) && count($wordarray) > $min_words_per_page) {
 						if ($md5sum == '') {
-							mysql_query ("insert into ".$mysql_table_prefix."links (site_id, url, title, description, fulltxt, indexdate, size, md5sum, level) values ('$site_id', '$url', '$title', '$desc', '$fulltxt', curdate(), '$pageSize', '$newmd5sum', $thislevel)") or die( mysql_error()."-spider.php L:307");
-							$result = mysql_query("select link_id from ".$mysql_table_prefix."links where url='$url'") or die( mysql_error()."-spider.php L:308");
-							$row = mysql_fetch_row($result);
+							mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."links (site_id, url, title, description, fulltxt, indexdate, size, md5sum, level) values ('$site_id', '$url', '$title', '$desc', '$fulltxt', curdate(), '$pageSize', '$newmd5sum', $thislevel)") or die( ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."-spider.php L:307");
+							$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link_id from ".$mysql_table_prefix."links where url='$url'") or die( ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."-spider.php L:308");
+							$row = mysqli_fetch_row($result);
 							$link_id = $row[0];
 
 							save_keywords($wordarray, $link_id, $dom_id);
@@ -321,17 +321,17 @@ if(!defined('__PRAGYAN_CMS'))
 							printStandardReport('indexed', $command_line);
 						}else if (($md5sum <> '') && ($md5sum <> $newmd5sum)) { //if page has changed, start updating
 
-							$result = mysql_query("select link_id from ".$mysql_table_prefix."links where url='$url'") or die( mysql_error()."-spider.php L:317");
-							$row = mysql_fetch_row($result);
+							$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link_id from ".$mysql_table_prefix."links where url='$url'") or die( ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."-spider.php L:317");
+							$row = mysqli_fetch_row($result);
 							$link_id = $row[0];
 							for ($i=0;$i<=15; $i++) {
 								$char = dechex($i);
-								mysql_query ("delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id") or die( mysql_error()."-spider.php L:322");
+								mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id") or die( ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."-spider.php L:322");
 								
 							}
 							save_keywords($wordarray, $link_id, $dom_id);
 							$query = "update ".$mysql_table_prefix."links set title='$title', description ='$desc', fulltxt = '$fulltxt', indexdate=now(), size = '$pageSize', md5sum='$newmd5sum', level=$thislevel where link_id=$link_id";
-							mysql_query($query) or die( mysql_error()."-spider.php L:327");
+							mysqli_query($GLOBALS["___mysqli_ston"], $query) or die( ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."-spider.php L:327");
 							printStandardReport('re-indexed', $command_line);
 						}
 					}else {
@@ -364,9 +364,9 @@ if(!defined('__PRAGYAN_CMS'))
 	function index_site($url, $reindex, $maxlevel, $soption, $url_inc, $url_not_inc, $can_leave_domain) {
 		global $mysql_table_prefix, $command_line, $mainurl,  $tmp_urls, $domain_arr, $all_keywords;
 		if (!isset($all_keywords)) {
-			$result = mysql_query("select keyword_ID, keyword from ".$mysql_table_prefix."keywords");
-			echo mysql_error();
-			while($row=mysql_fetch_array($result)) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select keyword_ID, keyword from ".$mysql_table_prefix."keywords");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			while($row=mysqli_fetch_array($result)) {
 				$all_keywords[addslashes($row[1])] = $row[0];
 			}
 		}
@@ -391,54 +391,54 @@ if(!defined('__PRAGYAN_CMS'))
 
 		
 	
-		$result = mysql_query("select site_id from ".$mysql_table_prefix."sites where url='$url'");
-		echo mysql_error();
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select site_id from ".$mysql_table_prefix."sites where url='$url'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row = mysqli_fetch_row($result);
 		$site_id = $row[0];
 		
 		if ($site_id != "" && $reindex == 1) {
-			mysql_query ("insert into ".$mysql_table_prefix."temp (link, level, id) values ('$url', 0, '$sessid')");
-			echo mysql_error();
-			$result = mysql_query("select url, level from ".$mysql_table_prefix."links where site_id = $site_id");
-			while ($row = mysql_fetch_array($result)) {
+			mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."temp (link, level, id) values ('$url', 0, '$sessid')");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select url, level from ".$mysql_table_prefix."links where site_id = $site_id");
+			while ($row = mysqli_fetch_array($result)) {
 				$site_link = $row['url'];
 				$link_level = $row['level'];
 				if ($site_link != $url) {
-					mysql_query ("insert into ".$mysql_table_prefix."temp (link, level, id) values ('$site_link', $link_level, '$sessid')");
+					mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."temp (link, level, id) values ('$site_link', $link_level, '$sessid')");
 				}
 			}
 			
 			$qry = "update ".$mysql_table_prefix."sites set indexdate=now(), spider_depth = $maxlevel, required = '$url_inc'," .
 					"disallowed = '$url_not_inc', can_leave_domain=$can_leave_domain where site_id=$site_id";
-			mysql_query ($qry);
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], $qry);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		} else if ($site_id == '') {
-			mysql_query ("insert into ".$mysql_table_prefix."sites (url, indexdate, spider_depth, required, disallowed, can_leave_domain) " .
+			mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."sites (url, indexdate, spider_depth, required, disallowed, can_leave_domain) " .
 					"values ('$url', now(), $maxlevel, '$url_inc', '$url_not_inc', $can_leave_domain)");
-			echo mysql_error();
-			$result = mysql_query("select site_ID from ".$mysql_table_prefix."sites where url='$url'");
-			$row = mysql_fetch_row($result);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select site_ID from ".$mysql_table_prefix."sites where url='$url'");
+			$row = mysqli_fetch_row($result);
 			$site_id = $row[0];
 		} else {
-			mysql_query ("update ".$mysql_table_prefix."sites set indexdate=now(), spider_depth = $maxlevel, required = '$url_inc'," .
+			mysqli_query($GLOBALS["___mysqli_ston"], "update ".$mysql_table_prefix."sites set indexdate=now(), spider_depth = $maxlevel, required = '$url_inc'," .
 					"disallowed = '$url_not_inc', can_leave_domain=$can_leave_domain where site_id=$site_id");
-			echo mysql_error();
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 	
 		
-		$result = mysql_query("select site_id, temp_id, level, count, num from ".$mysql_table_prefix."pending where site_id='$site_id'");
-		echo mysql_error();
-		$row = mysql_fetch_row($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select site_id, temp_id, level, count, num from ".$mysql_table_prefix."pending where site_id='$site_id'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$row = mysqli_fetch_row($result);
 		$pending = $row[0];
 		$level = 0;
 		$domain_arr = get_domains();
 		if ($pending == '') {
-			mysql_query ("insert into ".$mysql_table_prefix."temp (link, level, id) values ('$url', 0, '$sessid')");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."temp (link, level, id) values ('$url', 0, '$sessid')");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		} else if ($pending != '') {
 			printStandardReport('continueSuspended',$command_line);
-			mysql_query("select temp_id, level, count from ".$mysql_table_prefix."pending where site_id='$site_id'");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "select temp_id, level, count from ".$mysql_table_prefix."pending where site_id='$site_id'");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			$sessid = $row[1];
 			$level = $row[2];
 			$pend_count = $row[3] + 1;
@@ -448,8 +448,8 @@ if(!defined('__PRAGYAN_CMS'))
 		}
 	
 		if ($reindex != 1) {
-			mysql_query ("insert into ".$mysql_table_prefix."pending (site_id, temp_id, level, count) values ('$site_id', '$sessid', '0', '0')");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."pending (site_id, temp_id, level, count) values ('$site_id', '$sessid', '0', '0')");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 	
 	
@@ -473,9 +473,9 @@ if(!defined('__PRAGYAN_CMS'))
 	
 			$links = array();
 	
-			$result = mysql_query("select distinct link from ".$mysql_table_prefix."temp where level=$level && id='$sessid' order by link");
-			echo mysql_error();
-			$rows = mysql_num_rows($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "select distinct link from ".$mysql_table_prefix."temp where level=$level && id='$sessid' order by link");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$rows = mysqli_num_rows($result);
 	
 			if ($rows == 0) {
 				break;
@@ -483,7 +483,7 @@ if(!defined('__PRAGYAN_CMS'))
 	
 			$i = 0;
 	
-			while ($row = mysql_fetch_array($result)) {
+			while ($row = mysqli_fetch_array($result)) {
 				$links[] = $row['link'];
 			}
 	
@@ -523,22 +523,22 @@ if(!defined('__PRAGYAN_CMS'))
 				if ($forbidden == 0) {
 					printRetrieving($num, $thislink, $command_line);
 					$query = "select md5sum, indexdate from ".$mysql_table_prefix."links where url='$thislink'";
-					$result = mysql_query($query);
-					echo mysql_error();
-					$rows = mysql_num_rows($result);
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+					$rows = mysqli_num_rows($result);
 					if ($rows == 0) {
 						if($thislink != "/")
 						index_url($thislink, $level+1, $site_id, '',  $domain, '', $sessid, $can_leave_domain, $reindex);
 
-						mysql_query("update ".$mysql_table_prefix."pending set level = $level, count=$count, num=$num where site_id=$site_id");
-						echo mysql_error();
+						mysqli_query($GLOBALS["___mysqli_ston"], "update ".$mysql_table_prefix."pending set level = $level, count=$count, num=$num where site_id=$site_id");
+						echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 					}else if ($rows <> 0 && $reindex == 1) {
-						$row = mysql_fetch_array($result);
+						$row = mysqli_fetch_array($result);
 						$md5sum = $row['md5sum'];
 						$indexdate = $row['indexdate'];
 						index_url($thislink, $level+1, $site_id, $md5sum,  $domain, $indexdate, $sessid, $can_leave_domain, $reindex);
-						mysql_query("update ".$mysql_table_prefix."pending set level = $level, count=$count, num=$num where site_id=$site_id");
-						echo mysql_error();
+						mysqli_query($GLOBALS["___mysqli_ston"], "update ".$mysql_table_prefix."pending set level = $level, count=$count, num=$num where site_id=$site_id");
+						echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 					}else {
 						printStandardReport('inDatabase',$command_line);
 					}
@@ -549,10 +549,10 @@ if(!defined('__PRAGYAN_CMS'))
 			$level++;
 		}
 	
-		mysql_query ("delete from ".$mysql_table_prefix."temp where id = '$sessid'");
-		echo mysql_error();
-		mysql_query ("delete from ".$mysql_table_prefix."pending where site_id = '$site_id'");
-		echo mysql_error();
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."temp where id = '$sessid'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."pending where site_id = '$site_id'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		printStandardReport('completed',$command_line);
 	
 
@@ -560,9 +560,9 @@ if(!defined('__PRAGYAN_CMS'))
 
 	function index_all() {
 		global $mysql_table_prefix;
-		$result=mysql_query("select url, spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites");
-		echo mysql_error();
-    	while ($row=mysql_fetch_row($result)) {
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], "select url, spider_depth, required, disallowed, can_leave_domain from ".$mysql_table_prefix."sites");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+    	while ($row=mysqli_fetch_row($result)) {
     		$url = $row[0];
 	   		$depth = $row[1];
     		$include = $row[2];
@@ -582,10 +582,10 @@ if(!defined('__PRAGYAN_CMS'))
 
 	function get_temp_urls ($sessid) {
 		global $mysql_table_prefix;
-		$result = mysql_query("select link from ".$mysql_table_prefix."temp where id='$sessid'");
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link from ".$mysql_table_prefix."temp where id='$sessid'");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$tmp_urls = Array();
-    	while ($row=mysql_fetch_row($result)) {
+    	while ($row=mysqli_fetch_row($result)) {
 			$tmp_urls[$row[0]] = 1;
 		}
 		return $tmp_urls;
@@ -594,10 +594,10 @@ if(!defined('__PRAGYAN_CMS'))
 
 	function get_domains () {
 		global $mysql_table_prefix;
-		$result = mysql_query("select domain_id, domain from ".$mysql_table_prefix."domains");
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select domain_id, domain from ".$mysql_table_prefix."domains");
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$domains = Array();
-    	while ($row=mysql_fetch_row($result)) {
+    	while ($row=mysqli_fetch_row($result)) {
 			$domains[$row[1]] = $row[0];
 		}
 		return $domains;

--- a/cms/modules/search/admin/spiderfuncs.php
+++ b/cms/modules/search/admin/spiderfuncs.php
@@ -490,16 +490,16 @@ function save_keywords($wordarray, $link_id, $domain) {
 		if (strlen($word)<= 30) {
 			$keyword_id = $all_keywords[$word];
 			if ($keyword_id  == "") {
-                mysql_query("insert into ".$mysql_table_prefix."keywords (keyword) values ('$word')");
-				if (mysql_errno() == 1062) { 
-					$result = mysql_query("select keyword_ID from ".$mysql_table_prefix."keywords where keyword='$word'");
-					echo mysql_error();
-					$row = mysql_fetch_row($result);
+                mysqli_query($GLOBALS["___mysqli_ston"], "insert into ".$mysql_table_prefix."keywords (keyword) values ('$word')");
+				if (((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false)) == 1062) { 
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], "select keyword_ID from ".$mysql_table_prefix."keywords where keyword='$word'");
+					echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+					$row = mysqli_fetch_row($result);
 					$keyword_id = $row[0];
 				} else{
-				$keyword_id = mysql_insert_id();
+				$keyword_id = ((is_null($___mysqli_res = mysqli_insert_id($GLOBALS["___mysqli_ston"]))) ? false : $___mysqli_res);
 				$all_keywords[$word] = $keyword_id;
-				echo mysql_error();
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			} 
 			} 
 			$inserts[$wordmd5] .= ",($link_id, $keyword_id, $weight, $domain)"; 
@@ -511,8 +511,8 @@ function save_keywords($wordarray, $link_id, $domain) {
 		$values= substr($inserts[$char], 1);
 		if ($values!="") {
 			$query = "insert into ".$mysql_table_prefix."link_keyword$char (link_id, keyword_id, weight, domain) values $values";
-			mysql_query($query);
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		}
 		
 	
@@ -692,9 +692,9 @@ function calc_weights($wordarray, $title, $host, $path, $keywords) {
 
 function isDuplicateMD5($md5sum) {
 	global $mysql_table_prefix;
-	$result = mysql_query("select link_id from ".$mysql_table_prefix."links where md5sum='$md5sum'");
-	echo mysql_error();
-	if (mysql_num_rows($result) > 0) {
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link_id from ".$mysql_table_prefix."links where md5sum='$md5sum'");
+	echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+	if (mysqli_num_rows($result) > 0) {
 		return true;
 	}
 	return false;
@@ -753,23 +753,23 @@ function check_include($link, $inc, $not_inc) {
 function check_for_removal($url) {
 	global $mysql_table_prefix;
 	global $command_line;
-	$result = mysql_query("select link_id, visible from ".$mysql_table_prefix."links"." where url='$url'");
-	echo mysql_error();
-	if (mysql_num_rows($result) > 0) {
-		$row = mysql_fetch_row($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "select link_id, visible from ".$mysql_table_prefix."links"." where url='$url'");
+	echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+	if (mysqli_num_rows($result) > 0) {
+		$row = mysqli_fetch_row($result);
 		$link_id = $row[0];
 		$visible = $row[1];
 		if ($visible > 0) {
 			$visible --;
-			mysql_query("update ".$mysql_table_prefix."links set visible=$visible where link_id=$link_id");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "update ".$mysql_table_prefix."links set visible=$visible where link_id=$link_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		} else {
-			mysql_query("delete from ".$mysql_table_prefix."links where link_id=$link_id");
-			echo mysql_error();
+			mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."links where link_id=$link_id");
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			for ($i=0;$i<=15; $i++) {
 				$char = dechex($i);
-				mysql_query("delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
-				echo mysql_error();
+				mysqli_query($GLOBALS["___mysqli_ston"], "delete from ".$mysql_table_prefix."link_keyword$char where link_id=$link_id");
+				echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 			}
 			printStandardReport('pageRemoved',$command_line);
 		}

--- a/cms/modules/search/admin/spiderfuncs.php
+++ b/cms/modules/search/admin/spiderfuncs.php
@@ -736,7 +736,7 @@ function check_include($link, $inc, $not_inc) {
 				if (substr($str, 0, 1) == '*') {
 					if (preg_match(substr($str, 1), $link)) {
 						$include = true;
-						break 2;
+						break;
 					}
 				} else {
 					if (strpos($link, $str) !== false) {

--- a/cms/modules/search/include/commonfuncs.php
+++ b/cms/modules/search/include/commonfuncs.php
@@ -12,11 +12,11 @@
 	* @return array|null massiiv
 	 */
 	function sql_fetch_all($query) {
-		$result = mysql_query($query);
-		if($mysql_err = mysql_errno()) {
-			print $query.'<br>'.mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if($mysql_err = ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_errno($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_errno()) ? $___mysqli_res : false))) {
+			print $query.'<br>'.((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		} else {
-			while($row=mysql_fetch_array($result)) {
+			while($row=mysqli_fetch_array($result)) {
 				$data[]=$row;
 			}	
 		}		
@@ -49,11 +49,11 @@
 	function get_cats($parent) {
 		global $mysql_table_prefix;
 		$query = "SELECT * FROM ".$mysql_table_prefix."categories WHERE parent_num=$parent";
-		echo mysql_error();
-		$result = mysql_query($query);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		$arr[] = $parent;
-		if (mysql_num_rows($result) <> '') {
-			while ($row = mysql_fetch_array($result)) {
+		if (mysqli_num_rows($result) <> '') {
+			while ($row = mysqli_fetch_array($result)) {
 				$id = $row[category_id];
 				$arr = add_arrays($arr, get_cats($id));
 			}

--- a/cms/modules/search/include/js_suggest/suggest.php
+++ b/cms/modules/search/include/js_suggest/suggest.php
@@ -55,7 +55,7 @@ if ($suggest_history && $_GET['q']!='"')
 
 /* 
 	phrase search
-	!! LOCATE: in MySQL 3.23 this function is case sensitive, while in 4.0 it's only case-sensitive if either argument is a binary string
+	!! LOCATE: in mysql 3.23 this function is case sensitive, while in 4.0 it's only case-sensitive if either argument is a binary string
 */
 
 if ($suggest_phrases) 

--- a/cms/modules/search/include/searchfuncs.php
+++ b/cms/modules/search/include/searchfuncs.php
@@ -151,9 +151,9 @@ error_reporting(E_ALL ^ E_NOTICE);
 		global $length_of_link_desc,$mysql_table_prefix, $show_meta_description, $merge_site_results, $stem_words, $did_you_mean_enabled ;
 		
 		$possible_to_find = 1;
-		$result = mysql_query("select domain_id from ".$mysql_table_prefix."domains where domain = '$domain'");
-		if (mysql_num_rows($result)> 0) {
-			$thisrow = mysql_fetch_array($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], "select domain_id from ".$mysql_table_prefix."domains where domain = '$domain'");
+		if (mysqli_num_rows($result)> 0) {
+			$thisrow = mysqli_fetch_array($result);
 			$domain_qry = "and domain = ".$thisrow[0];
 		} else {
 			$domain_qry = "";
@@ -176,9 +176,9 @@ error_reporting(E_ALL ^ E_NOTICE);
 
             $query1 = "SELECT link_id from ".$mysql_table_prefix."link_keyword$wordmd5, ".$mysql_table_prefix."keywords where ".$mysql_table_prefix."link_keyword$wordmd5.keyword_id= ".$mysql_table_prefix."keywords.keyword_id and keyword='$searchword'";
 
-			$result = mysql_query($query1);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
 
-			while ($row = mysql_fetch_row($result)) {	
+			while ($row = mysqli_fetch_row($result)) {	
 				$notlist[$not_words]['id'][$row[0]] = 1;
 			}
 			$not_words++;
@@ -192,14 +192,14 @@ error_reporting(E_ALL ^ E_NOTICE);
 
 			$searchword = addslashes($wordarray[$phrase_words]);
 			$query1 = "SELECT link_id from ".$mysql_table_prefix."links where fulltxt like '% $searchword%'";
-			echo mysql_error();
-			$result = mysql_query($query1);
-			$num_rows = mysql_num_rows($result);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			$num_rows = mysqli_num_rows($result);
 			if ($num_rows == 0) {
 				$possible_to_find = 0;
 				break;
 			}
-			while ($row = mysql_fetch_row($result)) {	
+			while ($row = mysqli_fetch_row($result)) {	
 				$phraselist[$phrase_words]['id'][$row[0]] = 1;
 			}
 			$phrase_words++;
@@ -210,13 +210,13 @@ error_reporting(E_ALL ^ E_NOTICE);
 			$allcats = get_cats($category);
 			$catlist = implode(",", $allcats);
 			$query1 = "select link_id from ".$mysql_table_prefix."links, ".$mysql_table_prefix."sites, ".$mysql_table_prefix."categories, ".$mysql_table_prefix."site_category where ".$mysql_table_prefix."links.site_id = ".$mysql_table_prefix."sites.site_id and ".$mysql_table_prefix."sites.site_id = ".$mysql_table_prefix."site_category.site_id and ".$mysql_table_prefix."site_category.category_id in ($catlist)";
-			$result = mysql_query($query1);
-			echo mysql_error();
-			$num_rows = mysql_num_rows($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$num_rows = mysqli_num_rows($result);
 			if ($num_rows == 0) {
 				$possible_to_find = 0;
 			}
-			while ($row = mysql_fetch_row($result)) {	
+			while ($row = mysqli_fetch_row($result)) {	
 				$category_list[$row[0]] = 1;
 			}
 		}
@@ -234,9 +234,9 @@ error_reporting(E_ALL ^ E_NOTICE);
 			}
 			$wordmd5 = substr(md5($searchword), 0, 1);
 			$query1 = "SELECT distinct link_id, weight, domain from ".$mysql_table_prefix."link_keyword$wordmd5, ".$mysql_table_prefix."keywords where ".$mysql_table_prefix."link_keyword$wordmd5.keyword_id= ".$mysql_table_prefix."keywords.keyword_id and keyword='$searchword' $domain_qry order by weight desc";
-			echo mysql_error();
-			$result = mysql_query($query1);
-			$num_rows = mysql_num_rows($result);
+			echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			$num_rows = mysqli_num_rows($result);
 			if ($num_rows == 0) {
 				if ($type != "or") {
 					$possible_to_find = 0;
@@ -249,7 +249,7 @@ error_reporting(E_ALL ^ E_NOTICE);
 				$indx = $words;
 			}
 
-			while ($row = mysql_fetch_row($result)) {	
+			while ($row = mysqli_fetch_row($result)) {	
 				$linklist[$indx]['id'][] = $row[0];
 				$domains[$row[0]] = $row[2];
 				$linklist[$indx]['weight'][$row[0]] = $row[1];
@@ -327,10 +327,10 @@ error_reporting(E_ALL ^ E_NOTICE);
 			reset ($searchstr['+']);
 			foreach ($searchstr['+'] as $word) {
 				$word = addslashes($word);
-				$result = mysql_query("select keyword from ".$mysql_table_prefix."keywords where soundex(keyword) = soundex('$word')");
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], "select keyword from ".$mysql_table_prefix."keywords where soundex(keyword) = soundex('$word')");
 				$max_distance = 100;
 				$near_word ="";
-				while ($row=mysql_fetch_row($result)) {
+				while ($row=mysqli_fetch_row($result)) {
 					
 					$distance = levenshtein($row[0], $word);
 					if ($distance < $max_distance && $distance <4) {
@@ -401,11 +401,11 @@ error_reporting(E_ALL ^ E_NOTICE);
 
 		$query1 = "SELECT distinct link_id, url, title, description,  $fulltxt, size FROM ".$mysql_table_prefix."links WHERE link_id in ($inlist)";
 
-		$result = mysql_query($query1);
-		echo mysql_error();
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 
 		$i = 0;
-		while ($row = mysql_fetch_row($result)) {
+		while ($row = mysqli_fetch_row($result)) {
 			$res[$i]['title'] = $row[2];
 			$res[$i]['url'] = $row[1];
 			if ($row[3] != null && $show_meta_description == 1)
@@ -414,8 +414,8 @@ error_reporting(E_ALL ^ E_NOTICE);
 				$res[$i]['fulltxt'] = $row[4];
 			$res[$i]['size'] = $row[5];
 			$res[$i]['weight'] = $result_array[$row[0]];
-			$dom_result = mysql_query("select domain from ".$mysql_table_prefix."domains where domain_id='".$domains[$row[0]]."'");
-			$dom_row = mysql_fetch_row($dom_result);
+			$dom_result = mysqli_query($GLOBALS["___mysqli_ston"], "select domain from ".$mysql_table_prefix."domains where domain_id='".$domains[$row[0]]."'");
+			$dom_row = mysqli_fetch_row($dom_result);
 			$res[$i]['domain'] = $dom_row[0];
 			$i++;
 		}
@@ -427,7 +427,7 @@ error_reporting(E_ALL ^ E_NOTICE);
 		} else {
 			usort($res, "cmp"); 	
 		}
-		echo mysql_error();
+		echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
 		$res['maxweight'] = $maxweight;
 		$res['results'] = $results;
 		return $res;

--- a/cms/modules/search/search.php
+++ b/cms/modules/search/search.php
@@ -120,9 +120,9 @@ function saveToLog ($query, $elapsed, $results) {
         $results = 0;
     }
     $query =  "insert into ".$mysql_table_prefix."query_log (query, time, elapsed, results) values ('$query', now(), '$elapsed', '$results')";
-	mysql_query($query);
+	mysqli_query($GLOBALS["___mysqli_ston"], $query);
                     
-	echo mysql_error();
+	echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false));
                         
 }
 

--- a/cms/modules/share.lib.php
+++ b/cms/modules/share.lib.php
@@ -118,8 +118,8 @@ RET;
 		displayerror("No File Uploaded");
 	else{
 	$query = "SELECT * FROM `share` WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$result = mysql_query($query) or displayerror("Error in view");
-	$result = mysql_fetch_array($result) or displayerror("Error in view");
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror("Error in view");
+	$result = mysqli_fetch_array($result) or displayerror("Error in view");
 	$maxFileSizeInBytes = $result[3];
 	if(trim($result[2])=="") $uploadableFileTypes = false;
 		else {
@@ -135,8 +135,8 @@ RET;
 				$file_desc = safe_html($_POST['file_desc']);
 
 				$uploadQuery = "INSERT INTO `share_files` (`page_modulecomponentid`, `upload_filename`, `file_name`, `file_desc`, `upload_userid`) VALUES('$module_ComponentId', '$uploadFileName[0]','$file_name','$file_desc','{$this->userId}')";
-				$uploadResult = mysql_query($uploadQuery);
-		if(mysql_affected_rows()>0)
+				$uploadResult = mysqli_query($GLOBALS["___mysqli_ston"], $uploadQuery);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0)
 			displayinfo("Successfully Uploaded ".$file_name);
 		else
 			displayerror("File Not Uploaded");
@@ -146,13 +146,13 @@ RET;
 	}
 	}
 	if(isset($_POST['btnSubmit'])) {
-			$id = mysql_fetch_array(mysql_query("SELECT MAX(`comment_id`) AS MAX FROM `share_comments`"));
+			$id = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT MAX(`comment_id`) AS MAX FROM `share_comments`"));
 			$id = $id['MAX'] + 1;
 			$user = $this->userId;
 			$comment = escape(safe_html($_POST['comment']));
 			$file_id = escape($_POST['file_id']);
-			mysql_query("INSERT INTO `share_comments`(`comment_id`,`file_id`,`page_modulecomponentid`,`comment`,`userid`) VALUES('$id','$file_id','{$module_ComponentId}','$comment','$user')") or die(mysql_error());
-			if(mysql_affected_rows())
+			mysqli_query($GLOBALS["___mysqli_ston"], "INSERT INTO `share_comments`(`comment_id`,`file_id`,`page_modulecomponentid`,`comment`,`userid`) VALUES('$id','$file_id','{$module_ComponentId}','$comment','$user')") or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 				displayinfo("Post successful");
 			else
 				displayerror("Error in posting comment");
@@ -161,32 +161,32 @@ RET;
 	{
 		$file_id = escape($_GET['file']);
 		$query = "SELECT * FROM `share_files` WHERE `file_id` = '$file_id'";
-		$result = mysql_query($query);
-		if(mysql_num_rows($result)<0)
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_num_rows($result)<0)
 			{
 			displayerror("Sorry!!! No such file found");
 			}
 		else
 			{
-			$result = mysql_fetch_array($result);
+			$result = mysqli_fetch_array($result);
 			$username = getUserFullName($this->userId);
 			$content = "<script type=\"text/javascript\" languauge=\"javascript\" src=\"$temp/textarea_resize.js\"></script>";
 			$content .= "<div id='file'><b>{$result[3]}</b><br/>{$result[4]}<br /><br />Uploaded by: $username<br /><br /><a href=\"./{$result[2]}\" target='_blank'><input type='submit' value='Download'></a></div> ";
 			$comment_query = "SELECT * FROM `share_comments` WHERE `page_modulecomponentid` = '$module_ComponentId' AND `file_id` = '{$result[0]}'";
-			$comment_result = mysql_query($comment_query);
-			if(mysql_num_rows($comment_result)>0)
+			$comment_result = mysqli_query($GLOBALS["___mysqli_ston"], $comment_query);
+			if(mysqli_num_rows($comment_result)>0)
 			$content .= "<fieldset><legend>Comments</legend>";
-			while($row = mysql_fetch_array($comment_result))
+			while($row = mysqli_fetch_array($comment_result))
 				$content .= $this->renderComment($row['comment_id'],$row['userid'],$row['comment_datetime'],$row['comment'],$file_id);
-			if(mysql_num_rows($comment_result)>0)
+			if(mysqli_num_rows($comment_result)>0)
 				$content .= "</fieldset>";
 			$content .= $this->commentBox($file_id);
 			return $content;
 			}	
 	}
 	$query = "SELECT * FROM `share` WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$result = mysql_query($query) or displayerror(mysql_error()." Error in share.lib.php L:187");
-	$result = mysql_fetch_array($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." Error in share.lib.php L:187");
+	$result = mysqli_fetch_array($result);
 	$file_types = preg_replace('/\|/',', ',$result['file_type']);
 	$upload_form =<<<FORM
 <script type="text/javascript" language="javascript">
@@ -218,13 +218,13 @@ FORM;
 	$content = "<table width=100%><tr><td colspan='2'><b>{$result['page_desc']}</b><br /></td></tr><tr><td width=150px>Uploadable File Typles </td><td>{$file_types}</td></tr><tr><td>Max. file size </td><td> {$result['maxfile_size']} bytes</td></tr></table>";
 	$content .= $upload_form;
 	$content_query = "SELECT * FROM `share_files` WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$content_result = mysql_query($content_query) or displayerror("Error is retriving info from database. Please try later..");
-	if(mysql_num_rows($content_result)<=0)
+	$content_result = mysqli_query($GLOBALS["___mysqli_ston"], $content_query) or displayerror("Error is retriving info from database. Please try later..");
+	if(mysqli_num_rows($content_result)<=0)
 		$content .= "No Files found..";
 	else{
 
 		$content .= "<div id='file_container'>";
-		while($row = mysql_fetch_array($content_result))
+		while($row = mysqli_fetch_array($content_result))
 			$content .= $this->renderField($row);		
 		$content .= "</div>";
 	}
@@ -239,14 +239,14 @@ FORM;
 	{
 		$file_id = escape($_GET['delfile']);
 		$query = "SELECT * FROM `share_files` WHERE `file_id` = '$file_id'";
-		$result = mysql_query($query);
-		$result = mysql_fetch_array($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		$result = mysqli_fetch_array($result);
 		if(deleteFile($module_ComponentId,"share",$result['upload_filename']))
 			{
 			$del_query = "DELETE FROM `share_files` WHERE `file_id` = '$file_id'";
-			$del_result = mysql_query($del_query) or displayerror(mysql_error()."Error in share.lib.php L:240");
+			$del_result = mysqli_query($GLOBALS["___mysqli_ston"], $del_query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."Error in share.lib.php L:240");
 			$del_comment = "DELETE FROM `share_comments` WHERE `file_id` = '$file_id'";
-			$del_comment_result = mysql_query($del_comment) or displayerror(mysql_error()."error in  L:242");
+			$del_comment_result = mysqli_query($GLOBALS["___mysqli_ston"], $del_comment) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."error in  L:242");
 			if(!$del_result||!$del_comment_result)
 				displayerror("Some data has not been deleted properly!!!");
 			else
@@ -259,8 +259,8 @@ FORM;
 	{
 		$commentid = escape($_GET['delComment']);
 		$query = "DELETE FROM `share_comments` WHERE `comment_id` = $commentid";
-		$result = mysql_query($query);
-		if(mysql_affected_rows()<0)
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])<0)
 			displayerror("Error in deleting the comment");
 		else
 			displayinfo("Succesfully deleted comment");	
@@ -269,40 +269,40 @@ FORM;
 	{
 		$file_id = escape($_GET['file']);
 		$query = "SELECT * FROM `share_files` WHERE `file_id` = '$file_id'";
-		$result = mysql_query($query);
-		if(mysql_num_rows($result)<0)
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_num_rows($result)<0)
 			{
 			displayerror("Sorry!!! No such file found");
 			}
 		else
 			{
-			$result = mysql_fetch_array($result);
+			$result = mysqli_fetch_array($result);
 			$username = getUserFullName($this->userId);
 			$content = "<div id='file'><b>{$result[3]}</b><br/>{$result[4]}<br /><br />Uploaded by: $username<br /><br /><a href=\"./{$result[2]}\" target='_blank'><input type='submit' value='Download'></a></div> ";
 			$comment_query = "SELECT * FROM `share_comments` WHERE `page_modulecomponentid` = '$module_ComponentId' AND `file_id` = '{$result[0]}'";
-			$comment_result = mysql_query($comment_query) or die(mysql_error());
-			if(mysql_num_rows($comment_result)>0)
+			$comment_result = mysqli_query($GLOBALS["___mysqli_ston"], $comment_query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+			if(mysqli_num_rows($comment_result)>0)
 			$content .= "<fieldset><legend>Comments</legend>";
-			while($row = mysql_fetch_array($comment_result))
+			while($row = mysqli_fetch_array($comment_result))
 				$content .= $this->renderComment($row['comment_id'],$row['userid'],$row['comment_datetime'],$row['comment'],$file_id,'moderate');
-			if(mysql_num_rows($comment_result)>0)
+			if(mysqli_num_rows($comment_result)>0)
 				$content .= "</fieldset>";
 			return $content;
 			}	
 	}
 	$query = "SELECT * FROM `share` WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$result = mysql_query($query) or displayerror(mysql_error()." Error in share.lib.php L:187");
-	$result = mysql_fetch_array($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." Error in share.lib.php L:187");
+	$result = mysqli_fetch_array($result);
 	$file_types = preg_replace('/\|/',', ',$result['file_type']);
 	$content = "<table width=100%><tr><td colspan='2'><b>{$result['page_desc']}</b><br /></td></tr><tr><td width=150px>Uploadable File Typles </td><td>{$file_types}</td></tr><tr><td>Max. file size </td><td> {$result['maxfile_size']} bytes</td></tr></table>";
 	$content_query = "SELECT * FROM `share_files` WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$content_result = mysql_query($content_query) or displayerror("Error is retriving info from database. Please try later..");
-	if(mysql_num_rows($content_result)<=0)
+	$content_result = mysqli_query($GLOBALS["___mysqli_ston"], $content_query) or displayerror("Error is retriving info from database. Please try later..");
+	if(mysqli_num_rows($content_result)<=0)
 		$content .= "No Files found..";
 	else{
 
 		$content .= "<div id='file_container'>";
-		while($row = mysql_fetch_array($content_result))
+		while($row = mysqli_fetch_array($content_result))
 			$content .= $this->renderField($row,"moderate");		
 		$content .= "</div>";
 	}
@@ -321,16 +321,16 @@ FORM;
 	else {	
 	$max_size = escape($_POST['file_size']);
 	$query = "UPDATE `share` SET `page_desc` = '$desc', `file_type` = '$ftype', `maxfile_size` = '$max_size' WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$result = mysql_query($query);
-	if(mysql_affected_rows()<0)
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])<0)
 		displayerror("Error in updating the database. Please Try again later");
 	else
 		displayinfo("All settings updated successfully");
 		}
 	}
 	$query = "SELECT * FROM `share` WHERE `page_modulecomponentid` = '$module_ComponentId'";
-	$result = mysql_query($query) or displayerror(mysql_error()." Error in share.lib.php L:322");
-	$result = mysql_fetch_array($result) or displayerror(mysql_error()."Error in share.lib.php L:323");
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))." Error in share.lib.php L:322");
+	$result = mysqli_fetch_array($result) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false))."Error in share.lib.php L:323");
 	$edit_form =<<<EDIT
 <script type="text/javascript" language="javascript">
 function checkForm()
@@ -369,7 +369,7 @@ EDIT;
 	}
 	public function createModule($compId) {
 		$query = "INSERT INTO `share` (`page_modulecomponentid`,`page_desc`,`file_type`,`maxfile_size` )VALUES ('$compId','Coming Soon!!!','doc|docx','2000000')";
-		$result = mysql_query($query) or die(mysql_error() . " share.lib.php L:372");
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . " share.lib.php L:372");
 	}
 
 	public function deleteModule($moduleComponentId) {

--- a/cms/modules/sitemap.lib.php
+++ b/cms/modules/sitemap.lib.php
@@ -41,8 +41,8 @@ class sitemap implements module {
 		}
 		else {
 			$permQuery = 'SELECT `page_module`, `perm_action` FROM `' . MYSQL_DATABASE_PREFIX . 'permissionlist` WHERE `perm_id` = \'' . $permId."'";
-			$permResult = mysql_query($permQuery);
-			$permRow = mysql_fetch_row($permResult);
+			$permResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
+			$permRow = mysqli_fetch_row($permResult);
 			$module = $permRow[0];
 			$action = $permRow[1];
 			$treeData .= $this->getNodeHtml($pageId, $userId, $module, $action, $urlRequestRoot . '/');
@@ -80,10 +80,10 @@ TREEDATA;
 			$htmlOut .= "<li><a href=\"$pagePath\">" . getPageTitle($pageId) . "</a>\n";
 
 			$childrenQuery = 'SELECT `page_id` FROM `' . MYSQL_DATABASE_PREFIX  . 'pages` WHERE `page_parentid` <> `page_id` AND `page_parentid` = \'' . $pageId . '\' AND `page_displayinsitemap` = 1';
-			$childrenResult = mysql_query($childrenQuery);
+			$childrenResult = mysqli_query($GLOBALS["___mysqli_ston"], $childrenQuery);
 
 			$childrenHtml = '';
-			while($childrenRow = mysql_fetch_row($childrenResult)) {
+			while($childrenRow = mysqli_fetch_row($childrenResult)) {
 					$childrenHtml .= $this->getNodeHtml($childrenRow[0], $userId, $module, $action, $pagePath);
 			}
 			if($childrenHtml != '') {

--- a/cms/modules/sqlquery.lib.php
+++ b/cms/modules/sqlquery.lib.php
@@ -34,12 +34,12 @@ class sqlquery implements module {
 
 	public function actionView() {
 		$sqlQueryQuery = 'SELECT `sqlquery_title`, `sqlquery_query` FROM `sqlquery_desc` WHERE `page_modulecomponentid` = \'' . $this->moduleComponentId."'";
-		$sqlQueryResult = mysql_query($sqlQueryQuery);
+		$sqlQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $sqlQueryQuery);
 		if(!$sqlQueryResult) {
 			displayerror('Database error. An unknown error was encountered while trying to load page data.');
 			return '';
 		}
-		$sqlQueryRow = mysql_fetch_row($sqlQueryResult);
+		$sqlQueryRow = mysqli_fetch_row($sqlQueryResult);
 		if(!$sqlQueryRow) {
 			displayerror('Database error. Could not find data for the page requested.');
 			return '';
@@ -86,8 +86,8 @@ class sqlquery implements module {
 			
 			$helptext.="<h2>Tables of Database ".MYSQL_DATABASE."</h2><br/><table id='sqlhelptable' name='sqlhelptable' class='display'><thead></tr><tr><th>Table Name</th><th>Columns Information</th><th>Rows Information</th></tr></thead><tbody>";
 			$query="SHOW TABLES";
-			$res=mysql_query($query);
-			while($row=mysql_fetch_row($res))
+			$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			while($row=mysqli_fetch_row($res))
 			{
 				$helptext .="<tr><td>{$row[0]}</td><td><a href='./+edit&subaction=tablecols&tablename={$row[0]}'>View Columns</a></td><td><a href='./+edit&subaction=tablerows&tablename={$row[0]}'>View Rows</a></td></tr>";
 			}
@@ -100,14 +100,14 @@ class sqlquery implements module {
 			else { displayerror("Table name missing"); return $editPageContent; }
 			
 			$query="SELECT * FROM '$tablename'";
-			$res=mysql_query($query);
-			$numfields=mysql_num_fields($res);
+			$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			$numfields=(($___mysqli_tmp = mysqli_num_fields($res)) ? $___mysqli_tmp : false);
 			$helptext .="<table id='sqlhelptable' name='sqlhelptable' class='display'><thead><tr><th colspan=".$numfields.">Rows of Table $tablename <br/><a href='./+edit&subaction=tablecols&tablename=$tablename'>View Columns</a>  <a href='./+edit&subaction=listalltables'>View All Tables</a></th></tr>";
 			$helptext .="<tr>";
 			
 			for($i=0;$i<$numfields;$i++)
 			{
-				 $name = mysql_field_name($res, $i);
+				 $name = ((($___mysqli_tmp = mysqli_fetch_field_direct($res,  $i)->name) && (!is_null($___mysqli_tmp))) ? $___mysqli_tmp : false);
 				    if (!$name) {
 					displayerror("Field name could not be retrieved");
 					break;
@@ -117,7 +117,7 @@ class sqlquery implements module {
 			$helptext .="</tr></thead><tbody>";
 			
 			
-			while($row=mysql_fetch_row($res))
+			while($row=mysqli_fetch_row($res))
 			{
 				$helptext .="<tr>";
 				for($i=0;$i<$numfields;$i++)
@@ -135,10 +135,10 @@ class sqlquery implements module {
 			$helptext .="<table id='sqlhelptable' name='sqlhelptable' class='display'><thead><tr><th colspan=6>Column Information of Table $tablename <br/><a href='./+edit&subaction=tablerows&tablename=$tablename'>View Rows</a>  <a href='./+edit&subaction=listalltables'>View All Tables</a> </th></tr>";
 			$helptext .="<tr><th>Column Name</th><th>Column Type</th><th>Maximum Length</th><th>Default Value</th><th>Not Null</th><th>Primary Key</th></tr></thead><tbody>";
 			$query="SELECT * FROM '$tablename' LIMIT 1";
-			$res=mysql_query($query);
-			for($i=0;$i<mysql_num_fields($res);$i++)
+			$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			for($i=0;$i<(($___mysqli_tmp = mysqli_num_fields($res)) ? $___mysqli_tmp : false);$i++)
 			{
-				 $meta = mysql_fetch_field($res, $i);
+				 $meta = (((($___mysqli_tmp = mysqli_fetch_field_direct($res, 0)) && is_object($___mysqli_tmp)) ? ( (!is_null($___mysqli_tmp->primary_key = ($___mysqli_tmp->flags & MYSQLI_PRI_KEY_FLAG) ? 1 : 0)) && (!is_null($___mysqli_tmp->multiple_key = ($___mysqli_tmp->flags & MYSQLI_MULTIPLE_KEY_FLAG) ? 1 : 0)) && (!is_null($___mysqli_tmp->unique_key = ($___mysqli_tmp->flags & MYSQLI_UNIQUE_KEY_FLAG) ? 1 : 0)) && (!is_null($___mysqli_tmp->numeric = (int)(($___mysqli_tmp->type <= MYSQLI_TYPE_INT24) || ($___mysqli_tmp->type == MYSQLI_TYPE_YEAR) || ((defined("MYSQLI_TYPE_NEWDECIMAL")) ? ($___mysqli_tmp->type == MYSQLI_TYPE_NEWDECIMAL) : 0)))) && (!is_null($___mysqli_tmp->blob = (int)in_array($___mysqli_tmp->type, array(MYSQLI_TYPE_TINY_BLOB, MYSQLI_TYPE_BLOB, MYSQLI_TYPE_MEDIUM_BLOB, MYSQLI_TYPE_LONG_BLOB)))) && (!is_null($___mysqli_tmp->unsigned = ($___mysqli_tmp->flags & MYSQLI_UNSIGNED_FLAG) ? 1 : 0)) && (!is_null($___mysqli_tmp->zerofill = ($___mysqli_tmp->flags & MYSQLI_ZEROFILL_FLAG) ? 1 : 0)) && (!is_null($___mysqli_type = $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = (($___mysqli_type == MYSQLI_TYPE_STRING) || ($___mysqli_type == MYSQLI_TYPE_VAR_STRING)) ? "type" : "")) &&(!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && in_array($___mysqli_type, array(MYSQLI_TYPE_TINY, MYSQLI_TYPE_SHORT, MYSQLI_TYPE_LONG, MYSQLI_TYPE_LONGLONG, MYSQLI_TYPE_INT24))) ? "int" : $___mysqli_tmp->type)) &&(!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && in_array($___mysqli_type, array(MYSQLI_TYPE_FLOAT, MYSQLI_TYPE_DOUBLE, MYSQLI_TYPE_DECIMAL, ((defined("MYSQLI_TYPE_NEWDECIMAL")) ? constant("MYSQLI_TYPE_NEWDECIMAL") : -1)))) ? "real" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_TIMESTAMP) ? "timestamp" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_YEAR) ? "year" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && (($___mysqli_type == MYSQLI_TYPE_DATE) || ($___mysqli_type == MYSQLI_TYPE_NEWDATE))) ? "date " : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_TIME) ? "time" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_SET) ? "set" : $___mysqli_tmp->type)) &&(!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_ENUM) ? "enum" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_GEOMETRY) ? "geometry" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_DATETIME) ? "datetime" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && (in_array($___mysqli_type, array(MYSQLI_TYPE_TINY_BLOB, MYSQLI_TYPE_BLOB, MYSQLI_TYPE_MEDIUM_BLOB, MYSQLI_TYPE_LONG_BLOB)))) ? "blob" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type && $___mysqli_type == MYSQLI_TYPE_NULL) ? "null" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->type = ("" == $___mysqli_tmp->type) ? "unknown" : $___mysqli_tmp->type)) && (!is_null($___mysqli_tmp->not_null = ($___mysqli_tmp->flags & MYSQLI_NOT_NULL_FLAG) ? 1 : 0)) ) : false ) ? $___mysqli_tmp : false);
 				    if (!$meta) {
 					displayerror("Field information could not be retrieved");
 					break;
@@ -159,12 +159,12 @@ class sqlquery implements module {
 	private function getQueryEditForm($pageTitle = '', $sqlQuery = '', $useParams = false) {
 		if(!$useParams) {
 			$defaultValueQuery = 'SELECT `sqlquery_title`, `sqlquery_query` FROM `sqlquery_desc` WHERE `page_modulecomponentid` = \'' . $this->moduleComponentId."'";
-			$defaultValueResult = mysql_query($defaultValueQuery);
+			$defaultValueResult = mysqli_query($GLOBALS["___mysqli_ston"], $defaultValueQuery);
 			if(!$defaultValueResult) {
 				displayerror('Error. Could not retrieve data for the page requested.');
 				return '';
 			}
-			$defaultValueRow = mysql_fetch_row($defaultValueResult);
+			$defaultValueRow = mysqli_fetch_row($defaultValueResult);
 			if(!$defaultValueRow) {
 				displayerror('Error. Could not retrieve data for the page requested.');
 				return '';
@@ -206,7 +206,7 @@ QUERYEDITFORM;
 
 	private function generatePageData($sqlQuery) {
 		$sqlQuery = $sqlQuery;
-		$result = mysql_query($sqlQuery);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $sqlQuery);
 
 		if(!$result) {
 			return 'Error. The query used to generate this page is invalid. <a href="./+edit">Click here</a> to change the default query.<br />';
@@ -215,13 +215,13 @@ QUERYEDITFORM;
 		$pageContent = '<table>';
 
 		$pageContent .= "<tr>\n";
-		$fieldCount = mysql_num_fields($result);
+		$fieldCount = (($___mysqli_tmp = mysqli_num_fields($result)) ? $___mysqli_tmp : false);
 		for($i = 0; $i < $fieldCount; $i++) {
-			$pageContent .= "<th>" . mysql_field_name($result, $i) . "</th>";
+			$pageContent .= "<th>" . ((($___mysqli_tmp = mysqli_fetch_field_direct($result,  $i)->name) && (!is_null($___mysqli_tmp))) ? $___mysqli_tmp : false) . "</th>";
 		}
 		$pageContent .= "</tr>\n";
 
-		while($resultrow = mysql_fetch_row($result))
+		while($resultrow = mysqli_fetch_row($result))
 			$pageContent .= "<tr><td>" . implode('</td><td>', $resultrow) . "</td></tr>\n";
 		$pageContent .= "</table>\n";
 
@@ -230,7 +230,7 @@ QUERYEDITFORM;
 
 	private function saveQueryEditForm($pageTitle, $sqlQuery) {
 		$updateQuery = "UPDATE `sqlquery_desc` SET `sqlquery_title` = '$pageTitle', `sqlquery_query` = '$sqlQuery' WHERE `page_modulecomponentid` = '{$this->moduleComponentId}'";
-		$updateResult = mysql_query($updateQuery);
+		$updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 		if(!$updateResult) {
 			displayerror('SQL Error. Could not update database settings.');
 			return false;
@@ -249,7 +249,7 @@ QUERYEDITFORM;
         public function createModule($compId) {
 
                 $insertQuery = "INSERT INTO `sqlquery_desc`(`page_modulecomponentid`, `sqlquery_title`, `sqlquery_query`) VALUES('$compId', 'New Query', 'SELECT * FROM `mytable` WHERE 1')";
-                $insertResult = mysql_query($insertQuery);
+                $insertResult = mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery);
         }
 	public function moduleAdmin(){
 		return "This is the SQL Query module administration page. Options coming up soon!!!";

--- a/cms/openid/Services/Yadis/XRDS.php
+++ b/cms/openid/Services/Yadis/XRDS.php
@@ -292,7 +292,7 @@ class Services_Yadis_XRDS {
         $services = $this->parser->evalXPath('xrd:Service', $this->xrdNode);
 
         foreach ($services as $node) {
-            $s =& new Services_Yadis_Service();
+            $s = new Services_Yadis_Service();
             $s->element = $node;
             $s->parser =& $this->parser;
 

--- a/cms/pagesettings.lib.php
+++ b/cms/pagesettings.lib.php
@@ -25,10 +25,10 @@ if(!defined('__PRAGYAN_CMS'))
  */
 function getCreatablePageTypes($userid, $pageid) {
 	$moduleQuery = "SELECT `page_module` FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist` WHERE `perm_action` = 'create'";
-	$moduleResult = mysql_query($moduleQuery);
+	$moduleResult = mysqli_query($GLOBALS["___mysqli_ston"], $moduleQuery);
 	$creatableModules = array();
 
-	while ($moduleResultRow = mysql_fetch_row($moduleResult))
+	while ($moduleResultRow = mysqli_fetch_row($moduleResult))
 		if (getPermissions($userid, $pageid, "create", $moduleResultRow[0]))
 			$creatableModules[] = $moduleResultRow[0];
 	return $creatableModules;
@@ -44,13 +44,13 @@ function getSettingsForm($pageId, $userId) {
 	$pageId=escape($pageId);
 	$page_query = "SELECT `page_name`, `page_title`, `page_displaymenu`, `page_displayinmenu`, `page_displaysiblingmenu` , `page_module`, `page_displaypageheading`,`page_template`,`page_modulecomponentid`, `page_menutype`, `page_menudepth` , `page_displayinsitemap` ,`page_displayicon`" .
 	"FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id`='" . $pageId."'";
-	$page_result = mysql_query($page_query);
-	$page_values = mysql_fetch_assoc($page_result);
+	$page_result = mysqli_query($GLOBALS["___mysqli_ston"], $page_query);
+	$page_values = mysqli_fetch_assoc($page_result);
 	
 	
 	
 	$chkquery="SELECT `value` FROM `".MYSQL_DATABASE_PREFIX."global` WHERE `attribute`='allow_pagespecific_template'";
-	$row=mysql_fetch_row(mysql_query($chkquery));
+	$row=mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], $chkquery));
  	$allow_pagespecific_templates=$row[0]; // 0 if disabled, 1 if enabled
 	
 	if (!$page_values) {
@@ -73,16 +73,16 @@ function getSettingsForm($pageId, $userId) {
 	$displayicon = ($page_values['page_displayicon'] == 1 ? 'checked="checked" ' : '');
 	$templates = getAvailableTemplates();
 	$page_query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_parentid` = '$pageId' AND `page_parentid` != `page_id` ORDER BY `page_menurank` ASC  ";
-	$page_result = mysql_query($page_query) or die(mysql_error());
+	$page_result = mysqli_query($GLOBALS["___mysqli_ston"], $page_query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 	$childList ="";
 	$isLeaf = false;
-	if(mysql_num_rows($page_result)==0){
+	if(mysqli_num_rows($page_result)==0){
 	    $isLeaf = true;
 		$childList = "There are no child pages associated with this page.";
 	}
 	else
 		$childList = "<table border=\"1\" width=\"100%\"><tr><th>Child Pages</th><th>Display in menu bar</th><th>Display in Sitemap</th><th>Display Icon in menu</th><th>Move page up</th><th>Move page down</th><th>Delete</th></tr>";
-	while ($page_result_row = mysql_fetch_assoc($page_result)) {
+	while ($page_result_row = mysqli_fetch_assoc($page_result)) {
 		$childList .= '<tr><td><a href="./'.$page_result_row['page_name'].'+settings">' . $page_result_row['page_title'] . '</a></td>' .
 				'<td><input type="checkbox" name="menubarshowchildren[]" id="'.$page_result_row['page_name'].'" value="' . $page_result_row['page_name'] . '" ' . ($page_result_row['page_displayinmenu'] == 1 ? 'checked="yes" ' : '') . '/></td>'.
 				'<td><input type="checkbox" name="sitemapshowchildren[]" id="'.$page_result_row['page_name'].'" value="' . $page_result_row['page_name'] . '" ' . ($page_result_row['page_displayinsitemap'] == 1 ? 'checked="yes" ' : '') . '/></td>'.
@@ -91,7 +91,7 @@ function getSettingsForm($pageId, $userId) {
 				'<td align="center"><input type="submit" name="moveDn" onclick="this.form.action+=\''.$page_result_row['page_name'].'\'" value="Move Down" /></td>' .
 				'<td align="center"><input type="submit" name="deletePage" onclick="javascript:if(checkDelete(this,\''.$page_result_row['page_name'].'\')){this.form.action+=\''.$page_result_row['page_name'].'\'}"  value="Delete" /></td></tr>';
 	}
-	if(!mysql_num_rows($page_result)==0)
+	if(!mysqli_num_rows($page_result)==0)
 		$childList .= "</table>";
 
 /* PAGE INHERITED INFO */
@@ -342,13 +342,13 @@ MOVECOPY;
 /*TAGS TEXT BEGINS */
 	
 	$pageTagsQuery="SELECT `tag_text`, `tag_id` FROM `". MYSQL_DATABASE_PREFIX ."pagetags` WHERE `page_id` = '{$pageId}' ORDER BY `tag_text`;";
-	$pageTagsResult = mysql_query($pageTagsQuery);
-	if(!$pageTagsResult) { displayerror(mysql_error());}//Error handling
-	if(mysql_num_rows($pageTagsResult)){//Checking if the page has tags
+	$pageTagsResult = mysqli_query($GLOBALS["___mysqli_ston"], $pageTagsQuery);
+	if(!$pageTagsResult) { displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));}//Error handling
+	if(mysqli_num_rows($pageTagsResult)){//Checking if the page has tags
 		$pageTags="<table><tr>";
 		$pageTags.="<th> Tag Name </th>";
 		$pageTags.="<th> Delete </th></tr>";
-		while($pagetagrow = mysql_fetch_assoc($pageTagsResult)) {
+		while($pagetagrow = mysqli_fetch_assoc($pageTagsResult)) {
 			$pageTags.="<tr>";
 			$pageTags.="<td>".$pagetagrow['tag_text']."</td>";
 			$pageTags.="<td><a href='./+settings&subaction=tags&delTag={$pagetagrow[tag_id]}'>".$ICONS['Delete']['small']."</a></td>";
@@ -360,9 +360,9 @@ MOVECOPY;
 		$pageTags="There are no tags yet.";
 	}
 	$allTagsQuery="SELECT DISTINCT `tag_text` FROM `". MYSQL_DATABASE_PREFIX ."pagetags` ORDER BY `tag_text;";
-	$allTagsResult = mysql_query($allTagsQuery);
-	if(!$allTagsResult) { displayerror(mysql_error());}//Error handling
-	while($alltagrow = mysql_fetch_assoc($allTagsResult)) {
+	$allTagsResult = mysqli_query($GLOBALS["___mysqli_ston"], $allTagsQuery);
+	if(!$allTagsResult) { displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));}//Error handling
+	while($alltagrow = mysqli_fetch_assoc($allTagsResult)) {
 		$allTags.="<option value='{$alltagrow[tag_text]}'>"; //dataset option for newTag input
 	}
 	
@@ -400,7 +400,7 @@ MOVECOPY;
 	}
 	if($pageType == "External"){
 	$linkquery = "SELECT `page_extlink` FROM `" . MYSQL_DATABASE_PREFIX . "external` WHERE page_modulecomponentid = ".$linkmcid;
-	$linkres = mysql_fetch_row(mysql_query($linkquery));
+	$linkres = mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], $linkquery));
 	$link = $linkres[0];
 	$changeLink = "<tr><td>Externally Linked To:</td><td><input type=text name='exlink' id='link' value=$link></td></tr>"; 
 	}
@@ -408,7 +408,7 @@ MOVECOPY;
 	else if($menuType=="multidepth") $multidepthtype="selected";
 	else $completetype="selected";
 	
-	$row = mysql_fetch_array(mysql_query("SELECT `allowComments` FROM `article_content` WHERE `page_modulecomponentid` = '{$modulecomponentid}'"));
+	$row = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `allowComments` FROM `article_content` WHERE `page_modulecomponentid` = '{$modulecomponentid}'"));
 	$allowComments = $row['allowComments'] == 1 ? 'checked="checked" ' : '';
 	
 	$formDisplay =<<<FORMDISPLAY
@@ -629,8 +629,8 @@ function updateSettings($pageId, $userId, $pageName, $pageTitle, $showInMenu, $s
 		if(preg_match('/^[a-zA-Z][\_a-zA-Z0-9]*$/', $pageName)) {
 			$query = "SELECT `page_id` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_name` = '$pageName' AND `page_id` != '$pageId' AND `page_parentid` = " .
 								"(SELECT `page_parentid` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '$pageId')";
-			$result = mysql_query($query);
-			if (mysql_num_rows($result) > 0) {
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if (mysqli_num_rows($result) > 0) {
 				$errors = 'A page with the same name already exists in the folder.<br />';
 			} else {
 				$updates[] = "`page_name` = '$pageName'";
@@ -673,26 +673,26 @@ function updateSettings($pageId, $userId, $pageName, $pageTitle, $showInMenu, $s
 	}
 	if (count($updates) > 0) {
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET ' . join($updates, ', ') . " WHERE `page_id` = '$pageId';";
-		mysql_query($updateQuery);
+		mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 	}
 
 	if (is_array($visibleChildList) && count($visibleChildList) > 0) {
 		$visibleChildList = "'" . join($visibleChildList, "', '") . "'";
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayinmenu` = 1 WHERE ' .
 		"`page_name` IN ($visibleChildList) AND `page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
-		mysql_query($updateQuery);
+		mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayinmenu` = 0 WHERE ' .
 		"`page_name` NOT IN ($visibleChildList) AND `page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
 	} else {
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayinmenu` = 0 WHERE ' .
 		"`page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
 	}
-	mysql_query($updateQuery);
+	mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 	if (is_array($visiblesChildList) && count($visiblesChildList) > 0) {
 		$visiblesChildList = "'" . join($visiblesChildList, "', '") . "'";
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayinsitemap` = 1 WHERE ' .
 		"`page_name` IN ($visiblesChildList) AND `page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
-		mysql_query($updateQuery);
+		mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayinsitemap` = 0 WHERE ' .
 		"`page_name` NOT IN ($visiblesChildList) AND `page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
 	} else {
@@ -705,7 +705,7 @@ function updateSettings($pageId, $userId, $pageName, $pageTitle, $showInMenu, $s
 		$visibleiChildList = "'" . join($visibleiChildList, "', '") . "'";
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayicon` = 1 WHERE ' .
 		"`page_name` IN ($visibleiChildList) AND `page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
-		mysql_query($updateQuery);
+		mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_displayicon` = 0 WHERE ' .
 		"`page_name` NOT IN ($visibleiChildList) AND `page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
 	} else {
@@ -713,7 +713,7 @@ function updateSettings($pageId, $userId, $pageName, $pageTitle, $showInMenu, $s
 		"`page_parentid` = '$pageId' AND `page_parentid` != `page_id`";
 	}
 	}
-	mysql_query($updateQuery);
+	mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 
 	return $errors;
 }
@@ -721,12 +721,12 @@ function setChildTemplateFromParentID($parentId,$page_template)
 {
 	$parentId=escape($parentId);
 	$query= "SELECT `page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='".$parentId."' AND NOT `page_id`=0";
-	$result=mysql_query($query);
-	while($row=mysql_fetch_row($result))
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	while($row=mysqli_fetch_row($result))
 	{
 		$childPageId=$row[0];
 		$query="UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_template`='$page_template' WHERE `page_id`='$childPageId'";
-		mysql_query($query);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		setChildTemplateFromParentID($childPageId,$page_template);
 	}
 }
@@ -738,7 +738,7 @@ function setChildMenuStyleFromParentID($parentId,$menu_type,$showMenuBar,$showSi
 	$bshowMenuBar=($showMenuBar==true)?1:0;
 	$bshowSiblingMenu=($showSiblingMenu==true)?1:0;
 	$query= "SELECT `page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='".$parentId."' AND NOT `page_id`=0";
-	$result=mysql_query($query);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$menu="";
 	$sibling="";
 	if($menu_depth!=NULL)
@@ -747,11 +747,11 @@ function setChildMenuStyleFromParentID($parentId,$menu_type,$showMenuBar,$showSi
 	if(is_bool($showSiblingMenu))
 		$sibling=", `page_displaysiblingmenu`='$bshowSiblingMenu' ";
 	
-	while($row=mysql_fetch_row($result))
+	while($row=mysqli_fetch_row($result))
 	{
 		$childPageId=$row[0];
 		$query="UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_displaymenu`='$bshowMenuBar', `page_menutype`='$menu_type' $sibling  $menu WHERE `page_id`='$childPageId'";
-		mysql_query($query);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		
 		setChildMenuStyleFromParentID($childPageId,$menu_type,$showMenuBar,$showSiblingMenu,$menu_depth);
 	}
@@ -760,12 +760,12 @@ function setChildIconFromParentID($parentId,$displayicon)
 {if($displayicon=='')$displayicon=0;
 	$parentId=escape($parentId);
 	$query= "SELECT `page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='".$parentId."' AND NOT `page_id`=0";
-	$result=mysql_query($query);
-	while($row=mysql_fetch_row($result))
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	while($row=mysqli_fetch_row($result))
 	{
 		$childPageId=$row[0];
 		$query="UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_displayicon`='$displayicon' WHERE `page_id`='$childPageId'";
-		mysql_query($query);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		setChildIconFromParentID($childPageId,$displayicon);
 	}
 }
@@ -783,7 +783,7 @@ function pagesettings($pageId, $userId) {
 	$userId=escape($userId);
 	global $sourceFolder;
 	$chkquery="SELECT `value` FROM `".MYSQL_DATABASE_PREFIX."global` WHERE `attribute`='allow_pagespecific_template'";
-	$row=mysql_fetch_row(mysql_query($chkquery));
+	$row=mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], $chkquery));
  	$allow_pagespecific_templates=$row[0]; // 0 if disabled, 1 if enabled
  	
 	require_once($sourceFolder."/tree.lib.php");
@@ -840,13 +840,13 @@ function pagesettings($pageId, $userId) {
 				$_POST['pagename']=isset($_POST['pagename'])?$_POST['pagename']:"";
 				$_POST['pagetitle']=isset($_POST['pagetitle'])?$_POST['pagetitle']:"";
 				$var = (isset($_POST['allowComments'])?1:0);
-				$modulecomponentid = mysql_fetch_array(mysql_query("SELECT `page_modulecomponentid` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '{$pageId}'"));
+				$modulecomponentid = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `page_modulecomponentid` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '{$pageId}'"));
 				$modulecomponentid = $modulecomponentid['page_modulecomponentid'];
-				mysql_query("UPDATE `article_content` SET `allowComments` = $var WHERE `page_modulecomponentid` = '{$modulecomponentid}'");
+				mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `article_content` SET `allowComments` = $var WHERE `page_modulecomponentid` = '{$modulecomponentid}'");
 				if(isset($_POST['exlink']))
-					mysql_query("UPDATE `" . MYSQL_DATABASE_PREFIX . "external` SET `page_extlink` = '{$exlink}' WHERE `page_modulecomponentid`= '{$modulecomponentid}'");
+					mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `" . MYSQL_DATABASE_PREFIX . "external` SET `page_extlink` = '{$exlink}' WHERE `page_modulecomponentid`= '{$modulecomponentid}'");
 				else if(isset($_POST['link']))				
-					mysql_query("UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_modulecomponentid` = '{$linkpageid}' WHERE `page_id`= '$pageId'");
+					mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_modulecomponentid` = '{$linkpageid}' WHERE `page_id`= '$pageId'");
 				$updateErrors = updateSettings($pageId, $userId, escape($_POST['pagename']), escape($_POST['pagetitle']), isset($_POST['showinmenu']), isset($_POST['showheading']), isset($_POST['showmenubar']), isset($_POST['showsiblingmenu']), $visibleChildList,$visiblesChildList,$visibleiChildList, $page_template, $template_propogate, escape($_POST['menutype']),isset($_POST['menudepth'])?escape($_POST['menudepth']):NULL,$menu_propogate,isset($_POST['showinsitemap']),isset($_POST['displayicon']),$icon_propogate);
 
 				
@@ -876,30 +876,30 @@ function pagesettings($pageId, $userId) {
 				}
 				$childPageName=escape($_GET['pageName']);
 				$query="SELECT `page_menurank`,`page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='$pageId' AND `page_name`='$childPageName' AND `page_id` != '$pageId' ORDER BY `page_menurank` $sortOrder LIMIT 0,1 ";
-				$result=mysql_query($query);
-				$temp=mysql_fetch_assoc($result);
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$temp=mysqli_fetch_assoc($result);
 				$childPageId=$temp['page_id'];
 				$query="SELECT `page_menurank`,`page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`=$pageId AND `page_menurank` $comparison(SELECT `page_menurank` FROM  `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='$pageId' AND `page_name`='$childPageName') AND `page_id` != '$childPageId'  AND `page_parentid` != `page_id` ORDER BY `page_menurank` $sortOrder LIMIT 0,1 ";
-				$result=mysql_query($query) or displayinfo(mysql_error());
-				if(mysql_num_rows($result)==0){
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayinfo(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if(mysqli_num_rows($result)==0){
 					displayerror("You cannot move up/down the first/last page in menu");
 
 				}
-				$tempTarg=mysql_fetch_assoc($result);
+				$tempTarg=mysqli_fetch_assoc($result);
 				$query="SELECT `page_menurank`,`page_parentid` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id`='$childPageId'";
-				$result=mysql_query($query);
-				$tempSrc=mysql_fetch_assoc($result);
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				$tempSrc=mysqli_fetch_assoc($result);
 				if(($tempTarg['page_menurank'])==($tempSrc['page_menurank']))
 				{
 					$query="UPDATE `".MYSQL_DATABASE_PREFIX."pages` SET `page_menurank` = `page_id` WHERE `page_parentid`='$tempSrc[page_parentid]'";
-		 			mysql_query($query);
+		 			mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		 			displayinfo("Error in menu rank corrected. Please reorder the pages");
 				}
 				else{
 				$query="UPDATE `".MYSQL_DATABASE_PREFIX."pages`  SET `page_menurank` ='$tempSrc[page_menurank]' WHERE `page_id` = '$tempTarg[page_id]' ";
-				mysql_query($query);
+				mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				$query="UPDATE `".MYSQL_DATABASE_PREFIX."pages`  SET `page_menurank` ='$tempTarg[page_menurank]' WHERE `page_id` = '$childPageId' ";
-				mysql_query($query);
+				mysqli_query($GLOBALS["___mysqli_ston"], $query);
 				}
 			}
 			if(isset($_POST['deletePage']))
@@ -908,8 +908,8 @@ function pagesettings($pageId, $userId) {
 				if(isset($_GET['pageName']) && $_GET['pageName']!="") {
 					$childPageName=escape($_GET['pageName']);
 					$query="SELECT `page_id` FROM  `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='$pageId' AND `page_name`='$childPageName'";
-					$result=mysql_query($query);
-					$temp=mysql_fetch_assoc($result);
+					$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+					$temp=mysqli_fetch_assoc($result);
 					$childPageId=$temp['page_id'];
 					if(deletePage($childPageId,$userId))
 						displayinfo("Page deleted successfully.");
@@ -951,16 +951,16 @@ function pagesettings($pageId, $userId) {
 				else $page_template=escape($_POST['page_template']);
 
 				$maxquery="SELECT MAX( page_id ) AS MAX FROM ".MYSQL_DATABASE_PREFIX."pages";
-				$maxqueryresult = mysql_query($maxquery);
-				$maxqueryrow = mysql_fetch_array($maxqueryresult);
+				$maxqueryresult = mysqli_query($GLOBALS["___mysqli_ston"], $maxquery);
+				$maxqueryrow = mysqli_fetch_array($maxqueryresult);
 				$maxpageid = $maxqueryrow[0]+1;
 
 				$menutypequery="SELECT `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu` FROM ".MYSQL_DATABASE_PREFIX."pages WHERE page_id=".$pageId;
-				$menutyperesult = mysql_query($menutypequery);
-				$menutyperow = mysql_fetch_array($menutyperesult);
+				$menutyperesult = mysqli_query($GLOBALS["___mysqli_ston"], $menutypequery);
+				$menutyperow = mysqli_fetch_array($menutyperesult);
 				$alreadyexistquery="SELECT page_name FROM ".MYSQL_DATABASE_PREFIX."pages WHERE page_parentid='$pageId' AND page_name='".escape($_POST['childpagename'])."'";
-				$alreadyexistqueryresult = mysql_query($alreadyexistquery);
-				$alreadyexistquerynumrows = mysql_num_rows($alreadyexistqueryresult);
+				$alreadyexistqueryresult = mysqli_query($GLOBALS["___mysqli_ston"], $alreadyexistquery);
+				$alreadyexistquerynumrows = mysqli_num_rows($alreadyexistqueryresult);
 				$childPageName = str_replace(' ', '_', escape(strtolower($_POST['childpagename'])));
 				$childPageTitle = escape($_POST['childpagename']);
 				if(!preg_match('/^[a-z][\_a-z0-9]*$/',  $childPageName))
@@ -970,8 +970,8 @@ function pagesettings($pageId, $userId) {
 				elseif($_POST['childpagetype']=="menu") {
 					$menuquery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id` ,`page_name` ,`page_parentid` ,`page_title` ,`page_module` ,`page_modulecomponentid` , `page_template`, `page_menurank`, `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu`) " .
 							"VALUES ('$maxpageid', '".$childPageName."', '$pageId', '".$childPageTitle."', '".escape($_POST['childpagetype'])."', '0', '$page_template', '$maxpageid', '$menutyperow[0]','$menutyperow[1]','$menutyperow[2]','$menutyperow[3]','$menutyperow[4]')";
-					mysql_query($menuquery);
-						if (mysql_affected_rows() != 1)
+					mysqli_query($GLOBALS["___mysqli_ston"], $menuquery);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 							displayerror( 'Unable to create a new page');
 						else displayinfo("Menu successfully created! <a href='./$childPageName+settings'>Click here</a> to go to its page-settings and start creating links in the menu.");
 				}
@@ -985,16 +985,16 @@ function pagesettings($pageId, $userId) {
 					$parentId = parseUrlReal(escape($_POST['childpagelink']), $pageIdArray);
 					$linkquery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id` ,`page_name` ,`page_parentid` ,`page_title` ,`page_module` ,`page_modulecomponentid` , `page_template`, `page_menurank`, `page_openinnewtab`, `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu`) " .
 							"VALUES ('$maxpageid', '$childPageName', '$pageId', '$childPageTitle', '".escape($_POST['childpagetype'])."', '$parentId', '$page_template', '$maxpageid', '0', '$menutyperow[0]','$menutyperow[1]','$menutyperow[2]','$menutyperow[3]','$menutyperow[4]')";
-					mysql_query($linkquery);
-						if (mysql_affected_rows() != 1)
+					mysqli_query($GLOBALS["___mysqli_ston"], $linkquery);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 							displayerror( 'Unable to create a new page');
 					}
 					if ($_POST['linkselect']=="New Tab"){
 					$parentId = parseUrlReal(escape($_POST['childpagelink']), $pageIdArray);
 					$linkquery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id` ,`page_name` ,`page_parentid` ,`page_title` ,`page_module` ,`page_modulecomponentid` , `page_template`, `page_menurank`, `page_openinnewtab`, `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu`) " .
 							"VALUES ('$maxpageid', '$childPageName', '$pageId', '$childPageTitle', '".escape($_POST['childpagetype'])."', '$parentId', '$page_template', '$maxpageid', '1', '$menutyperow[0]','$menutyperow[1]','$menutyperow[2]','$menutyperow[3]','$menutyperow[4]')";
-					mysql_query($linkquery);
-						if (mysql_affected_rows() != 1)
+					mysqli_query($GLOBALS["___mysqli_ston"], $linkquery);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 							displayerror( 'Unable to create a new page');
 					}
 					}
@@ -1003,12 +1003,12 @@ function pagesettings($pageId, $userId) {
 				}
 				elseif($_POST['childpagetype']=="external") {
 					$extquery="SELECT MAX( page_modulecomponentid ) AS MAX FROM ".MYSQL_DATABASE_PREFIX."external";
-					$extqueryresult = mysql_query($extquery);
-					$extqueryrow = mysql_fetch_array($extqueryresult);
+					$extqueryresult = mysqli_query($GLOBALS["___mysqli_ston"], $extquery);
+					$extqueryrow = mysqli_fetch_array($extqueryresult);
 					$extpageid = $extqueryrow[0]+1;
 					$query="INSERT INTO `".MYSQL_DATABASE_PREFIX."external` (`page_modulecomponentid`,`page_extlink`) " .
 							"VALUES('$extpageid','".escape($_POST['externallink'])."')";
-					if(!($result = mysql_query($query))) {
+					if(!($result = mysqli_query($GLOBALS["___mysqli_ston"], $query))) {
 						displayerror("Unable to create an external link.");
 						return false;
 					}
@@ -1018,8 +1018,8 @@ function pagesettings($pageId, $userId) {
 						$linkquery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id` ,`page_name` ,`page_parentid` ,`page_title` ,`page_module` ,`page_modulecomponentid` , `page_template`, `page_menurank`,`page_openinnewtab`, `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu`) " .
 							"VALUES ('$maxpageid', '".escape($_POST['childpagename'])."', '$pageId', '".escape(ucfirst(escape($_POST['childpagename'])))."', '".escape($_POST['childpagetype'])."', '$extpageid', '$page_template' ,'$maxpageid','1', '$menutyperow[0]','$menutyperow[1]','$menutyperow[2]','$menutyperow[3]','$menutyperow[4]')";
 						
-						mysql_query($linkquery);
-						if (mysql_affected_rows() != 1)
+						mysqli_query($GLOBALS["___mysqli_ston"], $linkquery);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 						{
 							displayerror( 'Unable to create a new page');
 							return false;
@@ -1029,8 +1029,8 @@ function pagesettings($pageId, $userId) {
 						
 					$linkquery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id` ,`page_name` ,`page_parentid` ,`page_title` ,`page_module` ,`page_modulecomponentid` , `page_template`, `page_menurank`,`page_openinnewtab`, `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu`) " .
 						"VALUES ('$maxpageid', '".escape($_POST['childpagename'])."', '$pageId', '".escape(ucfirst(escape($_POST['childpagename'])))."', '".escape($_POST['childpagetype'])."', '$extpageid', '$page_template' ,'$maxpageid','0', '$menutyperow[0]','$menutyperow[1]','$menutyperow[2]','$menutyperow[3]','$menutyperow[4]')";
-					mysql_query($linkquery);
-					if (mysql_affected_rows() != 1)
+					mysqli_query($GLOBALS["___mysqli_ston"], $linkquery);
+					if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 						{
 						displayerror( 'Unable to create a new page');
 						return false;
@@ -1048,8 +1048,8 @@ function pagesettings($pageId, $userId) {
 					$page->createModule($newId);
 					$createquery = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id` ,`page_name` ,`page_parentid` ,`page_title` ,`page_module` ,`page_modulecomponentid` , `page_template`, `page_menurank`, `page_menutype`,`page_menudepth`,`page_displaysiblingmenu`,`page_displayicon`,`page_displayinmenu`) " .
 							"VALUES ('$maxpageid', '$childPageName', '$pageId', '$childPageTitle', '".escape($_POST['childpagetype'])."', '$newId', '$page_template', '$maxpageid', '$menutyperow[0]','$menutyperow[1]','$menutyperow[2]','$menutyperow[3]','$menutyperow[4]')";
-					mysql_query($createquery);
-						if (mysql_affected_rows() != 1)
+					mysqli_query($GLOBALS["___mysqli_ston"], $createquery);
+						if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 							displayerror( 'Unable to create a new page.');
 				}
 			}
@@ -1061,15 +1061,15 @@ function pagesettings($pageId, $userId) {
 		}
 		else if($_GET['subaction'] == 'tags') {
 			if(isset($_GET['delTag']) && $_GET['delTag']!=""){ //DELETING THE TAG
-				mysql_query("DELETE FROM `". MYSQL_DATABASE_PREFIX ."pagetags` WHERE `tag_id` = '".escape($_GET['delTag'])."'");
-				if(mysql_affected_rows())
+				mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `". MYSQL_DATABASE_PREFIX ."pagetags` WHERE `tag_id` = '".escape($_GET['delTag'])."'");
+				if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]))
 					displayinfo("Tag deleted!");
 				else
 					displayerror("Error in deleting tag.");
 			}
 			if(isset($_POST[newTag]) && $_POST[newTag]!=""){ //INSERTING THE TAG
 				$newTagQuery="INSERT INTO `". MYSQL_DATABASE_PREFIX ."pagetags` (`tag_id`, `page_id`, `tag_text`) VALUES (NULL, ".$pageId.", '".escape($_POST[newTag])."');";
-				$newTagResult=mysql_query($newTagQuery);
+				$newTagResult=mysqli_query($GLOBALS["___mysqli_ston"], $newTagQuery);
 				if($newTagResult)
 					displayinfo("Tag added!");
 				else
@@ -1093,12 +1093,12 @@ function pagesettings($pageId, $userId) {
  */
 function copyInstance($moduleType,$fromId,$toId) {
 	$error = false;
-	if($result = mysql_query("SELECT `module_tables` FROM `".MYSQL_DATABASE_PREFIX."modules` WHERE `module_name` = '{$moduleType}'")) {
-		$row = mysql_fetch_assoc($result);
+	if($result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `module_tables` FROM `".MYSQL_DATABASE_PREFIX."modules` WHERE `module_name` = '{$moduleType}'")) {
+		$row = mysqli_fetch_assoc($result);
 		$tables = explode(";",$row['module_tables']);
 		foreach($tables as $table) {
-			$result = mysql_query("SELECT * FROM `{$table}` WHERE `page_modulecomponentid` = '{$fromId}'");
-			$row = mysql_fetch_assoc($result);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `{$table}` WHERE `page_modulecomponentid` = '{$fromId}'");
+			$row = mysqli_fetch_assoc($result);
 			if($row) {
 				$prefix = "INSERT INTO `{$table}`";
 				$cols = array(); $vals = array();
@@ -1111,9 +1111,9 @@ function copyInstance($moduleType,$fromId,$toId) {
 				}
 				$prefix .= "(`".implode("`,`",$cols)."`)";
 				$query = $prefix." VALUES ('".implode("','",$vals)."')";
-				if(!mysql_query($query))
+				if(!mysqli_query($GLOBALS["___mysqli_ston"], $query))
 					$error = true;
-				while($row = mysql_fetch_assoc($result)) {
+				while($row = mysqli_fetch_assoc($result)) {
 					$vals = array();
 					foreach($row as $key => $val) {
 						if($key!='page_modulecomponentid')
@@ -1122,7 +1122,7 @@ function copyInstance($moduleType,$fromId,$toId) {
 							$vals[] = $toId;
 					}
 					$query = $prefix." VALUES ('".implode("','",$vals)."')";
-					if(!mysql_query($query))
+					if(!mysqli_query($GLOBALS["___mysqli_ston"], $query))
 						$error = true;
 				}
 			}
@@ -1141,11 +1141,11 @@ function copyInstance($moduleType,$fromId,$toId) {
  * @returns boolean indicating deletion status
  */
 function deleteInstance($moduleType,$page_modulecomponentid) {
-	if($result = mysql_query("SELECT `module_tables` FROM `".MYSQL_DATABASE_PREFIX."modules` WHERE `module_name` = '{$moduleType}'")) {
-		$row = mysql_fetch_assoc($result);
+	if($result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `module_tables` FROM `".MYSQL_DATABASE_PREFIX."modules` WHERE `module_name` = '{$moduleType}'")) {
+		$row = mysqli_fetch_assoc($result);
 		$tables = explode(";",$row['module_tables']);
 		foreach($tables as $table) {
-			if(!mysql_query("DELETE FROM `{$table}` WHERE `page_modulecomponentid` = '{$page_modulecomponentid}'"))
+			if(!mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `{$table}` WHERE `page_modulecomponentid` = '{$page_modulecomponentid}'"))
 				return false;
 		}
 	} else
@@ -1159,10 +1159,10 @@ function deleteInstance($moduleType,$page_modulecomponentid) {
  * @returns a new module component id for the given module type
  */
 function createInstance($moduleType) {
-	$result = mysql_query("SELECT MAX(page_modulecomponentid) as MAX FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_module` = '{$moduleType}'");
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT MAX(page_modulecomponentid) as MAX FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_module` = '{$moduleType}'");
 	if(!$result)
 		return 0;
-	$row = mysql_fetch_assoc($result);
+	$row = mysqli_fetch_assoc($result);
 	return (int)$row['MAX']+1;
 }
 
@@ -1178,9 +1178,9 @@ function createInstance($moduleType) {
 
 function deletePage($pageId,$userId){
  	$query="SELECT `page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='$pageId' AND `page_id`!=`page_parentid` ";
- 	$result=mysql_query($query);
+ 	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
  	$deleteAll = true;
- 	while($temp=mysql_fetch_assoc($result))
+ 	while($temp=mysqli_fetch_assoc($result))
  	{
 
   		if(getPermissions($userId,$pageId,"settings"))
@@ -1208,8 +1208,8 @@ function deletePage($pageId,$userId){
 			}
 			else {
 				$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."external` WHERE `page_modulecomponentid`='".$pageInfo['page_modulecomponentid']."'";
-				mysql_query($query);
-				if (mysql_affected_rows()>0) $deleted=true;
+				mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				if (mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0) $deleted=true;
 				else {
 					$deleted=false;
 					displayerror("There was an error in deleting the external link");
@@ -1220,8 +1220,8 @@ function deletePage($pageId,$userId){
 		//query to delete page row itself
 		if($deleted) {
 			$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id`='$pageId'";
-			mysql_query($query);
-			if (mysql_affected_rows()>0) return true;
+			mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if (mysqli_affected_rows($GLOBALS["___mysqli_ston"])>0) return true;
 			else return false;
 		}
 		else return false;
@@ -1254,8 +1254,8 @@ function move_page($userId,$pageId, $parentId, $pagetitle,$pagename,$deleteorigi
  */
 	//var_dump($str);
 	$query = "SELECT `page_id` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid` = '$parentId' AND `page_name` = '$pagename'";
-	$result = mysql_query($query);
-	if(mysql_num_rows($result) > 0)
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(mysqli_num_rows($result) > 0)
 		return "Error: There exists a page with the same name in the destination path.";
 	$parentInfo = getPageInfo($parentId);
 	if(!getPermissions($userId, $parentId, "settings"))
@@ -1273,8 +1273,8 @@ function move_page($userId,$pageId, $parentId, $pagetitle,$pagename,$deleteorigi
 	if ($deleteoriginalentry == true) {
 		if ($pageId != 0) {
 			$query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_parentid` = '" . $parentId . "' , `page_title` = '" . $pagetitle . "' , `page_name` = '" . $pagename . "' WHERE `page_id` ='$pageId' ;";
-			$result = mysql_query($query);
-				if (mysql_affected_rows() != 1)
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+				if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) != 1)
 					return 'Unable to perform the required action';
 			global $urlRequestRoot;
 			header("location:".$urlRequestRoot.getPagePath($pageId)."+settings&displayinfo=".rawurlencode("The page has been successfully moved."));
@@ -1313,37 +1313,37 @@ function copyPage($userId,$pageId,$parentId, $pagetitle,$pagename,$recursive) {
 	}
 	if($moduleType=="external"){
 		$extquery="SELECT MAX( page_modulecomponentid ) AS MAX FROM ".MYSQL_DATABASE_PREFIX."external";
-		$extqueryresult = mysql_query($extquery);
-		$extqueryrow = mysql_fetch_array($extqueryresult);
+		$extqueryresult = mysqli_query($GLOBALS["___mysqli_ston"], $extquery);
+		$extqueryrow = mysqli_fetch_array($extqueryresult);
 		$extpageid = $extqueryrow[0]+1;
 		$linkquery="SELECT page_extlink FROM ".MYSQL_DATABASE_PREFIX."external WHERE page_modulecomponentid='".$pageInfo['page_modulecomponentid']."'";
-		$linkqueryresult = mysql_query($linkquery);
-		$linkqueryrow = mysql_fetch_array($linkqueryresult);
+		$linkqueryresult = mysqli_query($GLOBALS["___mysqli_ston"], $linkquery);
+		$linkqueryrow = mysqli_fetch_array($linkqueryresult);
 		$link = $linkqueryrow[0];
 
 		$query="INSERT INTO `".MYSQL_DATABASE_PREFIX."external` (`page_modulecomponentid`,`page_extlink`) " .
 				"VALUES('$extpageid','$link')";
-		if(!($result = mysql_query($query))) {
+		if(!($result = mysqli_query($GLOBALS["___mysqli_ston"], $query))) {
 			displayerror("Unable to copy the page.");
 			return false;
 		}
 	}
 
 	$maxquery="SELECT MAX( page_id ) AS MAX FROM ".MYSQL_DATABASE_PREFIX."pages";
-	$maxqueryresult = mysql_query($maxquery);
-	$maxqueryrow = mysql_fetch_array($maxqueryresult);
+	$maxqueryresult = mysqli_query($GLOBALS["___mysqli_ston"], $maxquery);
+	$maxqueryrow = mysqli_fetch_array($maxqueryresult);
 	$maxpageid = $maxqueryrow[0]+1;
 
 	$query = "INSERT INTO `".MYSQL_DATABASE_PREFIX."pages` (`page_id`,`page_name`,`page_title`,`page_parentid`,`page_module`,`page_modulecomponentid`,`page_displayinmenu`, `page_displaymenu`, `page_displaysiblingmenu`,`page_menurank`) " .
 			"VALUES('$maxpageid','$pagename','$pagetitle','$parentId','{$pageInfo['page_module']}','$newmodulecomponentid','{$pageInfo['page_displayinmenu']}','{$pageInfo['page_displaymenu']}','{$pageInfo['page_displaysiblingmenu']}','$maxpageid')";
-	if(!($result = mysql_query($query))) {
+	if(!($result = mysqli_query($GLOBALS["___mysqli_ston"], $query))) {
 		displayerror("Unable to copy the page.");
 		return false;
 	}
 	if($recursive) {
 		$childrenquery="SELECT `page_id`,`page_name`,`page_title` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_parentid`='$pageId' ";
-		$childrenresult=mysql_query($childrenquery);
-		while($temp=mysql_fetch_assoc($childrenresult))
+		$childrenresult=mysqli_query($GLOBALS["___mysqli_ston"], $childrenquery);
+		while($temp=mysqli_fetch_assoc($childrenresult))
 		{
 	 		copyPage($userId,$temp['page_id'],$maxpageid, $temp['page_title'],$temp['page_name'],$recursive);
 		}
@@ -1358,31 +1358,31 @@ function updatePageInheritedInfo($pageId, $inheritedInfo) {
 	if($inheritedPageId == $pageId) {
 		if($inheritedInfo == '') {
 			$deleteQuery = 'DELETE FROM `' . MYSQL_DATABASE_PREFIX . 'inheritedinfo` WHERE `page_inheritedinfoid` = (SELECT `page_inheritedinfoid` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_id` = \'' . $pageId . '\')';
-			mysql_query($deleteQuery);
+			mysqli_query($GLOBALS["___mysqli_ston"], $deleteQuery);
 			$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_inheritedinfoid` = -1 WHERE `page_id` = \'' . $pageId."'";
-			if(!mysql_query($updateQuery))
+			if(!mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery))
 				displayerror('Could not remove the current page\'s inherited information. Database error.');
 		}
 		else {
 			$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'inheritedinfo` SET `page_inheritedinfocontent` = \'' . $inheritedInfo . '\' WHERE `page_inheritedinfoid` = (SELECT `page_inheritedinfoid` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_id` = \'' . $pageId . '\')';
-			if(!mysql_query($updateQuery))
+			if(!mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery))
 				displayerror('Could not update the current page\'s inherited information. Database error.');
 		}
 	}
 	else if($inheritedInfo != '' && $inheritedInfo != $prevInheritedInfo) {
 		/// Original inherited info came from a different page
 		$newIdQuery = 'SELECT MAX(`page_inheritedinfoid`) FROM `' . MYSQL_DATABASE_PREFIX . 'inheritedinfo`';
-		$newIdResult = mysql_query($newIdQuery);
-		$newIdRow = mysql_fetch_row($newIdResult);
+		$newIdResult = mysqli_query($GLOBALS["___mysqli_ston"], $newIdQuery);
+		$newIdRow = mysqli_fetch_row($newIdResult);
 		$newId = 1;
 		if(!is_null($newIdRow[0]))
 			$newId = $newIdRow[0] + 1;
 
 		$insertQuery = 'INSERT INTO `' . MYSQL_DATABASE_PREFIX . 'inheritedinfo`(`page_inheritedinfoid`, `page_inheritedinfocontent`) VALUES (\'' . $newId . '\', \'' . $inheritedInfo . '\')';
-		if(!mysql_query($insertQuery))
+		if(!mysqli_query($GLOBALS["___mysqli_ston"], $insertQuery))
 			displayerror('Could not add inherited information to the current page. Database error.');
 		$updateQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'pages` SET `page_inheritedinfoid` = \'' . $newId . '\' WHERE `page_id` = \'' . $pageId."'";
-		if(!mysql_query($updateQuery))
+		if(!mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery))
 			displayerror('Could not add inherited information to the current page. Database error.');
 	}
 }
@@ -1395,13 +1395,13 @@ function getPageInheritedInfo($pageId, &$inheritedInfoBuf) {
 
 	do {
 		$inheritedInfoIdQuery = 'SELECT `page_inheritedinfoid`, `page_parentid` FROM `' . MYSQL_DATABASE_PREFIX . 'pages` WHERE `page_id` = \'' . $curPageId."'";
-		$inheritedInfoIdResult = mysql_query($inheritedInfoIdQuery);
-		if(!$inheritedInfoIdResult) echo mysql_error() . '<br />' . $inheritedInfoIdQuery . '<br />';
-		$inheritedInfoIdRow = mysql_fetch_row($inheritedInfoIdResult);
+		$inheritedInfoIdResult = mysqli_query($GLOBALS["___mysqli_ston"], $inheritedInfoIdQuery);
+		if(!$inheritedInfoIdResult) echo ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '<br />' . $inheritedInfoIdQuery . '<br />';
+		$inheritedInfoIdRow = mysqli_fetch_row($inheritedInfoIdResult);
 		if(!is_null($inheritedInfoIdRow[0]) && $inheritedInfoIdRow[0] >= 0) {
 			$inheritedInfoQuery = 'SELECT `page_inheritedinfocontent` FROM `' . MYSQL_DATABASE_PREFIX . 'inheritedinfo` WHERE `page_inheritedinfoid` = \'' . $inheritedInfoIdRow[0]."'";
-			$inheritedInfoResult = mysql_query($inheritedInfoQuery);
-			$inheritedInfoBuf = mysql_fetch_row($inheritedInfoResult);
+			$inheritedInfoResult = mysqli_query($GLOBALS["___mysqli_ston"], $inheritedInfoQuery);
+			$inheritedInfoBuf = mysqli_fetch_row($inheritedInfoResult);
 			$inheritedInfoBuf = $inheritedInfoBuf[0];
 			return $curPageId;
 		}

--- a/cms/parseurl.lib.php
+++ b/cms/parseurl.lib.php
@@ -44,12 +44,12 @@ if(!defined('__PRAGYAN_CMS'))
 		if($urlPieces[$i] != "") {
 			$selectString.=", node".$i.".page_id AS pageid".$i;
 			$fromString.=", `$pagesTable` as node".$i;
-			$whereString.=" and node".$i.".page_parentid = IF(node".($i - 1).".page_module = 'link', node".($i - 1).".page_modulecomponentid, node".($i - 1).".page_id) and node".$i.".page_name='".mysql_real_escape_string($urlPieces[$i])."'";
+			$whereString.=" and node".$i.".page_parentid = IF(node".($i - 1).".page_module = 'link', node".($i - 1).".page_modulecomponentid, node".($i - 1).".page_id) and node".$i.".page_name='".((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $urlPieces[$i]) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""))."'";
 	  }
 	}
   	$pageid_query = $selectString.$fromString.$whereString;
-	if($pageid_result = mysql_query($pageid_query)) {
-		if(!($pageids = mysql_fetch_row($pageid_result))) {
+	if($pageid_result = mysqli_query($GLOBALS["___mysqli_ston"], $pageid_query)) {
+		if(!($pageids = mysqli_fetch_row($pageid_result))) {
 			displayerror("The requested page does not exist.");
 			return false;
 		}
@@ -57,7 +57,7 @@ if(!defined('__PRAGYAN_CMS'))
 	return $pageids[count($pageids) - 1];
 }
 
- /* The following fails to work in Mysql 4.1.10 : theyaga's mysql account*/
+ /* The following fails to work in mysql 4.1.10 : theyaga's mysql account*/
  /* (The AS node0 gives an error)
 function parseUrlReal($url, &$pageIdArray) {
 	$url = trim($url, '/');

--- a/cms/permission.lib.php
+++ b/cms/permission.lib.php
@@ -68,26 +68,26 @@ function getAllPermissionsOnPage($pagepath, $modifiableGroups, $grantableActions
 	$groupNames = array('0' => 'Everyone', '1' => 'Logged In Users'); ///< Associative array relative group ids to group names
 	$groupCount = 2;
 	$groupsQuery = 'SELECT `group_id`, `group_name` FROM `' . MYSQL_DATABASE_PREFIX . 'groups`';
-	$groupsResult = mysql_query($groupsQuery);
-	while($groupsRow = mysql_fetch_row($groupsResult)) {
+	$groupsResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupsQuery);
+	while($groupsRow = mysqli_fetch_row($groupsResult)) {
 		$groupIds[] = $groupsRow[0];
 		$groupNames[$groupsRow[0]] = $groupsRow[1];
 		$groupCount++;
 	}
-	mysql_free_result($groupsResult);
+	((mysqli_free_result($groupsResult) || (is_object($groupsResult) && (get_class($groupsResult) == "mysqli_result"))) ? true : false);
 
 	/// Retrieve Ids and Names of all users
 	$userIds = array(0);
 	$userNames = array('0' => 'Anonymous');
 	$userCount = 1;
 	$usersQuery = 'SELECT `user_id`, `user_name` FROM `' . MYSQL_DATABASE_PREFIX . 'users`';
-	$usersResult = mysql_query($usersQuery);
-	while($usersRow = mysql_fetch_row($usersResult)) {
+	$usersResult = mysqli_query($GLOBALS["___mysqli_ston"], $usersQuery);
+	while($usersRow = mysqli_fetch_row($usersResult)) {
 		$userNames[$usersRow[0]] = $usersRow[1];
 		$userIds[] = $usersRow[0];
 		$userCount++;
 	}
-	mysql_free_result($usersResult);
+	((mysqli_free_result($usersResult) || (is_object($usersResult) && (get_class($usersResult) == "mysqli_result"))) ? true : false);
 
 	/// $permList: Array of the form
 	///		$permList[$permId] = array($moduleName, $actionName, $actionDescription)
@@ -122,9 +122,9 @@ function getAllPermissionsOnPage($pagepath, $modifiableGroups, $grantableActions
 	             "FROM $userPermTable, $permListTable WHERE `page_id` IN (" . join($pagepath, ', ') . ") AND " .
 	             "$userPermTable.`perm_id` IN (" . join($permIds, ', ') .
 	             ") AND $userPermTable.`perm_id` = $permListTable.`perm_id`";
-	$permResult = mysql_query($permQuery);
+	$permResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
 
-	while($permRow = mysql_fetch_assoc($permResult)) {
+	while($permRow = mysqli_fetch_assoc($permResult)) {
 		$pageId = $permRow['page_id'];
 		$permId = $permRow['perm_id'];
 		$usergroupId = $permRow['usergroup_id'];
@@ -210,12 +210,12 @@ function getAllPermissionsOnPage($pagepath, $modifiableGroups, $grantableActions
 	$userGroups = array();
 	$groupsQuery = 'SELECT `user_id`, `group_id` FROM `'.MYSQL_DATABASE_PREFIX.'usergroup` ' .
 	               'ORDER BY `user_id`';
-	$groupsResult = mysql_query($groupsQuery);
-	while($groupsRow = mysql_fetch_row($groupsResult)) {
+	$groupsResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupsQuery);
+	while($groupsRow = mysqli_fetch_row($groupsResult)) {
 		if(!isset($userGroups[$groupsRow[0]])) $userGroups[$groupsRow[0]] = array();
 		$userGroups[$groupsRow[0]][] = $groupsRow[1];
 	}
-	mysql_free_result($groupsResult);
+	((mysqli_free_result($groupsResult) || (is_object($groupsResult) && (get_class($groupsResult) == "mysqli_result"))) ? true : false);
 
 
 	/// Calculate permissions as far as groups are concerned.
@@ -301,9 +301,9 @@ RET;
 function getPermissionId($module, $action) {
 	$permQuery = "SELECT `perm_id` FROM `".MYSQL_DATABASE_PREFIX."permissionlist` WHERE " .
 								"`page_module` = '$module' AND `perm_action` = '$action'";
-	$permResult = mysql_query($permQuery);
+	$permResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
 
-	if($permResult && ($permResultRow = mysql_fetch_array($permResult))) {
+	if($permResult && ($permResultRow = mysqli_fetch_array($permResult))) {
 		return $permResultRow[0];
 	}
 	else {
@@ -333,8 +333,8 @@ function getPagePermission(array $pagePath, $usergroupid, $action, $module, $per
 	$permQuery .= "$userpermTable.usergroup_id = $usergroupid AND $permissionlistTable.page_module = '$module' AND ";
 	$permQuery .= "$permissionlistTable.perm_action = '$action' AND $permissionlistTable.perm_id = $userpermTable.perm_id";
 	$permissionsArray = array ();
-	if ($permQueryResult = mysql_query($permQuery)) {
-		while ($permQueryResultRow = mysql_fetch_assoc($permQueryResult)) {
+	if ($permQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery)) {
+		while ($permQueryResultRow = mysqli_fetch_assoc($permQueryResult)) {
 			$permissionsArray[$permQueryResultRow['page_id']] = $permQueryResultRow['perm_permission'] == 'Y' ? true : false;
 		}
 	}
@@ -374,8 +374,8 @@ function getPermissions($userid, $pageid, $action, $module="") {
 		return true;
 	if($module=="") {
 		$query = "SELECT 1 FROM `".MYSQL_DATABASE_PREFIX."permissionlist` WHERE page_module=\"page\" AND perm_action=\"$action\"";
-		$result = mysql_query($query);
-		if(mysql_num_rows($result)>=1)
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_num_rows($result)>=1)
 			$module = 'page';
 		else
 			$module = getEffectivePageModule($pageid);
@@ -438,10 +438,10 @@ function determineGrantTargetId(&$targettype) {
 	}
 
 	if($targetId == -1 && $idQuery != '') {
-		$idResult = mysql_query($idQuery);
+		$idResult = mysqli_query($GLOBALS["___mysqli_ston"], $idQuery);
 
 		if($idResult) {
-			if($idResultRow = mysql_fetch_row($idResult)) {
+			if($idResultRow = mysqli_fetch_row($idResult)) {
 				$targetId = $idResultRow[0];
 			}
 		}
@@ -470,21 +470,21 @@ function grantPermissions($userid, $pageid) {
 		$perm = escape($_GET['perm']);
 		$flag = true;
 		if($perm == 'Y' || $perm == 'N') {
-			if($permission = mysql_fetch_array(mysql_query("SELECT `perm_permission` FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'"))) {
+			if($permission = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `perm_permission` FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'"))) {
 				if($permission['perm_permission'] != $perm) {
-					mysql_query("UPDATE `" . MYSQL_DATABASE_PREFIX . "userpageperm` SET `perm_permission` = '{$perm}' WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'");
-					if(mysql_affected_rows() == 0)
+					mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE `" . MYSQL_DATABASE_PREFIX . "userpageperm` SET `perm_permission` = '{$perm}' WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'");
+					if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) == 0)
 						$flag = false;
 				}
 			} else {
-				mysql_query("INSERT `" . MYSQL_DATABASE_PREFIX . "userpageperm`(`perm_type`, `page_id`, `usergroup_id`, `perm_id`, `perm_permission`) VALUES('$permtype','$pageid','$usergroupid','$permid','$perm')");
-				if(mysql_affected_rows() == 0)
+				mysqli_query($GLOBALS["___mysqli_ston"], "INSERT `" . MYSQL_DATABASE_PREFIX . "userpageperm`(`perm_type`, `page_id`, `usergroup_id`, `perm_id`, `perm_permission`) VALUES('$permtype','$pageid','$usergroupid','$permid','$perm')");
+				if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) == 0)
 					$flag = false;
 			}
 		} else {
-			if($permission = mysql_fetch_array(mysql_query("SELECT `perm_permission` FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'"))) {
-				mysql_query("DELETE FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'");
-				if(mysql_affected_rows() == 0)
+			if($permission = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `perm_permission` FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'"))) {
+				mysqli_query($GLOBALS["___mysqli_ston"], "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `perm_type` = '{$permtype}' AND `page_id` = '{$pageid}' AND `usergroup_id` = '{$usergroupid}' AND `perm_id` = '{$permid}'");
+				if(mysqli_affected_rows($GLOBALS["___mysqli_ston"]) == 0)
 					$flag = false;
 			}
 		}
@@ -500,7 +500,7 @@ function grantPermissions($userid, $pageid) {
 	if(isset($_GET['doaction']) && $_GET['doaction'] == 'getpermvars' && isset($_GET['pageid'])) {
 		global $cmsFolder,$urlRequestRoot, $templateFolder;
 		$pageid = escape($_GET['pageid']);
-		if(mysql_fetch_array(mysql_query("SELECT `page_name` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '{$pageid}'"))) {
+		if(mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `page_name` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '{$pageid}'"))) {
 		$pagepath = array();
 		parseUrlDereferenced($pageid, $pagepath);
 		$pageid = $pagepath[count($pagepath) - 1];
@@ -751,8 +751,8 @@ RET;
 
 function getPerms($pageId, $groupuser, $yesno) {
 	$ret = "";
-	$result = mysql_query("SELECT `usergroup_id`, `perm_id` FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `page_id` = '{$pageId}' AND `perm_type` = '{$groupuser}' AND `perm_permission` = '{$yesno}'");
-	while($row = mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `usergroup_id`, `perm_id` FROM `" . MYSQL_DATABASE_PREFIX . "userpageperm` WHERE `page_id` = '{$pageId}' AND `perm_type` = '{$groupuser}' AND `perm_permission` = '{$yesno}'");
+	while($row = mysqli_fetch_array($result))
 		$perms[$row['usergroup_id']][] = $row['perm_id'];
 	if(isset($perms)) 
 		foreach($perms as $group => $values) {
@@ -768,8 +768,8 @@ function getPerms($pageId, $groupuser, $yesno) {
 
 function customGetAllUsers() {
 	$ret = "";
-	$result = mysql_query("SELECT `user_email`, `user_name`, `user_id` FROM `" . MYSQL_DATABASE_PREFIX . "users`");
-	while($row = mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_email`, `user_name`, `user_id` FROM `" . MYSQL_DATABASE_PREFIX . "users`");
+	while($row = mysqli_fetch_array($result))
 		$ret .= "'{$row['user_id']}' : '{$row['user_name']} &lt;{$row['user_email']}&gt;', ";
 	$ret = rtrim($ret,", ");
 	return $ret;	
@@ -777,8 +777,8 @@ function customGetAllUsers() {
 
 function customGetGroups($priority) {
 	$ret = "'0' : 'Everyone', '1' : 'Logged in Users', ";
-	$result = mysql_query("SELECT `group_name`,`group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_priority` < '{$priority}'");
-	while($row = mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `group_name`,`group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_priority` < '{$priority}'");
+	while($row = mysqli_fetch_array($result))
 		$ret .= "'{$row['group_id']}' : '{$row['group_name']}', ";
 	$ret = rtrim($ret,", ");
 	return $ret;
@@ -786,8 +786,8 @@ function customGetGroups($priority) {
 
 function filterByPriority($priority,$groups) {
 	$return = array();
-	$result = mysql_query("SELECT `group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_priority` < '{$priority}'");
-	while($row = mysql_fetch_assoc($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `group_id` FROM `" . MYSQL_DATABASE_PREFIX . "groups` WHERE `group_priority` < '{$priority}'");
+	while($row = mysqli_fetch_assoc($result))
 		foreach($groups as $group)
 			if($group == $row['group_id'])
 				$return[] = $group;
@@ -796,8 +796,8 @@ function filterByPriority($priority,$groups) {
 
 function getAllPermissions() {
 	$ret = "";
-	$result = mysql_query("SELECT `perm_id`,`page_module`,`perm_action` FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist`");
-	while($row = mysql_fetch_array($result))
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `perm_id`,`page_module`,`perm_action` FROM `" . MYSQL_DATABASE_PREFIX . "permissionlist`");
+	while($row = mysqli_fetch_array($result))
 		$ret .= "'{$row['perm_id']}' : '{$row['page_module']} - {$row['perm_action']}', ";
 	$ret = rtrim($ret,", ");
 	return $ret;
@@ -824,9 +824,9 @@ function formatPermissions($perms) {
 function unsetPagePermission($usergroupid, $pageid, $action, $module, $permtype = 'group') {
 	$permQuery = "SELECT `perm_id` FROM `".MYSQL_DATABASE_PREFIX."permissionlist` WHERE " .
 							 "`perm_action` = '$action' AND `page_module` = '$module'";
-	$permQueryResult = mysql_query($permQuery);
+	$permQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
 
-	if(!$permQueryResult || !($permQueryResultRow = mysql_fetch_assoc($permQueryResult))) {
+	if(!$permQueryResult || !($permQueryResultRow = mysqli_fetch_assoc($permQueryResult))) {
 		return false;
 	}
 
@@ -835,7 +835,7 @@ function unsetPagePermission($usergroupid, $pageid, $action, $module, $permtype 
 	$removeQuery = "DELETE FROM `".MYSQL_DATABASE_PREFIX."userpageperm` " .
 								 "WHERE `usergroup_id` = '$usergroupid' AND `page_id` = '$pageid' AND `perm_id` = '$permid' AND " .
 								 "`perm_type` = '$permtype' LIMIT 1";
-	if(mysql_query($removeQuery)) {
+	if(mysqli_query($GLOBALS["___mysqli_ston"], $removeQuery)) {
 		return true;
 	}
 	else {
@@ -858,9 +858,9 @@ function unsetPagePermission($usergroupid, $pageid, $action, $module, $permtype 
 function setPagePermission($usergroupid, $pageid, $action, $module, $permission, $permtype = 'group') {
 	$permQuery = "SELECT `perm_id` FROM `".MYSQL_DATABASE_PREFIX."permissionlist` WHERE " .
 								 "`perm_action` = '$action' AND `page_module` = '$module'";
-	$permQueryResult = mysql_query($permQuery);
+	$permQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
 
-	if(!$permQueryResult || !($permQueryResultRow = mysql_fetch_assoc($permQueryResult))) {
+	if(!$permQueryResult || !($permQueryResultRow = mysqli_fetch_assoc($permQueryResult))) {
 		return false;
 	}
 
@@ -871,9 +871,9 @@ function setPagePermission($usergroupid, $pageid, $action, $module, $permission,
 	$permQuery = "SELECT `perm_permission` FROM `".MYSQL_DATABASE_PREFIX."userpageperm` WHERE " .
 							 "`usergroup_id` = '$usergroupid' AND `page_id` = '$pageid' AND `perm_id` = '$permid' AND " .
 							 "`perm_type` = '$permtype'";
-	$permQueryResult = mysql_query($permQuery);
+	$permQueryResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
 
-	if($permQueryResultRow = mysql_fetch_assoc($permQueryResult)) {
+	if($permQueryResultRow = mysqli_fetch_assoc($permQueryResult)) {
 		if($permission != $permQueryResultRow['perm_permission']) {
 			$updateQuery = "UPDATE `".MYSQL_DATABASE_PREFIX."userpageperm` SET `perm_permission` = '$permission' " .
 										 "WHERE `usergroup_id` = '$usergroupid' AND `page_id` = '$pageid' AND `perm_id` = '$permid' AND " .
@@ -886,7 +886,7 @@ function setPagePermission($usergroupid, $pageid, $action, $module, $permission,
 	}
 
 	if($updateQuery != '') {
-		$updateResult = mysql_query($updateQuery);
+		$updateResult = mysqli_query($GLOBALS["___mysqli_ston"], $updateQuery);
 		if(!$updateResult) {
 			return false;
 		}
@@ -947,9 +947,9 @@ function getModifiableGroups($userId, $maxPriorityGroup, $ordering = 'asc') {
 			"(SELECT `group_priority` FROM `$groupsTable` WHERE `group_id` = $maxPriorityGroup) " .
 			"ORDER BY `$groupsTable`.`group_priority` $ordering";
 	*/
-	$groupsResult = mysql_query($groupsQuery) or die($groupsQuery . '<br />' . mysql_error());
+	$groupsResult = mysqli_query($GLOBALS["___mysqli_ston"], $groupsQuery) or die($groupsQuery . '<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 
-	while($groupsRow = mysql_fetch_assoc($groupsResult)) {
+	while($groupsRow = mysqli_fetch_assoc($groupsResult)) {
 		$modifiableGroups[] = $groupsRow;
 	}
 
@@ -965,7 +965,7 @@ function getModifiableGroups($userId, $maxPriorityGroup, $ordering = 'asc') {
 function getGroupPermissions($groupids, $pagepath, $userid = -1) {
 	// For a given user, return the set of modules and actions he has at that level
 	$permQuery = "SELECT `perm_id`, `perm_action`, `page_module`, `perm_description` FROM `".MYSQL_DATABASE_PREFIX."permissionlist`";
-	$permResult = mysql_query($permQuery);
+	$permResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery);
 	if(!$permResult) {
 		return '';
 	}
@@ -973,7 +973,7 @@ function getGroupPermissions($groupids, $pagepath, $userid = -1) {
 	$permList = array();
 	$groupCount = count($groupids);
 
-	while($permResultRow = mysql_fetch_assoc($permResult)) {
+	while($permResultRow = mysqli_fetch_assoc($permResult)) {
 		$moduleName = $permResultRow['page_module'];
 		$actionName = $permResultRow['perm_action'];
 		$actionDescription = $permResultRow['perm_description'];

--- a/cms/profile.lib.php
+++ b/cms/profile.lib.php
@@ -18,8 +18,8 @@ if(!defined('__PRAGYAN_CMS'))
 
 function isProfileFormCaptchaEnabled() {
 	$captchaQuery = 'SELECT `form_usecaptcha` FROM `form_desc` WHERE `page_modulecomponentid` = 0';
-	$captchaResult = mysql_query($captchaQuery);
-	$captchaRow = mysql_fetch_row($captchaResult);
+	$captchaResult = mysqli_query($GLOBALS["___mysqli_ston"], $captchaQuery);
+	$captchaRow = mysqli_fetch_row($captchaResult);
 	if($captchaRow && isset($captchaRow[0])) {
 		return $captchaRow[0] == 1;
 	}
@@ -68,12 +68,12 @@ function profile($userId, $forEditRegistrant = false) {
 		
 		/// Retrieve existing information
 	$profileQuery = 'SELECT `user_name`, `user_fullname`, `user_password` FROM `' . MYSQL_DATABASE_PREFIX . 'users` WHERE `user_id` = \'' . $userId."'";
-	$profileResult = mysql_query($profileQuery);
+	$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
 	if(!$profileResult) {
-		displayerror('An error occurred while trying to process your request.<br />' . mysql_error() . '<br />' . $profileQuery);
+		displayerror('An error occurred while trying to process your request.<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '<br />' . $profileQuery);
 		return '';
 	}
-	$profileRow = mysql_fetch_row($profileResult);
+	$profileRow = mysqli_fetch_row($profileResult);
 	$newUserName = $userName = $profileRow[0];
 	$newUserFullname = $userFullname = $profileRow[1];
 	$userPassword = $profileRow[2];
@@ -122,7 +122,7 @@ function profile($userId, $forEditRegistrant = false) {
 
 			if(count($updates) > 0) {
 				$profileQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'users` SET ' . join($updates, ', ') . " WHERE `user_id` = '$userId'";
-				$profileResult = mysql_query($profileQuery);
+				$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
 				if(!$profileResult) {
 					displayerror('An error was encountered while attempting to process your request.');
 					$errors = true;
@@ -180,8 +180,8 @@ function getProfileForm($userId, $userName, $userFullname, $forEditRegistrant = 
 	$captchaValidation = '';
 	if(!$forEditRegistrant) {
 		$captchaQuery = 'SELECT `form_usecaptcha` FROM `form_desc` WHERE `page_modulecomponentid` = 0';
-		$captchaResult = mysql_query($captchaQuery);
-		$captchaRow = mysql_fetch_row($captchaResult);
+		$captchaResult = mysqli_query($GLOBALS["___mysqli_ston"], $captchaQuery);
+		$captchaRow = mysqli_fetch_row($captchaResult);
 		if(isset($captchaRow[0]) && $captchaRow[0] == 1) {
 			$captchaValidation = getCaptchaHtml();
 		} 
@@ -445,19 +445,19 @@ function getProfileRegistrantsList($showEditButtons = false) {
 function getProfileForms($userId) {
 	global $ICONS,$urlRequestRoot;
 	$query = "SELECT DISTINCT `page_modulecomponentid` FROM `form_elementdata` WHERE `user_id` = '$userId' AND `page_modulecomponentid` != '0'";
-	$result2 = mysql_query($query);
+	$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$regforms='';
-	if(mysql_num_rows($result2)>0)
+	if(mysqli_num_rows($result2)>0)
 		{
 			$regforms ="<fieldset style=\"padding: 8px\"><legend>{$ICONS['User Groups']['small']}Forms I Have Registered To</legend>";
 			$regforms .= '<ol>';
-			while($result = mysql_fetch_row($result2)) {
+			while($result = mysqli_fetch_row($result2)) {
 				if($result[0]!=0){
 					$formPath = getPagePath(getPageIdFromModuleComponentId('form', $result[0]));
 					$formPathLink = $urlRequestRoot . $formPath;
 					$query1 = "SELECT `form_heading` FROM `form_desc` WHERE `page_modulecomponentid` ='". $result[0]."'";		
-					$result1 = mysql_query($query1);
-					$result1 = mysql_fetch_row($result1);
+					$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+					$result1 = mysqli_fetch_row($result1);
 					$regforms .= '<li> <a href="'.$formPathLink.'">'.$result1[0].'</a></li>';
 				}
 		}
@@ -469,8 +469,8 @@ function getFormDeadlines($userId) {
 	global $ICONS,$urlRequestRoot;
 	$regforms="";
 	$query = "SELECT * FROM `".MYSQL_DATABASE_PREFIX."global`";
-	$result = mysql_query($query);
-	while($res = mysql_fetch_row($result)) {
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	while($res = mysqli_fetch_row($result)) {
 		if($res[0] == 'deadline_notify')
 		{
 			$deadline = $res[1] * 24 * 3600;
@@ -478,17 +478,17 @@ function getFormDeadlines($userId) {
 			
 	}	
 	$query = "SELECT DISTINCT `page_modulecomponentid` FROM `form_desc` WHERE HOUR(TIMEDIFF(`form_expirydatetime`,NOW( )))*3600+MINUTE(TIMEDIFF(`form_expirydatetime`,NOW( )))*60+SECOND(TIMEDIFF(`form_expirydatetime`,NOW( )))*60 <= '".$deadline."'";
-	$result2 = mysql_query($query);
-	if(mysql_num_rows($result2)>0){
+	$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(mysqli_num_rows($result2)>0){
 			$regforms ="<fieldset style=\"padding: 8px\"><legend>{$ICONS['User Groups']['small']}Forms Nearing Deadline</legend>";
 			$regforms .= '<ol>';
-			while($result = mysql_fetch_row($result2)) {
+			while($result = mysqli_fetch_row($result2)) {
 				if($result[0]!=0){
 				$formPath = getPagePath(getPageIdFromModuleComponentId('form', $result[0]));
 				$formPathLink = $urlRequestRoot . $formPath;
 				$query1 = "SELECT `form_heading` FROM `form_desc` WHERE `page_modulecomponentid` =". $result[0];		
-				$result1 = mysql_query($query1);
-				$result1 = mysql_fetch_row($result1);
+				$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+				$result1 = mysqli_fetch_row($result1);
 				$regforms .= '<li> <a href="'.$formPathLink.'">'.$result1[0].'</a></li>';
 				}
 			}

--- a/cms/registration.lib.php
+++ b/cms/registration.lib.php
@@ -165,11 +165,11 @@ FORM;
 	elseif (isset ($_POST['resend_key_email'])) {
 		$email = escape($_POST['resend_key_email']);
 		$query = "SELECT * FROM  `" . MYSQL_DATABASE_PREFIX . "users`  WHERE `user_email`='$email' ";
-		$result = mysql_query($query) or displayerror(mysql_error() . "registration L:131");
-		if (!mysql_num_rows($result))
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "registration L:131");
+		if (!mysqli_num_rows($result))
 			displayinfo("This email-id has not yet been registered. Kindly <a href=\"./+login&subaction=register\">register</a>.");
 		else {
-			$temp = mysql_fetch_assoc($result);
+			$temp = mysqli_fetch_assoc($result);
 			if ($temp['user_activated'] == 1)
 				displayinfo("E-mail $email has already been verified.<a href=\"./+login\"> Login</a> <a href=\"./+login&subaction=resetPasswd\">Forgot Password?</a>");
 			else {
@@ -198,15 +198,15 @@ FORM;
 	elseif (isset ($_GET['key'])) {
 		$emailId = escape($_GET['verify']);
 		$query = "SELECT * FROM  `" . MYSQL_DATABASE_PREFIX . "users`  WHERE `user_email`='{$emailId}'";
-		$result = mysql_query($query) or displayerror(mysql_error() . "registration L:76");
-		$temp = mysql_fetch_assoc($result);
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "registration L:76");
+		$temp = mysqli_fetch_assoc($result);
 		if ($temp['user_activated'] == 1)
 			displayinfo("E-mail ".escape($_GET[verify])." has already been verified");
 		else {
 			if ($_GET['key'] == getVerificationKey($_GET['verify'], $temp['user_password'], $temp['user_regdate'])) {
 				$query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "users` SET `user_activated`=1  WHERE `user_email`='$emailId'";
-				mysql_query($query) or die(mysql_error());
-				if (mysql_affected_rows() > 0)
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
+				if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) > 0)
 					displayinfo("Your e-mail ".escape($_GET[verify])." has been verified. Now you can fill your profile information by clicking <a href=\"./+profile\">here</a> or by clicking on the preferences link in the action bar any time you are logged in.");
 				else
 					displayerror("Verification error for ".escape($_GET[verify]).". Please contact administrator");
@@ -249,8 +249,8 @@ FORM;
 			return getRegistrationForm();
 			}
 		$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_email`='" . $umail . "'";
-		$result = mysql_query($query) or displayerror(mysql_error() . "in registration L:115");
-		if (mysql_num_rows($result)) {
+		$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "in registration L:115");
+		if (mysqli_num_rows($result)) {
 			displaywarning("Email already exists in database. Please use a different e-mail.");
 			return getRegistrationForm();
 		} else {
@@ -258,15 +258,15 @@ FORM;
 			$query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "users` " .
 					"(`user_name`, `user_email`, `user_fullname`, `user_password`, `user_activated`) " .
 					"VALUES ('".escape(htmlentities($_POST['user_name']))."', '".escape(htmlentities($_POST['user_email']))."', '".escape(htmlentities($_POST['user_fullname']))."', '$passwd', ".ACTIVATE_USER_ON_REG.")";
-			$result = mysql_query($query);
+			$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			$query1 = "SELECT `user_id` FROM `". MYSQL_DATABASE_PREFIX . "users` WHERE `user_email` ='".escape($_POST['user_email'])."' LIMIT 1";
-			$result1 = mysql_query($query1);
-			$result1 = mysql_fetch_array($result1);
+			$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query1);
+			$result1 = mysqli_fetch_array($result1);
 			$form_result = submitRegistrationForm(0, $result1[0], true, true); 
 			if(!$form_result)
 				{
 					$query1 = "DELETE FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE `user_id` = '".$result1[0]."'";
-					$result = mysql_query($query1); 
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query1); 
 					return getRegistrationForm();
 				}			
 			if ($result)
@@ -279,9 +279,9 @@ FORM;
 			{
 				$email = $umail;
 				$query = "SELECT * FROM  `" . MYSQL_DATABASE_PREFIX . "users`  WHERE `user_email`='$email' ";
-				$result = mysql_query($query) or displayerror(mysql_error() . "registration L:211");
+				$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "registration L:211");
 			
-				$temp = mysql_fetch_assoc($result);
+				$temp = mysqli_fetch_assoc($result);
 				$key = getVerificationKey($email, $temp['user_password'], $temp['user_regdate']);
 
 				// send mail code starts here - see common.lib.php for more

--- a/cms/search.lib.php
+++ b/cms/search.lib.php
@@ -25,8 +25,8 @@ function saveToLog ($query, $elapsed, $results) {
 	if ($results == '')
 		$results = 0;
 	$query = "insert into ".$sph_mysql_table_prefix."query_log (query, time, elapsed, results) values ('$query', now(), '$elapsed', '$results')";
-	if(!mysql_query($query))
-		displayerror(mysql_error());
+	if(!mysqli_query($GLOBALS["___mysqli_ston"], $query))
+		displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 }
 
 function getmicrotime(){

--- a/cms/searchbar.lib.php
+++ b/cms/searchbar.lib.php
@@ -25,9 +25,9 @@ function getSearchbar($userId, $pageId) {
         $_GET['searchContents'] = escape($_GET['searchContents']);
 
         $allPageQuery="SELECT `page_id`, `page_module` FROM `". MYSQL_DATABASE_PREFIX ."pages`";
-        $allPageResult=mysql_query($allPageQuery);
+        $allPageResult=mysqli_query($GLOBALS["___mysqli_ston"], $allPageQuery);
         $pagesIdList=array(); //Contains all pages for which the user has view permission
-        while ($row=mysql_fetch_assoc($allPageResult)) {
+        while ($row=mysqli_fetch_assoc($allPageResult)) {
             if(getPermissions($userId, $row['page_id'], $action="view", $module=$row['page_module']))
                 array_push($pagesIdList, intval($row['page_id']));
         }
@@ -37,11 +37,11 @@ function getSearchbar($userId, $pageId) {
         }
         $searchQueryParams=substr($searchQueryParams,0,-1);
         $searchQuery="SELECT * FROM `". MYSQL_DATABASE_PREFIX ."pagetags` WHERE `tag_text` LIKE '%{$_GET['searchContents']}%' AND `page_id` IN (".$searchQueryParams.");";
-        $tagsWithPermsResult= mysql_query($searchQuery);
+        $tagsWithPermsResult= mysqli_query($GLOBALS["___mysqli_ston"], $searchQuery);
 
-        $searchResult=mysql_query($searchQuery);
+        $searchResult=mysqli_query($GLOBALS["___mysqli_ston"], $searchQuery);
         $suggestions="";
-        while ($row=mysql_fetch_assoc($searchResult)) {
+        while ($row=mysqli_fetch_assoc($searchResult)) {
             $suggestions.="<a href=".hostURL().getPagePath($row['page_id']).">";
             $pageInfo=getPageInfo($row['page_id']);
             $suggestions.=$pageInfo['page_title']."</a><br/>";
@@ -95,9 +95,9 @@ SEARCHSCRIPT;
  */
 function getPagetags($pageId) {
     $pageTagQuery="SELECT `tag_text` FROM `". MYSQL_DATABASE_PREFIX ."pagetags` WHERE `page_id` = {$pageId}";
-    $pageTagResult=mysql_query($pageTagQuery);
+    $pageTagResult=mysqli_query($GLOBALS["___mysqli_ston"], $pageTagQuery);
     $pagetags=[];
-    while ($row=mysql_fetch_assoc($pageTagResult)) {
+    while ($row=mysqli_fetch_assoc($pageTagResult)) {
         array_push($pagetags, $row['tag_text']);
     }
     $pagetags = implode(" , ", $pagetags);

--- a/cms/tbman_executer.lib.php
+++ b/cms/tbman_executer.lib.php
@@ -38,9 +38,9 @@ class tbman_executer {
 		//to generate the "WHERE..." string
 //		if ($this->pv['querystring'] == "")
 //			$this->pv['querystring'] = "SHOW TABLES";
-		@ $result = mysql_query($this->pv['querystring']);
+		@ $result = mysqli_query($GLOBALS["___mysqli_ston"], $this->pv['querystring']);
 		if (!$result) {
-			displayerror("Error line 26: " . mysql_error());
+			displayerror("Error line 26: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			return;
 		} else
 			$this->result = $result;
@@ -53,9 +53,9 @@ class tbman_executer {
 			foreach ($fields as $tok) {
 				if ($tok == "")
 					continue;
-				@ $result = mysql_query($tok);
+				@ $result = mysqli_query($GLOBALS["___mysqli_ston"], $tok);
 				if (!$result) {
-					displayerror("Error line 42 (tbman_executer.lib.php): " . mysql_error());
+					displayerror("Error line 42 (tbman_executer.lib.php): " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 					return;
 				} 
 			}
@@ -108,8 +108,8 @@ class tbman_executer {
 		$this->query .= $str . ";";
 	}
 	function get_wherestring($i) {
-		mysql_data_seek($this->result, $i);
-		$row = mysql_fetch_assoc($this->result);
+		mysqli_data_seek($this->result,  $i);
+		$row = mysqli_fetch_assoc($this->result);
 		$str = " WHERE ";
 		//if(isset($this->extra_where)) { $str .= $this->extra_where." AND "; }		
 		foreach ($row as $field => $value) {

--- a/cms/tbman_renderer.lib.php
+++ b/cms/tbman_renderer.lib.php
@@ -28,9 +28,9 @@ class tbman
     $this->tablename=$this->get_tablename_from_query($querystring);
     $this->querystring=$querystring;
   //  echo "<br/>querystring in tbman_renderer.lib.php: ".$querystring;
-    @ $result=mysql_query($querystring);//@suppresses error messages
+    @ $result=mysqli_query($GLOBALS["___mysqli_ston"], $querystring);//@suppresses error messages
     if(!$result) {                             // and allows to put custom error messages like this one - Error: (used here)
-    	displayerror("Error(tbman_renderer.lib.php): ".mysql_error());
+    	displayerror("Error(tbman_renderer.lib.php): ".((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
     	return;
     }
 	  else
@@ -59,9 +59,9 @@ STR;
 	$str.="\n<form id='f1' name='f1' method='post' action='".$this->formaction."'>";
     $str.="\n<table id=resultTable cellpadding=2 cellspacing=1>";
 	
-    for($i=0;$i<mysql_num_rows($result);$i++)
+    for($i=0;$i<mysqli_num_rows($result);$i++)
       {
-	$a_rows=mysql_fetch_assoc($result);
+	$a_rows=mysqli_fetch_assoc($result);
 
 #Field name row and add row-
 	if($i==0)//ie run only once
@@ -195,7 +195,7 @@ STR;
 
     //making query to get info about the column named $key-
 		/*mysql_field_len($result,$key).*/    
-    $b=mysql_fetch_assoc(mysql_query("explain ".$this->tablename." '".$fieldname."'"));
+    $b=mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "explain ".$this->tablename." '".$fieldname."'"));
 
     $a=$b['Type'];//gives datatype of this format - varchar(20)
 	if($a=="text") return "text_type";

--- a/cms/template.lib.php
+++ b/cms/template.lib.php
@@ -27,14 +27,14 @@ function getPageTemplate($pageId)
 {
  	
  	$query="SELECT `value` FROM `".MYSQL_DATABASE_PREFIX."global` WHERE `attribute`='allow_pagespecific_template'";
-	$result=mysql_query($query);
-	$row=mysql_fetch_row($result);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	$row=mysqli_fetch_row($result);
  	if($row[0]==0)
  		return DEF_TEMPLATE;
 
  	$query="SELECT `page_template` FROM `".MYSQL_DATABASE_PREFIX."pages` WHERE `page_id`='$pageId'";
-	$result=mysql_query($query);
-	$row=mysql_fetch_row($result);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	$row=mysqli_fetch_row($result);
  	if($row[0]=="")
  		return DEF_TEMPLATE;
  	return $row[0];
@@ -312,29 +312,29 @@ function handleTemplateManagement()
 	else if(isset($_POST['btn_uninstall']))		
 	{
 		$query = "SELECT `value` FROM `" . MYSQL_DATABASE_PREFIX . "global` WHERE attribute= 'default_template'";
-			$res   = mysql_query($query);
+			$res   = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			$row1   = array();
-			$row1   = mysql_fetch_row($res);
+			$row1   = mysqli_fetch_row($res);
 		
 		if(!isset($_POST['Template']) || $_POST['Template']=="") return "";
 		
 		$toDelete = escape($_POST['Template']);
 		$query="SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "templates` WHERE `template_name` = '" . $toDelete . "'";
 		$query2 = "SELECT `page_id` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_template` = '{$toDelete}' LIMIT 10";
-		$result2 = mysql_query($query2) or displayerror(mysql_error());
+		$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		
 			if($row1[0] == $toDelete)
 			{
 				displayerror("The default template cannot be deleted! If you want to delete this template, first change the default template from 'Global Settings'.");
 			return "";
 			}
-		if(mysql_num_rows($result2)==0||isset($_POST['confirm'])) {
-			if($row = mysql_fetch_array(mysql_query($query)))
+		if(mysqli_num_rows($result2)==0||isset($_POST['confirm'])) {
+			if($row = mysqli_fetch_array(mysqli_query($GLOBALS["___mysqli_ston"], $query)))
 			{
 			$query="DELETE FROM `" . MYSQL_DATABASE_PREFIX . "templates` WHERE `template_name` = '" . $toDelete . "'";
-			mysql_query($query);
+			mysqli_query($GLOBALS["___mysqli_ston"], $query);
 			$query = "UPDATE `" . MYSQL_DATABASE_PREFIX . "pages` SET `page_template` = '".$row1[0]."' WHERE `page_template` = '".$toDelete."'";
-			mysql_query($query) or displayerror(mysql_error());
+			mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 			$templateDir = $sourceFolder . "/templates/" . $toDelete . "/";
 			if(file_exists($templateDir))
 				delDir($templateDir);
@@ -345,7 +345,7 @@ function handleTemplateManagement()
 				return "";
 		}}
 		$pageList = "";
-		while($row = mysql_fetch_assoc($result2))
+		while($row = mysqli_fetch_assoc($result2))
 			$pageList .= "/home" . getPagePath($row['page_id']) . "<br>";
 		
 		$templatename = safe_html($_POST['Template']);

--- a/cms/tree.lib.php
+++ b/cms/tree.lib.php
@@ -54,10 +54,10 @@ class DirectoryTreeNode {
 
 		/// SELECT perm_permission, usergroup_id FROM $pagepermTable WHERE ((usergroup_id IN join() AND perm_type='group')
 		///		OR (usergroup_id = $userid AND perm_type = 'user')) AND page_id = $pid AND perm_id = $permId
-		$permResult = mysql_query($permQuery) or die($permQuery . "<br />" . mysql_error());
+		$permResult = mysqli_query($GLOBALS["___mysqli_ston"], $permQuery) or die($permQuery . "<br />" . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 		$groupCount = count($groups);
 
-		while ($permResultRow = mysql_fetch_row($permResult)) {
+		while ($permResultRow = mysqli_fetch_row($permResult)) {
 			$index = array_search($permResultRow[1], $groups);
 
 			if($index === false) {
@@ -99,8 +99,8 @@ class DirectoryTreeNode {
 	 */
 	public function __construct(& $pageId, & $userid, & $groups, &$permId, $permSet, $retrieveLinks = false) {
 		$pageNameQuery = "SELECT `page_name`, `page_title` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_id` = '$pageId'";
-		$pageNameResult = mysql_query($pageNameQuery);
-		$pageNameResultRow = mysql_fetch_row($pageNameResult);
+		$pageNameResult = mysqli_query($GLOBALS["___mysqli_ston"], $pageNameQuery);
+		$pageNameResultRow = mysqli_fetch_row($pageNameResult);
 
 		$this->pageId = $pageId;
 		$this->pageName = $pageNameResultRow[0];
@@ -112,9 +112,9 @@ class DirectoryTreeNode {
 		$this->children = array ();
 
 		$childQuery = "SELECT `page_id`, `page_module` FROM `" . MYSQL_DATABASE_PREFIX . "pages` WHERE `page_parentid` = '$pageId' and `page_parentid` != `page_id` ORDER BY `page_menurank`";
-		$childResult = mysql_query($childQuery);
+		$childResult = mysqli_query($GLOBALS["___mysqli_ston"], $childQuery);
 
-		while ($childResultRow = mysql_fetch_assoc($childResult)) {
+		while ($childResultRow = mysqli_fetch_assoc($childResult)) {
 			if($childResultRow['page_module'] != "link" || $retrieveLinks == true) {
 				$a = new DirectoryTreeNode($childResultRow['page_id'], $userid, $groups, $permId, $permSet);
 

--- a/cms/upload.lib.php
+++ b/cms/upload.lib.php
@@ -140,8 +140,8 @@ function upload($moduleComponentId, $moduleName, $userId, $uploadFormName, $maxF
  */
 function saveUploadedFile($moduleComponentId,$moduleName, $userId, $uploadFileName, $tempFileName, $uploadFileType, $uploadDir) {
 	$query = 'SELECT MAX(`upload_fileid`) FROM `' . MYSQL_DATABASE_PREFIX . 'uploads`';
-	$result = mysql_query($query) or die(mysql_error() . 'upload.lib L:131');
-	$row = mysql_fetch_row($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . 'upload.lib L:131');
+	$row = mysqli_fetch_row($result);
 	$upload_fileid = 1;
 	if(!is_null($row[0])) {
 		$upload_fileid = $row[0] + 1;
@@ -155,17 +155,17 @@ function saveUploadedFile($moduleComponentId,$moduleName, $userId, $uploadFileNa
 		$duplicateCheckQuery = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` " .
 				"WHERE `page_modulecomponentid` = '$moduleComponentId' AND `page_module` = '$moduleName'" .
 				" AND upload_filename = '$uploadFileName'";
-		$duplicateCheckResult = mysql_query($duplicateCheckQuery);
+		$duplicateCheckResult = mysqli_query($GLOBALS["___mysqli_ston"], $duplicateCheckQuery);
 			/// Checking for duplicate entry of the file.		
-			if(mysql_num_rows($duplicateCheckResult) >= 1) {
+			if(mysqli_num_rows($duplicateCheckResult) >= 1) {
 			displayerror("A file with the name $uploadFileName already exists. Please use a different filename.");
 			return false;
 			}
 		$query = 'INSERT INTO `' . MYSQL_DATABASE_PREFIX . 'uploads` ' .
 				'(`page_modulecomponentid`, `page_module`, `upload_fileid`, `upload_filename`, `upload_filetype`, `user_id`) ' .
 				"VALUES ('$moduleComponentId', '$moduleName', '$upload_fileid', " .
-				"'" . mysql_escape_string($uploadFileName) . "', '$uploadFileType', '$userId')";
-		mysql_query($query) or die(mysql_error() . "upload.lib L:158<br />");
+				"'" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $uploadFileName) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "', '$uploadFileType', '$userId')";
+		mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "upload.lib L:158<br />");
 		/// If galery create thumbnail and store in the database.
 		if($moduleName=="gallery")
 		{
@@ -181,8 +181,8 @@ function saveUploadedFile($moduleComponentId,$moduleName, $userId, $uploadFileNa
 		$query = 'INSERT INTO `' . MYSQL_DATABASE_PREFIX . 'uploads` ' .
 				'(`page_modulecomponentid`, `page_module`, `upload_fileid`, `upload_filename`, `upload_filetype`, `user_id`) ' .
 				"VALUES ('$moduleComponentId', '$moduleName', '$thumb_upload_fileid', " .
-				"'" . mysql_escape_string($thumb_name) . "', '$uploadFileType', '$userId')";
-		mysql_query($query) or die(mysql_error() . "upload.lib L:163<br />");
+				"'" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $thumb_name) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "', '$uploadFileType', '$userId')";
+		mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "upload.lib L:163<br />");
 		}
 		move_uploaded_file($tempFileName, "$uploadDir/$moduleName/$finalName");
 		return $uploadFileName;
@@ -199,9 +199,9 @@ function saveUploadedFile($moduleComponentId,$moduleName, $userId, $uploadFileNa
 
 function getUploadedFiles($moduleComponentId, $moduleName) {
 	$query = "SELECT `upload_filename`, `upload_filetype`, `upload_time`, `user_id` FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE `page_modulecomponentid` ='" . $moduleComponentId . "' AND `page_module` = '" . $moduleName . "'";
-	$result = mysql_query($query);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$fileArray = array ();
-	while ($row = mysql_fetch_assoc($result))
+	while ($row = mysqli_fetch_assoc($result))
 		$fileArray[] = $row;
 
 	return $fileArray;
@@ -227,21 +227,21 @@ function fileCopy($sourcePage_modulecomponentid,$sourcePage_module,$sourceFile_n
 	global $sourceFolder, $uploadFolder;
 	$uploadDir = $sourceFolder . "/" . $uploadFolder;
 
-	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE `page_modulecomponentid` ='" . $sourcePage_modulecomponentid . "' AND `upload_filename` ='" . mysql_escape_string($sourceFile_name) . "'";
-	$result = mysql_query($query);
-	$array1 = mysql_fetch_assoc($result);
+	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE `page_modulecomponentid` ='" . $sourcePage_modulecomponentid . "' AND `upload_filename` ='" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $sourceFile_name) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "'";
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	$array1 = mysqli_fetch_assoc($result);
 	$tmp_name = $uploadDir . "/" . $sourcePage_module . "/" . str_repeat("0", (10 - strlen((string) $array1['upload_fileid']))) . $array1['upload_fileid'] . "_" . $sourceFile_name;
 	$query1= "SELECT MAX(upload_fileid) as MAX FROM `" . MYSQL_DATABASE_PREFIX . "uploads` ";
-	$result1 = mysql_query($query) or die(mysql_error() . "upload.lib");
-	$row1 = mysql_fetch_assoc($result);
+	$result1 = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "upload.lib");
+	$row1 = mysqli_fetch_assoc($result);
 	$upload_fileid = $row1['MAX'] + 1;
 	$finalname = str_repeat("0", (10 - strlen((string) $upload_fileid))) . $upload_fileid . "_" . $destinationFile_name;
 	if(!copy($tmp_name, $uploadDir . "/" . $destinationPage_module . "/" . $finalname))
 	   return false;
 	$query2 = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "uploads` (`page_modulecomponentid` ,`page_module` , `upload_fileid` , `upload_filename` ," .
 							" `upload_filetype` , `user_id`) VALUES ('$destinationPage_modulecomponentid', '$destinationPage_module','$upload_fileid'," .
-							" '" . mysql_escape_string($destinationFile_name) . "', '{$array1['upload_filetype']}','$user_id')";
-	$result2 = mysql_query($query2);
+							" '" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $destinationFile_name) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "', '{$array1['upload_filetype']}','$user_id')";
+	$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
 
 
 }
@@ -263,16 +263,16 @@ function fileMove($sourcePage_modulecomponentid,$sourcePage_module,$sourceFile_n
 	global $sourceFolder, $uploadFolder;
 	$uploadDir = "$sourceFolder/$uploadFolder";
 
-	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE `page_modulecomponentid` = '$sourcePage_modulecomponentid' AND `upload_filename` ='" . mysql_escape_string($sourceFile_name) . "'";
-	$result = mysql_query($query);
-	$array1 = mysql_fetch_assoc($result);
+	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE `page_modulecomponentid` = '$sourcePage_modulecomponentid' AND `upload_filename` ='" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $sourceFile_name) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "'";
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	$array1 = mysqli_fetch_assoc($result);
 	$oldname = "$uploadDir/$sourcePage_module/" . str_repeat('0', (10 - strlen((string) $array1['upload_fileid']))) . $array1['upload_fileid'] . "_$sourceFile_name";
 	$finalname = "$uploadDir/$destinationPage_module/" . str_repeat('0', (10 - strlen((string) $array1['upload_fileid']))) . $array1['upload_fileid'] . "_$destinationFile_name";
 	rename($oldname,$finalname);
 	$query2 = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "uploads` (`page_modulecomponentid`, `page_module`, `upload_fileid`, `upload_filename`, " .
 							"`upload_filetype`, `user_id`) VALUES ('$destinationPage_modulecomponentid', '$destinationPage_module', '$upload_fileid', " .
-							" '" . mysql_escape_string($destinationFile_name) . "', '{$array1['upload_filetype']}','$user_id')";
-	$result2 = mysql_query($query2);
+							" '" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $destinationFile_name) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "', '{$array1['upload_filetype']}','$user_id')";
+	$result2 = mysqli_query($GLOBALS["___mysqli_ston"], $query2);
 }
 
 
@@ -287,9 +287,9 @@ function fileMove($sourcePage_modulecomponentid,$sourcePage_module,$sourceFile_n
  */
 function getFileName($moduleComponentId, $page_module, $upload_fileid) {
 	$query = " SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads` WHERE `page_modulecomponentid` ='$moduleComponentId' AND `page_module` ='$page_module' AND `upload_fileid` ='$upload_fileid'";
-	$result = mysql_query($query);
-	if (mysql_num_rows($result) > 0) {
-		$name = mysql_fetch_assoc($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if (mysqli_num_rows($result) > 0) {
+		$name = mysqli_fetch_assoc($result);
 		return $name['upload_filename'];
 	} else
 		return false;
@@ -308,11 +308,11 @@ function deleteFile( $moduleComponentId, $page_module, $upload_filename) {
 	global $uploadFolder;
 	global $sourceFolder;
 	$upload_filename = stripslashes($upload_filename);
-	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads`WHERE `page_modulecomponentid` ='$moduleComponentId' AND `page_module` = '$page_module' AND `upload_filename`= '" . mysql_escape_string($upload_filename) . "'";
+	$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "uploads`WHERE `page_modulecomponentid` ='$moduleComponentId' AND `page_module` = '$page_module' AND `upload_filename`= '" . ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"], $upload_filename) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : "")) . "'";
 
-	$result = mysql_query($query) or displayerror(mysql_error() . "upload L:260");
-	if(mysql_num_rows($result)<1) return false;
-	$row = mysql_fetch_assoc($result);
+	$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or displayerror(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . "upload L:260");
+	if(mysqli_num_rows($result)<1) return false;
+	$row = mysqli_fetch_assoc($result);
 	$upload_fileid = $row['upload_fileid'];
 
 	$filename = str_repeat("0", (10 - strlen((string) $upload_fileid))) . $upload_fileid . "_" . $upload_filename;
@@ -325,8 +325,8 @@ function deleteFile( $moduleComponentId, $page_module, $upload_filename) {
 		$thumb_name = "thumb_".$upload_filename;
 		deleteFile($moduleComponentId,$page_module,$thumb_name);
 	}
-	mysql_query($query);
-	if (mysql_affected_rows() > 0) {
+	mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) > 0) {
 	//	displayinfo("File data has been deleted from the database");
 		return true;
 	} else {

--- a/cms/userprofile.lib.php
+++ b/cms/userprofile.lib.php
@@ -23,16 +23,16 @@ function generatePublicProfile($userProfileId,$accessUserId) {
 	require_once("$sourceFolder/upload.lib.php");
 	require_once ("$sourceFolder/profile.lib.php");
 	$profileQuery = 'SELECT `user_name`, `user_fullname`, `user_email` FROM `' . MYSQL_DATABASE_PREFIX . 'users` WHERE `user_id` = \'' . $userId."'";
-	$profileResult = mysql_query($profileQuery);
+	$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
 	if(!$profileResult) {
-		displayerror('An error occurred while trying to process your request.<br />' . mysql_error() . '<br />' . $profileQuery);
+		displayerror('An error occurred while trying to process your request.<br />' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '<br />' . $profileQuery);
 		return '';
 	}
-	if(mysql_num_rows($profileResult)==0){
+	if(mysqli_num_rows($profileResult)==0){
 		displayerror("The Requested user is not found." );
 		return "Click <a href='".$urlRequestRoot."'>here </a> to return to the home page";
 	}
-	$profileRow = mysql_fetch_row($profileResult);
+	$profileRow = mysqli_fetch_row($profileResult);
 	$userName = $profileRow[0];
 	$userFullname = $profileRow[1];
 	$userEmail = $profileRow[2];

--- a/cms/users.lib.php
+++ b/cms/users.lib.php
@@ -127,10 +127,10 @@ function handleUserMgmt()
 	if(isset($_POST['user_selected_activate'])) {
 		foreach($_POST as $key => $var)
 			if(substr($key,0,9)=="selected_") {
-				if(!mysql_query("UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=1 WHERE user_id='".substr($key,9)."'")) {
-					$result = mysql_query("SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='".substr($key,9)."'");
+				if(!mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=1 WHERE user_id='".substr($key,9)."'")) {
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='".substr($key,9)."'");
 					if($result) {
-						$row = mysql_fetch_assoc($result);
+						$row = mysqli_fetch_assoc($result);
 						displayerror("Couldn't activate user, {$row['user_fullname']}");
 					}
 				}
@@ -144,10 +144,10 @@ function handleUserMgmt()
 					displayerror("You cannot deactivate administrator!");
 					continue;
 				}
-				if(!mysql_query("UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=0 WHERE user_id='".substr($key,9)."'")) {
-					$result = mysql_query("SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='".substr($key,9)."'");
+				if(!mysqli_query($GLOBALS["___mysqli_ston"], "UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=0 WHERE user_id='".substr($key,9)."'")) {
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], "SELECT `user_fullname` FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='".substr($key,9)."'");
 					if($result) {
-						$row = mysql_fetch_assoc($result);
+						$row = mysqli_fetch_assoc($result);
 						displayerror("Couldn't deactivate user, {$row['user_fullname']}");
 					}
 				}
@@ -163,9 +163,9 @@ function handleUserMgmt()
 					continue;
 				}
 				$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '".substr($key,9)."'";
-				if(mysql_query($query)) {
+				if(mysqli_query($GLOBALS["___mysqli_ston"], $query)) {
 					$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."openid_users` WHERE `user_id` = '".substr($key,9)."'";
-					if(!mysql_query($query))
+					if(!mysqli_query($GLOBALS["___mysqli_ston"], $query))
 						$done = false;
 				} else
 					$done = false;
@@ -177,7 +177,7 @@ function handleUserMgmt()
 	if(isset($_POST['user_activate']))
 	{
 		$query="UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=1 WHERE user_id='{$_GET['userid']}'";
-		if(mysql_query($query))
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 			displayInfo("User Successfully Activated!");
 		else displayerror("User Not Activated!");
 		return registeredUsersList($_POST['editusertype'],"edit",false);
@@ -186,7 +186,7 @@ function handleUserMgmt()
 	{
 		
 		$query="UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=1";
-		if(mysql_query($query))
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 			displayInfo("All users activated successfully!");
 		else displayerror("Users Not Deactivated!");
 		
@@ -200,7 +200,7 @@ function handleUserMgmt()
 			return registeredUsersList($_POST['editusertype'],"edit",false);
 		}
 		$query="UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=0 WHERE user_id='{$_GET['userid']}'";
-		if(mysql_query($query))
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 			displayInfo("User Successfully Deactivated!");
 		else displayerror("User Not Deactivated!");
 		
@@ -210,7 +210,7 @@ function handleUserMgmt()
 	{
 		
 		$query="UPDATE ".MYSQL_DATABASE_PREFIX."users SET user_activated=0 WHERE user_id != ".ADMIN_USERID;
-		if(mysql_query($query))
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 			displayInfo("All users deactivated successfully except Administrator!");
 		else displayerror("Users Not Deactivated!");
 		
@@ -225,10 +225,10 @@ function handleUserMgmt()
 			return registeredUsersList($_POST['editusertype'],"edit",false);
 		}
 		$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id` = '$userId'";
-		if(mysql_query($query))
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 		{
 			$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."openid_users` WHERE `user_id` = '$userId'";
-			if(mysql_query($query))
+			if(mysqli_query($GLOBALS["___mysqli_ston"], $query))
 			{
 				displayinfo("User Successfully Deleted!");
 			}
@@ -247,14 +247,14 @@ function handleUserMgmt()
 			$updates = array();
 			$userId=$_GET['userid'];
 			$query="SELECT * FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='{$userId}'";
-			$row=mysql_fetch_assoc(mysql_query($query));
+			$row=mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], $query));
 			$errors = false;
 			
 			if(isset($_POST['user_name']) && $row['user_name']!=$_POST['user_name'])
 			{
 				$chkquery="SELECT * FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_name`='".escape($_POST['user_name'])."'";
-				$result=mysql_query($chkquery) or die("failed  : $chkquery");
-				if(mysql_num_rows($result)>0) 
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $chkquery) or die("failed  : $chkquery");
+				if(mysqli_num_rows($result)>0) 
 				{
 					displayerror("User Name already exists in database!");
 					$errors=true;
@@ -309,7 +309,7 @@ function handleUserMgmt()
 				if(count($updates) > 0)
 				{
 					$profileQuery = 'UPDATE `' . MYSQL_DATABASE_PREFIX . 'users` SET ' . join($updates, ', ') . " WHERE `user_id` = ".escape($_GET['userid'])."'";
-					$profileResult = mysql_query($profileQuery);
+					$profileResult = mysqli_query($GLOBALS["___mysqli_ston"], $profileQuery);
 					if(!$profileResult) {
 					displayerror('An error was encountered while attempting to process your request.'.$profileQuery);
 					$errors = true;
@@ -336,7 +336,7 @@ function handleUserMgmt()
 		$xcolumnIds=array_keys($columnList);
 		$xcolumnNames=array_values($columnList);
 		
-		$row=mysql_fetch_assoc(mysql_query($query));
+		$row=mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], $query));
 		
 		
 		$userfieldprettynames=array("User ID","Username","Email","Full Name","Password","Registration","Last Login","Activated","Login Method");	
@@ -416,14 +416,14 @@ function handleUserMgmt()
 		if($qstring!="")
 		{
 			$query = "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "users` WHERE $qstring ";
-			$resultSearch = mysql_query($query);
-			if (mysql_num_rows($resultSearch) > 0) {
-				$num = mysql_num_rows($resultSearch);
+			$resultSearch = mysqli_query($GLOBALS["___mysqli_ston"], $query);
+			if (mysqli_num_rows($resultSearch) > 0) {
+				$num = mysqli_num_rows($resultSearch);
 				
 				$userInfo=array();
 				
 				
-				while($row=mysql_fetch_assoc($resultSearch))
+				while($row=mysqli_fetch_assoc($resultSearch))
 				{
 					$userInfo['user_id'][]=$row['user_id'];
 					$userInfo['user_name'][]=$row['user_name'];
@@ -489,8 +489,8 @@ function handleUserMgmt()
 				$user_id=$_GET['userid'];
 				$chkquery="SELECT COUNT(user_id) FROM `".MYSQL_DATABASE_PREFIX."users` WHERE `user_id`='$user_id' OR `user_name`='$user_name' OR `user_email`='$user_email'";
 			
-				$result=mysql_query($chkquery);
-				$row=mysql_fetch_row($result);
+				$result=mysqli_query($GLOBALS["___mysqli_ston"], $chkquery);
+				$row=mysqli_fetch_row($result);
 			
 				if($row[0]>0) displayerror("Another user with the same name or email already exists!");
 				else if($user_password!=$_POST['user_password2']) displayerror("Passwords mismatch!");
@@ -498,11 +498,11 @@ function handleUserMgmt()
 				{
 					if(isset($_POST['user_activated'])) $user_activated=1;
 					$query = "INSERT INTO `" . MYSQL_DATABASE_PREFIX . "users` (`user_id` ,`user_name` ,`user_email` ,`user_fullname` ,`user_password` ,`user_regdate` ,`user_lastlogin` ,`user_activated`,`user_loginmethod`)VALUES ('$user_id' ,'$user_name' ,'$user_email' ,'$user_fullname' , MD5('$user_password') ,CURRENT_TIMESTAMP , '', '$user_activated','$user_loginmethod')";
-					$result = mysql_query($query) or die(mysql_error());
+					$result = mysqli_query($GLOBALS["___mysqli_ston"], $query) or die(((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 					global $sourceFolder,$moduleFolder;
 		require_once("$sourceFolder/$moduleFolder/form/registrationformsubmit.php");
 		require_once("$sourceFolder/$moduleFolder/form/registrationformgenerate.php");
-					if (mysql_affected_rows() && submitRegistrationForm(0, $user_id, true, true)) displayinfo("User $user_fullname Successfully Created!");
+					if (mysqli_affected_rows($GLOBALS["___mysqli_ston"]) && submitRegistrationForm(0, $user_id, true, true)) displayinfo("User $user_fullname Successfully Created!");
 					else displayerror("Failed to create user");
 				}
 			}
@@ -539,7 +539,7 @@ function handleUserMgmt()
 function getAllUsersInfo(&$userId,&$userName,&$userEmail,&$userFullName,&$userPassword,&$userLastLogin,&$userRegDate,&$userActivated,&$userLoginMethod)
 {
 	$query="SELECT * FROM `".MYSQL_DATABASE_PREFIX."users` ORDER BY `user_id` ASC";
-	$result=mysql_query($query);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$userId=array();
 	$userEmail=array();
 	$userName=array();
@@ -550,7 +550,7 @@ function getAllUsersInfo(&$userId,&$userName,&$userEmail,&$userFullName,&$userPa
 	$userActivated=array();
 	$userLoginMethod=array();
 	$i=0;
-	while($row=mysql_fetch_assoc($result))
+	while($row=mysqli_fetch_assoc($result))
 	{
 		$userId[$i]=$row['user_id'];
 		$userName[$i]=$row['user_name'];

--- a/cms/widget.lib.php
+++ b/cms/widget.lib.php
@@ -331,9 +331,9 @@ function getInheritedWidgets($pageId)
 	if($parentId==$pageId) return array();
 	
 	$query="SELECT t1.`widget_id` AS 'id', t1.`widget_instanceid` AS 'instanceid', t1.`widget_location` AS 'location', t2.`widget_name` AS 'name', t2.`widget_description` AS 'description', t2.`widget_author` AS 'author', t2.`widget_version` AS 'version', t2.`widget_classname` AS 'classname', t2.`widget_foldername` AS 'foldername' FROM `".MYSQL_DATABASE_PREFIX."widgets` AS t1, `".MYSQL_DATABASE_PREFIX."widgetsinfo` AS t2 WHERE t1.`page_id`='$parentId' AND t1.`widget_propagate`=1 AND t2.`widget_id`=t1.`widget_id` ORDER BY t1.`widget_location` ASC";
-	$result=mysql_query($query);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$return=array();
-	while($row=mysql_fetch_array($result))
+	while($row=mysqli_fetch_array($result))
 	{
 		$row['source']=getPagePath($parentId);
 		$return[]=$row;
@@ -352,7 +352,7 @@ function getInheritedWidgets($pageId)
 function propagateWidgetInstance($widgetId,$widgetInstanceId)
 {
 	$query="UPDATE `".MYSQL_DATABASE_PREFIX."widgets` SET `widget_propagate`=1 WHERE `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId'";
-	mysql_query($query);
+	mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	displayinfo("Widget has been succesfully propagated to all child pages recursively.");
 }
 
@@ -364,7 +364,7 @@ function propagateWidgetInstance($widgetId,$widgetInstanceId)
 function unpropagateWidgetInstance($widgetId,$widgetInstanceId)
 {
 	$query="UPDATE `".MYSQL_DATABASE_PREFIX."widgets` SET `widget_propagate`=0 WHERE `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId'";
-	mysql_query($query);
+	mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	displayinfo("Widget copies has been succesfully removed from all child pages recursively.");
 }
 
@@ -377,21 +377,21 @@ function unpropagateWidgetInstance($widgetId,$widgetInstanceId)
 function deleteWidgetInstance($widgetId,$widgetInstanceId)
 {
 	$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."widgets` WHERE `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId'";
-	if(mysql_query($query)===FALSE)
+	if(mysqli_query($GLOBALS["___mysqli_ston"], $query)===FALSE)
 	{
 		displayerror("Could not delete widget. Internal error occurred.");
 		return FALSE;
 	}
 	
 	$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."widgetsconfig` WHERE `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId'";
-	if(mysql_query($query)===FALSE)
+	if(mysqli_query($GLOBALS["___mysqli_ston"], $query)===FALSE)
 	{
 		displayerror("Could not delete widget. Internal error occurred.");
 		return FALSE;
 	}
 	
 	$query="DELETE FROM `".MYSQL_DATABASE_PREFIX."widgetsdata` WHERE `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId'";
-	if(mysql_query($query)===FALSE)
+	if(mysqli_query($GLOBALS["___mysqli_ston"], $query)===FALSE)
 	{
 		displayerror("Could not delete widget. Internal error occurred.");
 		return FALSE;
@@ -414,9 +414,9 @@ function deleteWidgetInstance($widgetId,$widgetInstanceId)
 function modifyWidgetInstanceLocation($pageId,$widgetId,$widgetInstanceId,$mod)
 {
 	$query="UPDATE `".MYSQL_DATABASE_PREFIX."widgets` SET `widget_location`=`widget_location`$mod WHERE `page_id`='$pageId' AND `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId' AND `widget_location`$mod >= 0";
-	$res=mysql_query($query);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	if(!$res) return false;
-	if(mysql_affected_rows()==0)
+	if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])==0)
 		displayerror("Could not move widget to that location. Location cannot be negative.");
 	else displayinfo("Widget has been successfully relocated.");			
 }
@@ -432,9 +432,9 @@ function modifyWidgetInstanceLocation($pageId,$widgetId,$widgetInstanceId,$mod)
 function modifyWidgetInstanceOrder($pageId,$widgetId,$widgetInstanceId,$mod)
 {
 	$query="UPDATE `".MYSQL_DATABASE_PREFIX."widgets` SET `widget_order`=`widget_order`$mod WHERE `page_id`='$pageId' AND `widget_id`='$widgetId' AND `widget_instanceid`='$widgetInstanceId'";
-	$res=mysql_query($query);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	if(!$res) return false;
-	if(mysql_affected_rows()==0)
+	if(mysqli_affected_rows($GLOBALS["___mysqli_ston"])==0)
 		displayerror("Could not move widget. Some internal error occurred.");
 	else displayinfo("Widget has been successfully reordered.");			
 }
@@ -449,13 +449,13 @@ function modifyWidgetInstanceOrder($pageId,$widgetId,$widgetInstanceId,$mod)
 function createWidgetInstance($pageId,$widgetId)
 {
 	$query="SELECT `widget_name` AS 'name', `widget_classname` AS 'classname', `widget_foldername` AS 'foldername' FROM `".MYSQL_DATABASE_PREFIX."widgetsinfo` WHERE `widget_id`='$widgetId'";
-	$res=mysql_query($query);
-	if(mysql_num_rows($res)==0)
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	if(mysqli_num_rows($res)==0)
 	{
 		displayerror("Required widget is not registered with Pragyan CMS properly.");
 		return false;
 	}
-	$row=mysql_fetch_array($res);
+	$row=mysqli_fetch_array($res);
 	
 	global $widgetFolder;
 	$classname=$row['classname'];
@@ -501,9 +501,9 @@ function createWidgetInstance($pageId,$widgetId)
 function getEnabledWidgets($pageId)
 {
 	$query="SELECT t1.`widget_id` AS 'id', t1.`widget_instanceid` AS 'instanceid', t1.`widget_location` AS 'location', t1.`widget_order` AS 'order', t1.`widget_propagate` AS 'propagate', t2.`widget_name` AS 'name', t2.`widget_description` AS 'description', t2.`widget_author` AS 'author', t2.`widget_version` AS 'version', t2.`widget_classname` AS 'classname', t2.`widget_foldername` AS 'foldername' FROM `".MYSQL_DATABASE_PREFIX."widgets` AS t1, `".MYSQL_DATABASE_PREFIX."widgetsinfo` AS t2 WHERE t1.`page_id`='$pageId' AND t2.`widget_id`=t1.`widget_id` ORDER BY t1.`widget_location`, t1.`widget_order` ASC";
-	$result=mysql_query($query);
+	$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$return=array();
-	while($row=mysql_fetch_array($result))
+	while($row=mysqli_fetch_array($result))
 		$return[]=$row;
 	return $return;
 }
@@ -538,15 +538,15 @@ function handleWidgetAdmin($pageId)
 	if(isset($_GET["deletewidget"])) {
 		$widgetId = escape($_GET['deletewidget']);
 		if(is_numeric($widgetId)) {
-			$widget = mysql_fetch_assoc(mysql_query("SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "widgetsinfo` WHERE `widget_id` = '{$widgetId}'"));
+			$widget = mysqli_fetch_assoc(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT * FROM `" . MYSQL_DATABASE_PREFIX . "widgetsinfo` WHERE `widget_id` = '{$widgetId}'"));
 			$error = false;
 			$deletelist = array("widgets","widgetsinfo","widgetsconfiginfo","widgetsconfig","widgetsdata");
 			$rowCount = 0;
 			foreach($deletelist as $deleteitem) {
 				$query = "DELETE FROM `" . MYSQL_DATABASE_PREFIX . $deleteitem . "` WHERE `widget_id` = '{$widgetId}'";
-				mysql_query($query) or die($query . "<br><br>" . mysql_error());
+				mysqli_query($GLOBALS["___mysqli_ston"], $query) or die($query . "<br><br>" . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)));
 				
-				$ans = mysql_fetch_row(mysql_query("SELECT COUNT(*) FROM `" . MYSQL_DATABASE_PREFIX . $deleteitem . "` WHERE `widget_id` = '{$widgetId}'"));
+				$ans = mysqli_fetch_row(mysqli_query($GLOBALS["___mysqli_ston"], "SELECT COUNT(*) FROM `" . MYSQL_DATABASE_PREFIX . $deleteitem . "` WHERE `widget_id` = '{$widgetId}'"));
 				$rowCount += $ans[0];
 			}
 			if(is_dir("$sourceFolder/$widgetFolder/{$widget['widget_foldername']}"))
@@ -565,13 +565,13 @@ function handleWidgetAdmin($pageId)
 		$widgetid=escape($_GET['widgetid']);		
 		
 		$query="SELECT `widget_name` AS 'name', `widget_classname` AS 'classname', `widget_foldername` AS 'foldername' FROM `".MYSQL_DATABASE_PREFIX."widgetsinfo` WHERE `widget_id`='$widgetid'";
-		$res=mysql_query($query);
-		if(mysql_num_rows($res)==0)
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if(mysqli_num_rows($res)==0)
 		{
 			displayerror("Required widget is not registered with Pragyan CMS properly.");
 			return false;
 		}
-		$row=mysql_fetch_array($res);
+		$row=mysqli_fetch_array($res);
 	
 		global $widgetFolder;
 		$classname=$row['classname'];
@@ -693,10 +693,10 @@ function getConfigFormAsArray($widgetconfigs,$containsFileUploadFields,$widgetin
 			
 		$query="SELECT `config_name` AS 'confname', `config_value` AS 'confvalue' FROM ".MYSQL_DATABASE_PREFIX."widgetsconfig WHERE `widget_instanceid`='$widgetinstanceid' AND `widget_id`='{$widgetconfigs[0]['id']}'  AND `config_name` IN ('".join($confnames,"','")."')";
 
-		$res=mysql_query($query);
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 
 		/// For those configurations which are set, overwrite the $formValues array
-		while($row=mysql_fetch_assoc($res))
+		while($row=mysqli_fetch_assoc($res))
 		{
 			$formValues[$row['confname']]=$row['confvalue'];	
 		}
@@ -1026,9 +1026,9 @@ function renderNoinputTypeField($elementName,$value,$options,&$htmlOutput)
 function getWidgetPageConfigInfo($widgetid)
 {
 	$query="SELECT `widget_id` AS 'id', `config_name` AS 'confname', `config_displaytext` AS 'confdisplay', `config_type` AS 'conftype',`config_options` AS 'confoptions',`config_default` AS 'confdefault'  FROM `".MYSQL_DATABASE_PREFIX."widgetsconfiginfo` WHERE `widget_id`='$widgetid' AND `is_global`=0 ORDER BY `config_rank`";
-	$res=mysql_query($query);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$ret=array();
-	while($arr=mysql_fetch_assoc($res))
+	while($arr=mysqli_fetch_assoc($res))
 	{
 		$ret[]=$arr;
 	}
@@ -1043,9 +1043,9 @@ function getWidgetPageConfigInfo($widgetid)
 function getWidgetGlobalConfigInfo($widgetid)
 {
 	$query="SELECT `widget_id` AS 'id', `config_name` AS 'confname', `config_displaytext` AS 'confdisplay', `config_type` AS 'conftype',`config_options` AS 'confoptions',`config_default` AS 'confdefault'  FROM `".MYSQL_DATABASE_PREFIX."widgetsconfiginfo` WHERE `widget_id`='$widgetid' AND `is_global`=1 ORDER BY `config_rank`";
-	$res=mysql_query($query);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$ret=array();
-	while($arr=mysql_fetch_assoc($res))
+	while($arr=mysqli_fetch_assoc($res))
 	{
 		$ret[]=$arr;
 	}
@@ -1059,8 +1059,8 @@ function getWidgetGlobalConfigInfo($widgetid)
 function getWidgetInfo($widgetid)
 {
 	$query="SELECT `widget_id` AS 'id', `widget_name` AS 'name', `widget_description` AS 'description', `widget_version` AS 'version', `widget_author` AS 'author', `widget_foldername` AS 'foldername' FROM `".MYSQL_DATABASE_PREFIX."widgetsinfo` WHERE `widget_id`='$widgetid'";
-	$res=mysql_query($query);
-	return mysql_fetch_assoc($res);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+	return mysqli_fetch_assoc($res);
 }
 /**
  * Retrieves the widget id and name of all the widgets
@@ -1069,9 +1069,9 @@ function getWidgetInfo($widgetid)
 function getAllWidgetsInfo()
 {
 	$query="SELECT `widget_id` AS 'id',`widget_name` AS 'name',`widget_description` AS 'description', `widget_version` AS 'version', `widget_author` AS 'author' FROM `".MYSQL_DATABASE_PREFIX."widgetsinfo`";
-	$res=mysql_query($query);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	$ret=array();
-	while($row=mysql_fetch_array($res))
+	while($row=mysqli_fetch_array($res))
 	{
 		$ret[]=$row;
 	}
@@ -1088,11 +1088,11 @@ function updateWidgetConf($widgetid,$widgetinstanceid=-1,$isglobal=TRUE)
 {
 	$query="SELECT `config_name`,`config_type`,`config_default`,`config_options` FROM `".MYSQL_DATABASE_PREFIX."widgetsconfiginfo` WHERE `widget_id`='$widgetid' AND `is_global`=".(int)$isglobal;
 	
-	$res=mysql_query($query);
+	$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 	
 	if($isglobal) $widgetinstanceid=-1;
 	
-	while($row=mysql_fetch_array($res))
+	while($row=mysqli_fetch_array($res))
 	{
 	
 		$conftype=$row['config_type'];
@@ -1107,9 +1107,9 @@ function updateWidgetConf($widgetid,$widgetinstanceid=-1,$isglobal=TRUE)
 		
 		$query="SELECT `config_value` FROM `".MYSQL_DATABASE_PREFIX."widgetsconfig` WHERE `config_name`='$confname' AND `widget_id`='$widgetid' AND `widget_instanceid`='$widgetinstanceid'";
 	
-		$result=mysql_query($query);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		
-		while($row=mysql_fetch_assoc($result))
+		while($row=mysqli_fetch_assoc($result))
 			$confcur=$row['config_value'];
 		
 		if($conftype=='checkbox')
@@ -1119,15 +1119,15 @@ function updateWidgetConf($widgetid,$widgetinstanceid=-1,$isglobal=TRUE)
 		
 		///If there was no submit value, then check for the current value, if even that's missing then use the default value	
 		$confval=($confval===false)?(($confcur===false)?$confdef:$confcur):$confval;
-		if(mysql_num_rows($result)==0)
+		if(mysqli_num_rows($result)==0)
 		{
 			$query="INSERT INTO `".MYSQL_DATABASE_PREFIX."widgetsconfig` (`widget_id`,`widget_instanceid`,`config_name`,`config_value`) VALUES ($widgetid,$widgetinstanceid,'$confname','$confval')";
-			mysql_query($query);
+			mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		}	
 		else if($confval!=$confcur)
 		{
 			$query="UPDATE `".MYSQL_DATABASE_PREFIX."widgetsconfig` SET `config_value`='$confval' WHERE `config_name`='$confname' AND `widget_id`='$widgetid' AND `widget_instanceid`='$widgetinstanceid'";
-			mysql_query($query);
+			mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		}
 	
 	}

--- a/cms/widgetFramework.class.php
+++ b/cms/widgetFramework.class.php
@@ -69,13 +69,13 @@ abstract class widgetFramework
 	
 		///Loading widget information
 		$query="SELECT `widget_name` AS 'name', `widget_description` AS 'description', `widget_version` AS 'version', `widget_author` AS 'author' FROM `".MYSQL_DATABASE_PREFIX."widgetsinfo` WHERE `widget_id`='{$this->widgetId}'";
-		$res=mysql_query($query);
-		if($res===false || mysql_num_rows($res)==0)
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
+		if($res===false || mysqli_num_rows($res)==0)
 		{
 			displayerror("Error in loading widget {$this->widgetName}");
 			return false;
 		}
-		$row=mysql_fetch_array($res);
+		$row=mysqli_fetch_array($res);
 		
 		$this->widgetName=$row['name'];
 		$this->widgetDescription=$row['description'];
@@ -84,7 +84,7 @@ abstract class widgetFramework
 		
 		///Loading configuration settings (both instance-specific and global)
 		$query="SELECT `config_name` AS 'key', `config_value` AS 'value' FROM `".MYSQL_DATABASE_PREFIX."widgetsconfig` WHERE `widget_id`='{$this->widgetId}' AND `widget_instanceid` IN ({$this->widgetInstanceId},-1) ";
-		$res=mysql_query($query);
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		
 		if($res===false)
 		{
@@ -92,7 +92,7 @@ abstract class widgetFramework
 			return false;
 		}
 		$this->settings = array();
-		while($row=mysql_fetch_array($res))
+		while($row=mysqli_fetch_array($res))
 		{
 			$this->settings[$row['key']]=$row['value'];
 		}
@@ -100,14 +100,14 @@ abstract class widgetFramework
 		///If configurations doesn't exists, then loading default values.
 		$query="SELECT `config_name` AS 'key', `config_default` AS 'value', `is_global` AS 'global' FROM `".MYSQL_DATABASE_PREFIX."widgetsconfiginfo` WHERE `widget_id`='{$this->widgetId}'";
 		
-		$res=mysql_query($query);
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		if($res===false)
 		{
 			displayerror("Error in loading widget {$this->widgetName}");
 			return false;
 		}
 		
-		while($row=mysql_fetch_array($res))
+		while($row=mysqli_fetch_array($res))
 		{
 			if(!isset($this->settings[$row['key']]))
 			{
@@ -117,7 +117,7 @@ abstract class widgetFramework
 				if(($row['global']=='1' && $this->widgetInstanceId==-1) || ($row['global']=='0' && $this->widgetInstanceId!=-1))
 				{
 					$query="INSERT IGNORE INTO `".MYSQL_DATABASE_PREFIX."widgetsconfig` (`widget_id`,`widget_instanceid`,`config_name`,`config_value`) VALUES ('{$this->widgetId}', '{$this->widgetInstanceId}', '{$row['key']}', '{$row['value']}')";
-					$res2=mysql_query($query);
+					$res2=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 					if($res2===false)
 					{
 						displayerror("Error in loading widget {$this->widgetName}");
@@ -129,14 +129,14 @@ abstract class widgetFramework
 	
 		///Loading data settigns
 		$query="SELECT `widget_datakey` AS 'key', `widget_datavalue` AS 'value' FROM `".MYSQL_DATABASE_PREFIX."widgetsdata` WHERE `widget_id`='{$this->widgetId}' AND`widget_instanceid` = '{$this->widgetInstanceId}'";
-		$res=mysql_query($query);
+		$res=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		if($res===false)
 		{
 			displayerror("Error in loading widget {$this->widgetName}");
 			return false;
 		}
 		$this->data = array();
-		while($row=mysql_fetch_array($res))
+		while($row=mysqli_fetch_array($res))
 		{
 			$this->data[$row['key']]=$row['value'];
 		}
@@ -167,7 +167,7 @@ abstract class widgetFramework
 		
 		///If some configuration fields are already there in table, we remove them.
 		$query = "DELETE FROM `".MYSQL_DATABASE_PREFIX."widgetsconfiginfo` WHERE `widget_id`='{$this->widgetId}'";
-		mysql_query($query);
+		mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		
 		
 		$install=$this->setConfigs($this->defaultConfigs);
@@ -196,7 +196,7 @@ abstract class widgetFramework
 			$query="INSERT IGNORE INTO `".MYSQL_DATABASE_PREFIX."widgetsconfiginfo` (`widget_id`,`config_name`,`config_type`,`config_options`,`config_displaytext`,`config_default`,`is_global`,`config_rank`) VALUES ({$this->widgetId},'{$config['name']}','{$config['type']}','{$config['options']}','{$config['displaytext']}','{$config['default']}',{$config['global']},{$rank})";
 			
 			$rank++;
-			if(mysql_query($query)==false)
+			if(mysqli_query($GLOBALS["___mysqli_ston"], $query)==false)
 			{
 				displayerror("Error in saving configurations for the widget {$this->widgetName}");
 				return false;
@@ -218,7 +218,7 @@ abstract class widgetFramework
 		
 		$query="UPDATE `".MYSQL_DATABASE_PREFIX."widgetsconfig` SET `config_value`='$value' WHERE `config_name`='$key' AND `widget_id`='{$this->widgetId}' AND `widget_instanceid`='{$this->widgetInstanceId}'";
 
-		if(mysql_query($query)===false) {
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query)===false) {
 			displayerror("Error in saving setting for the widget {$this->widgetName}.");
 			return false; 
 		}
@@ -242,7 +242,7 @@ abstract class widgetFramework
 		else 
 			$query="INSERT INTO `".MYSQL_DATABASE_PREFIX."widgetsdata` (`widget_id`,`widget_instanceid`,`widget_datakey`,`widget_datavalue`) VALUES ('{$this->widgetId}','{$this->widgetInstanceId}','$key','$value')";
 		
-		if(mysql_query($query)===false)
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query)===false)
 		{
 			displayerror("Error in saving data for the widget {$this->widgetName}.");
 			return false;
@@ -265,16 +265,16 @@ abstract class widgetFramework
 		$defaultloc=1;
 		
 		$query="SELECT MAX(`widget_instanceid`) FROM `".MYSQL_DATABASE_PREFIX."widgets` WHERE `widget_id` = '{$this->widgetId}'";
-		$result=mysql_query($query);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		if($result===false) return false;
-		$row1=mysql_fetch_row($result);
+		$row1=mysqli_fetch_row($result);
 		if($row1==NULL)
 		 $row1[0]=0;
 		
 		$query="SELECT MAX(`widget_order`) FROM `".MYSQL_DATABASE_PREFIX."widgets` WHERE `page_id` = '$pageId' AND `widget_location` = '$defaultloc'";
-		$result=mysql_query($query);
+		$result=mysqli_query($GLOBALS["___mysqli_ston"], $query);
 		if($result===false) return false;
-		$row2=mysql_fetch_array($result);
+		$row2=mysqli_fetch_array($result);
 		if($row2==NULL)
 		 $row2[0]=0;
 		
@@ -284,7 +284,7 @@ abstract class widgetFramework
 		
 		$query="INSERT INTO `".MYSQL_DATABASE_PREFIX."widgets` (`widget_id`,`widget_instanceid`,`page_id`,`widget_location`,`widget_order`) VALUES ('{$this->widgetId}','$instanceId','$pageId','$widgetLocation','$widgetOrder')";
 		
-		if(mysql_query($query)==false)
+		if(mysqli_query($GLOBALS["___mysqli_ston"], $query)==false)
 			return false;
 		
 	}


### PR DESCRIPTION
- Replace all the `mysql_` functions with their `mysqli_` counterparts.
- Remove add primary key for `events_details`
- Fix parse errors and `=& new Object();` assignments.

I've tested pages, articles, forms and uploading files. It is mostly tested and should not have any errors.

Tested on:
Apache/2.4.18 (Unix)
PHP/7.0.10
MySQL/5.7.14