### PR TITLE
Rename class error

### DIFF
--- a/cms/modules/form/captcha/class/captcha.class.php
+++ b/cms/modules/form/captcha/class/captcha.class.php
@@ -27,7 +27,7 @@
   ******************************************************************/
 
   require('filter.class.php');
-  require('error.class.php');
+  require('captchaerror.class.php');
 
   class captcha
   {
@@ -59,12 +59,12 @@
       global $sourceFolder, $moduleFolder;
       $this->fontpath = "$sourceFolder/$moduleFolder/form/captcha/fonts/";
       $this->fonts    = $this->getFonts();
-      $errormgr       = new error;
+      $errormgr       = new captchaerror;
 
       if ($this->fonts == FALSE)
       {
 
-      	//$errormgr = new error;
+      	//$errormgr = new captchaerror;
       	$errormgr->addError('No fonts available!');
       	$errormgr->displayError();
 //      	die();

--- a/cms/modules/form/captcha/class/captchaerror.class.php
+++ b/cms/modules/form/captcha/class/captchaerror.class.php
@@ -26,12 +26,12 @@
 
   ******************************************************************/
 
-  class error
+  class captchaerror
   {
 
   	var $errors;
 
-  	function error ()
+  	function captchaerror ()
   	{
 
   	  $this->errors = array();


### PR DESCRIPTION
Rename class error to captchaerror to fix collision with existing class
called error in PHP7.